### PR TITLE
Change create_index prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ You can check out [the API documentation](https://docs.meilisearch.com/reference
 // Create an index
 $index = $client->createIndex('books');
 // Create an index and give the primary-key
-$index = $client->createIndex([
-    'uid' => 'books',
-    'primaryKey' => 'book_id'
-]);
+$index = $client->createIndex(
+    'books',
+    ['primaryKey' => 'book_id']
+);
 ```
 
 #### List all indexes <!-- omit in toc -->

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,13 +33,12 @@ class Client extends HTTPRequest
         return $this->indexInstance($uid);
     }
 
-    public function createIndex($attributes)
+    public function createIndex($index_uid, $options = [])
     {
-        if (is_array($attributes)) {
-            $body = $attributes;
-        } else {
-            $body = ['uid' => $attributes];
-        }
+        $body = array_merge(
+            ['uid' => $index_uid],
+            $options
+        );
         $response = $this->httpPost('/indexes', $body);
         $uid = $response['uid'];
 

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -33,10 +33,10 @@ class ClientTest extends TestCase
 
     public function testCreateIndexWithUidAndPrimaryKey()
     {
-        $index = $this->client->createIndex([
-            'uid' => 'index',
-            'primaryKey' => 'ObjectId',
-        ]);
+        $index = $this->client->createIndex(
+            'index',
+            ['primaryKey' => 'ObjectId'],
+        );
 
         $this->assertInstanceOf(Index::class, $index);
         $this->assertSame('index', $index->getUid());
@@ -64,10 +64,10 @@ class ClientTest extends TestCase
     public function testShowIndex()
     {
         $index = 'index';
-        $this->client->createIndex([
-            'uid' => $index,
-            'primaryKey' => 'objectID',
-        ]);
+        $this->client->createIndex(
+            $index,
+            ['primaryKey' => 'objectID'],
+        );
 
         $response = $this->client->showIndex($index);
 
@@ -138,7 +138,7 @@ class ClientTest extends TestCase
     public function testExceptionIfNoUidWhenCreating()
     {
         $this->expectException(HTTPRequestException::class);
-        $this->client->createIndex(['primaryKey' => 'id']);
+        $this->client->createIndex(null);
     }
 
     public function testExceptionIfNoIndexWhenShowing()

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -19,10 +19,10 @@ class IndexTest extends TestCase
 
     public function testGetPrimaryKey()
     {
-        $indexB = $this->client->createIndex([
-            'uid' => 'indexB',
-            'primaryKey' => 'objectId',
-        ]);
+        $indexB = $this->client->createIndex(
+            'indexB',
+            ['primaryKey' => 'objectId'],
+        );
 
         $this->assertNull($this->index->getPrimaryKey());
         $this->assertSame('objectId', $indexB->getPrimaryKey());
@@ -30,20 +30,20 @@ class IndexTest extends TestCase
 
     public function testGetUid()
     {
-        $indexB = $this->client->createIndex([
-            'uid' => 'indexB',
-            'primaryKey' => 'objectId',
-        ]);
+        $indexB = $this->client->createIndex(
+            'indexB',
+            ['primaryKey' => 'objectId'],
+        );
         $this->assertSame('index', $this->index->getUid());
         $this->assertSame('indexB', $indexB->getUid());
     }
 
     public function testShow()
     {
-        $index = $this->client->createIndex([
-            'uid' => 'indexB',
-            'primaryKey' => 'objectId',
-        ]);
+        $index = $this->client->createIndex(
+            'indexB',
+            ['primaryKey' => 'objectId'],
+        );
 
         $response = $index->show();
 
@@ -67,10 +67,10 @@ class IndexTest extends TestCase
 
     public function testExceptionIsThrownWhenOverwritingPrimaryKey()
     {
-        $index = $this->client->createIndex([
-            'uid' => 'indexB',
-            'primaryKey' => 'objectId',
-        ]);
+        $index = $this->client->createIndex(
+            'indexB',
+            ['primaryKey' => 'objectId'],
+        );
 
         $this->expectException(HTTPRequestException::class);
 

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -15,7 +15,7 @@ class DisplayedAttributesTest extends TestCase
     public function testGetDefaultDisplayedAttributes()
     {
         $indexA = $this->client->createIndex('indexA');
-        $indexB = $this->client->createIndex(['uid' => 'indexB', 'primaryKey' => 'objectID']);
+        $indexB = $this->client->createIndex('indexB', ['primaryKey' => 'objectID']);
 
         $attributesA = $indexA->getDisplayedAttributes();
         $attributesB = $indexB->getDisplayedAttributes();

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -15,7 +15,7 @@ class SearchableAttributesTest extends TestCase
     public function testGetDefaultSearchableAttributes()
     {
         $indexA = $this->client->createIndex('indexA');
-        $indexB = $this->client->createIndex(['uid' => 'indexB', 'primaryKey' => 'objectID']);
+        $indexB = $this->client->createIndex('indexB', ['primaryKey' => 'objectID']);
 
         $searchableAttributesA = $indexA->getSearchableAttributes();
         $searchableAttributesB = $indexB->getSearchableAttributes();

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -28,10 +28,10 @@ class SettingsTest extends TestCase
             ->createIndex('indexA')
             ->getSettings();
         $settingB = $this->client
-            ->createIndex([
-                'uid' => 'indexB',
-                'primaryKey' => $primaryKey,
-            ])->getSettings();
+            ->createIndex(
+                'indexB',
+                ['primaryKey' => $primaryKey],
+            )->getSettings();
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingA['rankingRules']);
         $this->assertNull($settingA['distinctAttribute']);


### PR DESCRIPTION
Related to [this comment](https://github.com/meilisearch/integration-guides/issues/2#issuecomment-642012475).

Before:
```php
$client->createIndex('indexUID')
$client->createIndex(['uid' => 'indexUID', 'primaryKey' => 'book_id'])
```

After:
```php
$client->createIndex('indexUID')
$client->createIndex('indexUID', ['primaryKey' => 'book_id'])
```