### PR TITLE
Update tests after MeiliSearch bump to v0.12.0

### DIFF
--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -72,9 +72,9 @@ class SettingsTest extends TestCase
         $this->assertEquals(['asc(title)', 'typo'], $settings['rankingRules']);
         $this->assertEquals('title', $settings['distinctAttribute']);
         $this->assertIsArray($settings['searchableAttributes']);
-        $this->assertEquals(['title'], $settings['searchableAttributes']);
+        $this->assertEmpty($settings['searchableAttributes']);
         $this->assertIsArray($settings['displayedAttributes']);
-        $this->assertEquals(['title'], $settings['displayedAttributes']);
+        $this->assertEmpty($settings['displayedAttributes']);
         $this->assertEquals(['the'], $settings['stopWords']);
         $this->assertIsArray($settings['synonyms']);
         $this->assertEmpty($settings['synonyms']);
@@ -106,7 +106,7 @@ class SettingsTest extends TestCase
         $this->assertEquals('title', $settings['distinctAttribute']);
         $this->assertEquals(['title'], $settings['searchableAttributes']);
         $this->assertIsArray($settings['displayedAttributes']);
-        $this->assertEquals(['title'], $settings['displayedAttributes']);
+        $this->assertEmpty($settings['displayedAttributes']);
         $this->assertEquals(['the'], $settings['stopWords']);
         $this->assertIsArray($settings['synonyms']);
         $this->assertEmpty($settings['synonyms']);


### PR DESCRIPTION
The tests currently fail because of [this issue](https://github.com/meilisearch/MeiliSearch/issues/798).