### PR TITLE
Fix/request exception

### DIFF
--- a/src/Exceptions/HTTPRequestException.php
+++ b/src/Exceptions/HTTPRequestException.php
@@ -2,6 +2,9 @@
 
 namespace MeiliSearch\Exceptions;
 
+use function array_key_exists;
+use function is_array;
+
 class HTTPRequestException extends \Exception
 {
     public $http_status = 0;
@@ -11,8 +14,9 @@ class HTTPRequestException extends \Exception
     public function __construct($http_status, $http_body, $previous = null)
     {
         $this->http_body = $http_body;
-        if (isset($this->http_body) && array_key_exists('message', $this->http_body)) {
-            $this->http_message = $this->http_body['message'];
+        if (!empty($this->http_body)) {
+            $this->http_message = is_array($this->http_body) && array_key_exists('message', $this->http_body) ?
+                $this->http_body['message'] : $this->http_body;
         }
         $this->http_status = $http_status;
         parent::__construct($this->http_message, $this->http_status, $previous);

--- a/tests/Exception/HTTPRequestExceptionTest.php
+++ b/tests/Exception/HTTPRequestExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Exception;
+
+use MeiliSearch\Exceptions\HTTPRequestException;
+use Tests\TestCase;
+
+/**
+ * Class HTTPRequestExceptionTest.
+ */
+class HTTPRequestExceptionTest extends TestCase
+{
+    public function testBadClientUrl()
+    {
+        try {
+            $this->client->base_url = 'http://127.0.0.1.com:1234';
+            $this->client->createIndex('index');
+        } catch (HTTPRequestException $e) {
+            $this->assertEquals(500, $e->http_status);
+            $this->assertIsString($e->http_message);
+            $this->assertIsString($e->http_body);
+        }
+    }
+}


### PR DESCRIPTION
This a new fix related to class `MeiliSearch\Exceptions\HTTPRequestException`

I had a case where I configured a bad client URL and the code returned a string in variable `$http_body` instead of array and the code returned this error message: `array_key_exists() expects parameter 2 to be array, string given`.

I also in the same PR fix other tests classes who are not compatible with PHP7.2.

I added a new test for the **HTTPRequestException** class to check my changes using a bad client url.

> This PR code depends of the previous one: https://github.com/meilisearch/meilisearch-php/pull/47