### PR TITLE
Wait for pending update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,4 @@ A webhook will be triggered and push the new package on [Packagist](https://pack
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package works for MeiliSearch `v0.9.x`.
+This package works for MeiliSearch `>=v0.10`.

--- a/src/Index.php
+++ b/src/Index.php
@@ -88,7 +88,7 @@ class Index extends HTTPRequest
         return $this->httpGet('/indexes/'.$this->uid.'/updates');
     }
 
-    public function waitForUpdateStatus($update_id, $timeout_in_ms = 2000, $range_in_ms = 10)
+    public function waitForPendingUpdate($update_id, $timeout_in_ms = 2000, $interval_in_ms = 10)
     {
         $timeout_temp = 0;
         while ($timeout_in_ms > $timeout_temp) {
@@ -96,8 +96,8 @@ class Index extends HTTPRequest
             if ('enqueued' != $res['status']) {
                 return $res;
             }
-            $timeout_temp += $range_in_ms;
-            usleep(1000 * $range_in_ms);
+            $timeout_temp += $interval_in_ms;
+            usleep(1000 * $interval_in_ms);
         }
         throw new TimeOutException();
     }

--- a/src/Index.php
+++ b/src/Index.php
@@ -88,7 +88,7 @@ class Index extends HTTPRequest
         return $this->httpGet('/indexes/'.$this->uid.'/updates');
     }
 
-    public function waitForPendingUpdate($update_id, $timeout_in_ms = 2000, $interval_in_ms = 10)
+    public function waitForPendingUpdate($update_id, $timeout_in_ms = 5000, $interval_in_ms = 50)
     {
         $timeout_temp = 0;
         while ($timeout_in_ms > $timeout_temp) {

--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -4,5 +4,5 @@ namespace MeiliSearch;
 
 class MeiliSearch
 {
-    const VERSION = '0.9.0';
+    const VERSION = '0.10.0';
 }

--- a/tests/DocumentsTest.php
+++ b/tests/DocumentsTest.php
@@ -40,7 +40,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->addDocuments(static::$documents);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
     }
 
     // DOCUMENTS
@@ -67,7 +67,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->addDocuments([['id' => $id, 'title' => $new_title]]);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocument($id);
         $this->assertSame($id, $res['id']);
         $this->assertSame($new_title, $res['title']);
@@ -83,7 +83,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->updateDocuments([['id' => $id, 'title' => $new_title]]);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocument($id);
         $this->assertSame($id, $res['id']);
         $this->assertSame($new_title, $res['title']);
@@ -99,7 +99,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->updateDocuments([['id' => $id, 'title' => $title]]);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocument($id);
         $this->assertSame($id, $res['id']);
         $this->assertSame($title, $res['title']);
@@ -114,7 +114,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->deleteDocument($id);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocuments();
         $this->assertCount(count(static::$documents), $res);
         $this->assertNull($this->findDocumentWithId($res, $id));
@@ -126,7 +126,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->deleteDocuments($ids);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocuments();
         $this->assertCount(count(static::$documents) - 2, $res);
         $this->assertNull($this->findDocumentWithId($res, $ids[0]));
@@ -138,7 +138,7 @@ class DocumentsTest extends TestCase
         $res = static::$index->deleteAllDocuments();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $res = static::$index->getDocuments();
         $this->assertCount(0, $res);
     }
@@ -161,7 +161,7 @@ class DocumentsTest extends TestCase
         $index = static::$client->createIndex('addUid');
         $res = $index->addDocuments($documents, 'unique');
         $this->assertArrayHasKey('updateId', $res);
-        $index->waitForUpdateStatus($res['updateId']);
+        $index->waitForPendingUpdate($res['updateId']);
         $this->assertSame('unique', $index->getPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
     }
@@ -178,7 +178,7 @@ class DocumentsTest extends TestCase
         $index = static::$client->createIndex('udpateUid');
         $res = $index->updateDocuments($documents, 'unique');
         $this->assertArrayHasKey('updateId', $res);
-        $index->waitForUpdateStatus($res['updateId']);
+        $index->waitForPendingUpdate($res['updateId']);
         $this->assertSame('unique', $index->getPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
     }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -29,7 +29,7 @@ class SearchTest extends TestCase
             ['id' => 42,   'title' => 'The Hitchhiker\'s Guide to the Galaxy'],
         ];
         $res = static::$index->updateDocuments($documents);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/Settings/AcceptNewFieldsTest.php
+++ b/tests/Settings/AcceptNewFieldsTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class AcceptNewFieldsTest extends TestCase
 {

--- a/tests/Settings/AcceptNewFieldsTest.php
+++ b/tests/Settings/AcceptNewFieldsTest.php
@@ -36,7 +36,7 @@ class AcceptNewFieldsTest extends TestCase
         $res = static::$index->updateAcceptNewFields(false);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $this->assertFalse(static::$index->getAcceptNewFields());
     }
 }

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class DisplayedAttributesTest extends TestCase
 {

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -45,7 +45,7 @@ class DisplayedAttributesTest extends TestCase
         $res = static::$index1->updateDisplayedAttributes($new_da);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $da = static::$index1->getDisplayedAttributes();
         $this->assertIsArray($da);
         $this->assertEquals($new_da, $da);
@@ -56,7 +56,7 @@ class DisplayedAttributesTest extends TestCase
         $res = static::$index1->resetDisplayedAttributes();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $da = static::$index1->getDisplayedAttributes();
         $this->assertIsArray($da);
     }

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class DistinctAttributeTest extends TestCase
 {

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -37,7 +37,7 @@ class DistinctAttributeTest extends TestCase
         $res = static::$index->updateDistinctAttribute($new_da);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $da = static::$index->getDistinctAttribute();
         $this->assertEquals($new_da, $da);
     }
