### PR TITLE
Add facets settings routes

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -257,6 +257,25 @@ class Index extends HTTPRequest
         return $this->httpPost('/indexes/'.$this->uid.'/settings/accept-new-fields', $accept_new_fields);
     }
 
+    // Settings - Attributes for faceting
+
+    public function getAttributesForFaceting()
+    {
+        return $this->httpGet('/indexes/'.$this->uid.'/settings/attributes-for-faceting');
+    }
+
+    public function updateAttributesForFaceting($attributes_for_faceting)
+    {
+        return $this->httpPost('/indexes/'.$this->uid.'/settings/attributes-for-faceting', $attributes_for_faceting);
+    }
+
+    public function resetAttributesForFaceting()
+    {
+        return $this->httpDelete('/indexes/'.$this->uid.'/settings/attributes-for-faceting');
+    }
+
+    // PRIVATE
+
     private function flattenOptions(array $options)
     {
         return array_map(function ($entry) {

--- a/tests/Settings/AttributesForFacetingTest.php
+++ b/tests/Settings/AttributesForFacetingTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Settings;
+
+use Tests\TestCase;
+
+class AttributesForFacetingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->deleteAllIndexes();
+    }
+
+    public function testGetDefaultAttributesForFaceting()
+    {
+        $index = $this->client->createIndex('index');
+
+        $attributes = $index->getAttributesForFaceting();
+
+        $this->assertIsArray($attributes);
+        $this->assertEmpty($attributes);
+    }
+
+    public function testUpdateAttributesForFaceting()
+    {
+        $newAttributes = ['title'];
+        $index = $this->client->createIndex('index');
+
+        $promise = $index->updateAttributesForFaceting($newAttributes);
+
+        $this->assertIsValidPromise($promise);
+        $index->waitForPendingUpdate($promise['updateId']);
+
+        $attributesForFaceting = $index->getAttributesForFaceting();
+
+        $this->assertIsArray($attributesForFaceting);
+        $this->assertEquals($newAttributes, $attributesForFaceting);
+    }
+
+    public function testResetAttributesForFaceting()
+    {
+        $index = $this->client->createIndex('index');
+        $newAttributes = ['title'];
+
+        $promise = $index->updateAttributesForFaceting($newAttributes);
+        $index->waitForPendingUpdate($promise['updateId']);
+
+        $promise = $index->resetAttributesForFaceting();
+
+        $this->assertIsValidPromise($promise);
+
+        $index->waitForPendingUpdate($promise['updateId']);
+
+        $attributesForFaceting = $index->getAttributesForFaceting();
+        $this->assertIsArray($attributesForFaceting);
+        $this->assertEmpty($attributesForFaceting);
+    }
+}


### PR DESCRIPTION
NB: tests do not run yet because the v0.11 is not out.
If you want to run the tests with the last version of MeiliSearch, use `cargo` in the MeiliSearch repo, and go on my branch.

The tests in local:

```bash
$ sh scripts/tests.sh
Setting FDs limit to 1000
Launching tests...
PHPUnit 8.5.4 by Sebastian Bergmann and contributors.

............F..............................F..................... 65 / 87 ( 74%)
......................                                            87 / 87 (100%)

Time: 3.76 seconds, Memory: 8.00 MB

There were 2 failures:

1) Tests\Endpoints\ClientTest::testExceptionIfNoIndexWhenDeleting
Failed asserting that exception of type "MeiliSearch\Exceptions\HTTPRequestException" is thrown.

2) Tests\Endpoints\IndexTest::testExceptionIsThrownIfNoIndexWhenDeleting
Failed asserting that exception of type "MeiliSearch\Exceptions\HTTPRequestException" is thrown.

FAILURES!
Tests: 87, Assertions: 335, Failures: 2.
```