### PR TITLE
Add new method `getOrCreateIndex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ $index = $client->createIndex(
 );
 ```
 
+#### Get an index or create it if it doesn't exist <!-- omit in toc -->
+```php
+// Get or create an index
+$index = $client->getOrCreateIndex('books');
+// Get or create an index and give the primary-key
+$index = $client->getOrCreateIndex(
+    'books',
+    ['primaryKey' => 'book_id']
+);
+```
+
+#### Get an index or create it if it doesn't exist <!-- omit in toc -->
+```php
+// Get or create an index
+$index = $client->getOrCreateIndex('books');
+// Get or create an index and give the primary-key
+$index = $client->getOrCreateIndex(
+    'books',
+    ['primaryKey' => 'book_id']
+);
+```
+
 #### List all indexes <!-- omit in toc -->
 
 ```php

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,8 @@
 
 namespace MeiliSearch;
 
+use MeiliSearch\Exceptions\HTTPRequestException;
+
 class Client extends HTTPRequest
 {
     // Indexes
@@ -43,6 +45,24 @@ class Client extends HTTPRequest
         $uid = $response['uid'];
 
         return $this->indexInstance($uid);
+    }
+
+    /**
+     * @throws HTTPRequestException
+     */
+    public function getOrCreateIndex(string $uid, array $options = []): Index
+    {
+        $index = $this->getIndex($uid);
+
+        try {
+            $index = $this->createIndex($uid, $options);
+        } catch (HTTPRequestException $e) {
+            if (is_array($e->http_body) && 'index_already_exists' !== $e->http_body['errorCode']) {
+                throw $e;
+            }
+        }
+
+        return $index;
     }
 
     // Health

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -141,6 +141,60 @@ class ClientTest extends TestCase
         $this->assertNull($index->getPrimaryKey());
     }
 
+    public function testGetOrCreateIndexWithOnlyUid()
+    {
+        $index = $this->client->getOrCreateIndex('index');
+
+        $this->assertInstanceOf(Index::class, $index);
+        $this->assertSame('index', $index->getUid());
+        $this->assertNull($index->getPrimaryKey());
+    }
+
+    public function testGetOrCreateIndexWithUidAndPrimaryKey()
+    {
+        $index = $this->client->getOrCreateIndex(
+            'index',
+            ['primaryKey' => 'ObjectId']
+        );
+
+        $this->assertInstanceOf(Index::class, $index);
+        $this->assertSame('index', $index->getUid());
+        $this->assertSame('ObjectId', $index->getPrimaryKey());
+    }
+
+    public function testGetOrCreateIndexWithUidInOptions()
+    {
+        $index = $this->client->getOrCreateIndex(
+            'index',
+            [
+                'uid' => 'wrong',
+                'primaryKey' => 'ObjectId',
+            ]
+        );
+
+        $this->assertInstanceOf(Index::class, $index);
+        $this->assertSame('index', $index->getUid());
+        $this->assertSame('ObjectId', $index->getPrimaryKey());
+    }
+
+    public function testGetOrCreateWithIndexAlreadyExists()
+    {
+        $index1 = $this->client->getOrCreateIndex('index');
+        $index2 = $this->client->getOrCreateIndex('index');
+        $index3 = $this->client->getOrCreateIndex('index');
+
+        $this->assertSame('index', $index1->getUid());
+        $this->assertSame('index', $index2->getUid());
+        $this->assertSame('index', $index3->getUid());
+
+        $update = $index1->addDocuments([['book_id' => 1, 'name' => 'Some book']]);
+        $index1->waitForPendingUpdate($update['updateId']);
+
+        $documents = $index2->getDocuments();
+        $this->assertCount(1, $documents);
+        $index2->delete();
+    }
+
     public function testExceptionIfUidTakenWhenCreating()
     {
         $this->client->createIndex('index');


### PR DESCRIPTION
Implements the `getOrCreateIndex` method, as specified in [this discussion](https://github.com/meilisearch/integration-guides/issues/2)

* Add `getOrCreateIndex` method
* Add tests
* Update Readme with examples

> Related to issue #26