### PR TITLE
Implement faceting in search

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -107,14 +107,12 @@ class Index extends HTTPRequest
 
     // Search
 
-    public function search($query, $options = null)
+    public function search($query, array $options = [])
     {
-        if ($options) {
-            $options = $this->flattenOptions($options);
-            $parameters = array_merge(['q' => $query], $options);
-        } else {
-            $parameters = ['q' => $query];
-        }
+        $parameters = array_merge(
+            ['q' => $query],
+            $this->parseOptions($options)
+        );
 
         return $this->httpGet('/indexes/'.$this->uid.'/search', $parameters);
     }
@@ -276,14 +274,16 @@ class Index extends HTTPRequest
 
     // PRIVATE
 
-    private function flattenOptions(array $options)
+    private function parseOptions(array $options)
     {
-        return array_map(function ($entry) {
-            if (is_array($entry)) {
-                return implode(',', $entry);
+        foreach ($options as $key => $value) {
+            if ('facetsDistribution' === $key || 'facetFilters' === $key) {
+                $options[$key] = json_encode($value);
+            } elseif (is_array($value)) {
+                $options[$key] = implode(',', $value);
             }
+        }
 
-            return $entry;
-        }, $options);
+        return $options;
     }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -122,6 +122,61 @@ class SearchTest extends TestCase
         $this->assertSame('Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
     }
 
+    public function testBasicSearchWithFacetsDistribution()
+    {
+        $this->createFreshIndexAndSeedDocuments();
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $response = $this->index->search('prince', [
+            'facetsDistribution' => ['genre'],
+        ]);
+        $this->assertSame(2, $response['nbHits']);
+        $this->assertArrayHasKey('facetsDistribution', $response);
+        $this->assertArrayHasKey('exhaustiveFacetsCount', $response);
+        $this->assertArrayHasKey('genre', $response['facetsDistribution']);
+        $this->assertTrue($response['exhaustiveFacetsCount']);
+        $this->assertSame($response['facetsDistribution']['genre']['fantasy'], 1);
+        $this->assertSame($response['facetsDistribution']['genre']['adventure'], 1);
+        $this->assertSame($response['facetsDistribution']['genre']['romance'], 0);
+    }
+
+    public function testBasicSearchWithFacetFilters()
+    {
+        $this->createFreshIndexAndSeedDocuments();
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $response = $this->index->search('prince', [
+            'facetFilters' => [['genre:fantasy']],
+        ]);
+        $this->assertSame(1, $response['nbHits']);
+        $this->assertArrayNotHasKey('facetsDistribution', $response);
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(4, $response['hits'][0]['id']);
+    }
+
+    public function testCustomSearchWithFacetFiltersAndAttributesToRetrieve()
+    {
+        $this->createFreshIndexAndSeedDocuments();
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $response = $this->index->search('prince', [
+            'facetFilters' => [['genre:fantasy']],
+            'attributesToRetrieve' => ['id', 'title'],
+        ]);
+        $this->assertSame(1, $response['nbHits']);
+        $this->assertArrayNotHasKey('facetsDistribution', $response);
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(4, $response['hits'][0]['id']);
+        $this->assertArrayHasKey('id', $response['hits'][0]);
+        $this->assertArrayHasKey('title', $response['hits'][0]);
+        $this->assertArrayNotHasKey('comment', $response['hits'][0]);
+    }
+
+    // PRIVATE
+
     private function createFreshIndexAndSeedDocuments()
     {
         $this->client->deleteAllIndexes();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,12 +8,12 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     const DOCUMENTS = [
-        ['id' => 123, 'title' => 'Pride and Prejudice', 'comment' => 'A great book'],
-        ['id' => 456, 'title' => 'Le Petit Prince', 'comment' => 'A french book'],
-        ['id' => 2, 'title' => 'Le Rouge et le Noir', 'comment' => 'Another french book'],
-        ['id' => 1, 'title' => 'Alice In Wonderland', 'comment' => 'A weird book'],
-        ['id' => 1344, 'title' => 'The Hobbit', 'comment' => 'An awesome book'],
-        ['id' => 4, 'title' => 'Harry Potter and the Half-Blood Prince', 'comment' => 'The best book'],
+        ['id' => 123, 'title' => 'Pride and Prejudice', 'comment' => 'A great book', 'genre' => 'romance'],
+        ['id' => 456, 'title' => 'Le Petit Prince', 'comment' => 'A french book', 'genre' => 'adventure'],
+        ['id' => 2, 'title' => 'Le Rouge et le Noir', 'comment' => 'Another french book', 'genre' => 'romance'],
+        ['id' => 1, 'title' => 'Alice In Wonderland', 'comment' => 'A weird book', 'genre' => 'fantasy'],
+        ['id' => 1344, 'title' => 'The Hobbit', 'comment' => 'An awesome book', 'genre' => 'romance'],
+        ['id' => 4, 'title' => 'Harry Potter and the Half-Blood Prince', 'comment' => 'The best book', 'genre' => 'fantasy'],
         ['id' => 42, 'title' => 'The Hitchhiker\'s Guide to the Galaxy'],
     ];
 


### PR DESCRIPTION
### EXPECTED TESTS FAILURE

<s><img width="745" alt="Capture d’écran 2020-06-04 à 20 35 23" src="https://user-images.githubusercontent.com/20380692/83797437-f0051880-a6a2-11ea-908e-9d6bdc70f09a.png">

Because of [this issue](https://github.com/meilisearch/MeiliSearch/issues/741).</s>

Issue fixed! All the tests pass!

### PHP TIPS

Just found out that writing:

```php
 public function search($query, array $options = [])
```

instead of

```php
 public function search($query, $options = [])
```

raises this kind of beautiful error if you try to call the method this way
```php
search('prince', null);
```
```bash
TypeError: Argument 2 passed to MeiliSearch\Index::search() must be of the type array, null given, called in /Users/curquiza/Documents/meilisearch-php/tests/Endpoints/SearchTest.php on line 16
```

Very explicit for our users without any effort 👌 