### PR TITLE
Added dependabot v1

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+    - package_manager: "php:composer"
+      directory: "/"
+      update_schedule: "live"
+      default_labels:
+          - "depbump"
+      commit_message:
+          prefix: "[bump-version]"


### PR DESCRIPTION
Keeping dependencies up-to-date.

https://dependabot.com/docs/config-file/

https://dependabot.com/

This of course can be installed on all clients and even on the core repository.

You also need to allow dependabot on the repo-level but I can definitely say it's really good for what it does.