@@ -47,7 +47,7 @@ class DistinctAttributeTest extends TestCase
         $res = static::$index->resetDistinctAttribute();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $this->assertNull(static::$index->getDistinctAttribute());
     }
 }

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class RankingRulesTest extends TestCase
 {

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -51,7 +51,7 @@ class RankingRulesTest extends TestCase
         $res = static::$index->updateRankingRules($new_rr);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $rr = static::$index->getRankingRules();
         $this->assertIsArray($rr);
         $this->assertEquals($new_rr, $rr);
@@ -62,7 +62,7 @@ class RankingRulesTest extends TestCase
         $res = static::$index->resetRankingRules();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $rr = static::$index->getRankingRules();
         $this->assertIsArray($rr);
         $this->assertEquals(static::$default_ranking_rules, $rr);

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -48,7 +48,7 @@ class SearchableAttributesTest extends TestCase
         $res = static::$index1->updateSearchableAttributes($new_sa);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $sa = static::$index1->getSearchableAttributes();
         $this->assertIsArray($sa);
         $this->assertEquals($new_sa, $sa);
@@ -59,7 +59,7 @@ class SearchableAttributesTest extends TestCase
         $res = static::$index1->resetSearchableAttributes();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $sa = static::$index1->getSearchableAttributes();
         $this->assertIsArray($sa);
     }

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class SearchableAttributesTest extends TestCase
 {

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -76,7 +76,7 @@ class SettingsTest extends TestCase
         ]);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $settings = static::$index1->getSettings();
         $this->assertEquals(['asc(title)', 'typo'], $settings['rankingRules']);
         $this->assertEquals('title', $settings['distinctAttribute']);
@@ -97,7 +97,7 @@ class SettingsTest extends TestCase
         ]);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $settings = static::$index1->getSettings();
         $this->assertEquals(['asc(title)', 'typo'], $settings['rankingRules']);
         $this->assertEquals('title', $settings['distinctAttribute']);
@@ -115,7 +115,7 @@ class SettingsTest extends TestCase
         $res = static::$index1->resetSettings();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index1->waitForUpdateStatus($res['updateId']);
+        static::$index1->waitForPendingUpdate($res['updateId']);
         $settings = static::$index1->getSettings();
         $this->assertEquals(static::$default_ranking_rules, $settings['rankingRules']);
         $this->assertNull($settings['distinctAttribute']);

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class SettingsTest extends TestCase
 {

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -38,7 +38,7 @@ class StopWordsTest extends TestCase
         $res = static::$index->updateStopWords($new_sw);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $sw = static::$index->getStopWords();
         $this->assertIsArray($sw);
         $this->assertEquals($new_sw, $sw);
@@ -49,7 +49,7 @@ class StopWordsTest extends TestCase
         $res = static::$index->resetStopWords();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $sw = static::$index->getStopWords();
         $this->assertIsArray($sw);
         $this->assertEmpty($sw);

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class StopWordsTest extends TestCase
 {

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -3,8 +3,7 @@
 use MeiliSearch\Client;
 use PHPUnit\Framework\TestCase;
 
-define('__ROOT__', dirname(dirname(__FILE__)));
-require_once __ROOT__.'/utils.php';
+require_once dirname(dirname(__FILE__)).'/utils.php';
 
 class SynonymsTest extends TestCase
 {

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -40,7 +40,7 @@ class SynonymsTest extends TestCase
         $res = static::$index->updateSynonyms($new_s);
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $s = static::$index->getSynonyms();
         $this->assertIsArray($s);
         $this->assertEquals($new_s, $s);
@@ -51,7 +51,7 @@ class SynonymsTest extends TestCase
         $res = static::$index->resetSynonyms();
         $this->assertIsArray($res);
         $this->assertArrayHasKey('updateId', $res);
-        static::$index->waitForUpdateStatus($res['updateId']);
+        static::$index->waitForPendingUpdate($res['updateId']);
         $s = static::$index->getSynonyms();
         $this->assertIsArray($s);
         $this->assertEmpty($s);

--- a/tests/UpdatesTest.php
+++ b/tests/UpdatesTest.php
@@ -37,7 +37,7 @@ class UpdatesTest extends TestCase
     public function testGetOneUpdate()
     {
         $update_id = static::$index->updateDocuments(static::$documents)['updateId'];
-        $res = static::$index->waitForUpdateStatus($update_id);
+        $res = static::$index->waitForPendingUpdate($update_id);
         $this->assertIsArray($res);
         $this->assertSame($res['status'], 'processed');
         $this->assertSame($res['updateId'], $update_id);


### PR DESCRIPTION
Related to [this issue](https://github.com/meilisearch/integrations-guides/issues/1).

- Rename `waitForUpdateStatus` into `waitForPendingUpdate`
- Add tests for this method

Bonus:
- Prepare for the `v0.10`
- Remove `define('__ROOT__', dirname(dirname(__FILE__)));` line in tests file to avoid this warning when running tests:
```
Notice: Constant __ROOT__ already defined in /Users/curquiza/Documents/meilisearch-php/tests/Settings/DisplayedAttributesTest.php on line 6
PHP Notice:  Constant __ROOT__ already defined in /Users/curquiza/Documents/meilisearch-php/tests/Settings/RankingRulesTest.php on line 6
```