### PR TITLE
Implementing native fn invocation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,12 +12,9 @@ indent_style             = space
 
 [*.php]
 indent_size              = 4
-indent_style             = space
 
 [*.md]
-indent_style             = space
 max_line_length          = 80
 
 [*{.yaml, yml}]
 indent_size              = 2
-indent_style             = space

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
+    - name: Run linter
+      run: vendor/bin/php-cs-fixer fix -v --config=.php_cs.dist --using-cache=no --dry-run --allow-risky=yes
+
     - name: Docker setup
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
 
     - name: Run test suite
       run: sh scripts/tests.sh
-
-    - name: Run linter
-      run: vendor/bin/php-cs-fixer fix -v --config=.php_cs.dist --using-cache=no --dry-run

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = \PhpCsFixer\Finder::create()
     ->in(__DIR__.DIRECTORY_SEPARATOR.'src')
     ->in(__DIR__.DIRECTORY_SEPARATOR.'tests')
@@ -7,6 +9,8 @@ $finder = \PhpCsFixer\Finder::create()
 
 $rules = [
     '@Symfony' => true,
+    'declare_strict_types' => true,
+    'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced'],
 ];
 
 return \PhpCsFixer\Config::create()

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,13 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5",
         "friendsofphp/php-cs-fixer": "^2.16"
+    },
+    "scripts": {
+        "lint": [
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --dry-run --using-cache=yes --allow-risky=yes"
+        ],
+        "lint:fix": [
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --using-cache=no --allow-risky=yes"
+        ]
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch;
 
 use MeiliSearch\Exceptions\HTTPRequestException;
@@ -57,7 +59,7 @@ class Client extends HTTPRequest
         try {
             $index = $this->createIndex($uid, $options);
         } catch (HTTPRequestException $e) {
-            if (is_array($e->http_body) && 'index_already_exists' !== $e->http_body['errorCode']) {
+            if (\is_array($e->http_body) && 'index_already_exists' !== $e->http_body['errorCode']) {
                 throw $e;
             }
         }

--- a/src/Exceptions/HTTPRequestException.php
+++ b/src/Exceptions/HTTPRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch\Exceptions;
 
 class HTTPRequestException extends \Exception
@@ -11,7 +13,7 @@ class HTTPRequestException extends \Exception
     public function __construct($http_status, $http_body, $previous = null)
     {
         $this->http_body = $http_body;
-        if (isset($this->http_body) && array_key_exists('message', $this->http_body)) {
+        if (isset($this->http_body) && \array_key_exists('message', $this->http_body)) {
             $this->http_message = $this->http_body['message'];
         }
         $this->http_status = $http_status;

--- a/src/Exceptions/TimeOutException.php
+++ b/src/Exceptions/TimeOutException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch\Exceptions;
 
 class TimeOutException extends \Exception

--- a/src/HTTPRequest.php
+++ b/src/HTTPRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch;
 
 use Http\Discovery\HttpClientDiscovery;

--- a/src/Index.php
+++ b/src/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch;
 
 use MeiliSearch\Exceptions\TimeOutException;
@@ -279,7 +281,7 @@ class Index extends HTTPRequest
         foreach ($options as $key => $value) {
             if ('facetsDistribution' === $key || 'facetFilters' === $key) {
                 $options[$key] = json_encode($value);
-            } elseif (is_array($value)) {
+            } elseif (\is_array($value)) {
                 $options[$key] = implode(',', $value);
             }
         }

--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MeiliSearch;
 
 class MeiliSearch

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\HTTPRequestException;
@@ -35,7 +37,7 @@ class ClientTest extends TestCase
     {
         $index = $this->client->createIndex(
             'index',
-            ['primaryKey' => 'ObjectId'],
+            ['primaryKey' => 'ObjectId']
         );
 
         $this->assertInstanceOf(Index::class, $index);
@@ -50,7 +52,7 @@ class ClientTest extends TestCase
             [
                 'uid' => 'wrong',
                 'primaryKey' => 'ObjectId',
-            ],
+            ]
         );
 
         $this->assertInstanceOf(Index::class, $index);
@@ -81,7 +83,7 @@ class ClientTest extends TestCase
         $index = 'index';
         $this->client->createIndex(
             $index,
-            ['primaryKey' => 'objectID'],
+            ['primaryKey' => 'objectID']
         );
 
         $response = $this->client->showIndex($index);

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\HTTPRequestException;
@@ -23,7 +25,7 @@ class DocumentsTest extends TestCase
         $index->waitForPendingUpdate($promise['updateId']);
 
         $response = $index->getDocuments();
-        $this->assertCount(count(self::DOCUMENTS), $response);
+        $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
     public function testGetSingleDocument()
@@ -59,7 +61,7 @@ class DocumentsTest extends TestCase
         $this->assertSame($replacement['title'], $response['title']);
         $this->assertFalse(array_search('comment', $response));
         $response = $index->getDocuments();
-        $this->assertCount(count(self::DOCUMENTS), $response);
+        $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
     public function testUpdateDocuments()
@@ -84,7 +86,7 @@ class DocumentsTest extends TestCase
 
         $response = $index->getDocuments();
 
-        $this->assertCount(count(self::DOCUMENTS), $response);
+        $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
     public function testAddWithUpdateDocuments()
@@ -109,7 +111,7 @@ class DocumentsTest extends TestCase
 
         $response = $index->getDocuments();
 
-        $this->assertCount(count(self::DOCUMENTS) + 1, $response);
+        $this->assertCount(\count(self::DOCUMENTS) + 1, $response);
     }
 
     public function testDeleteNonExistingDocument()
@@ -126,7 +128,7 @@ class DocumentsTest extends TestCase
         $index->waitForPendingUpdate($promise['updateId']);
         $response = $index->getDocuments();
 
-        $this->assertCount(count(self::DOCUMENTS), $response);
+        $this->assertCount(\count(self::DOCUMENTS), $response);
         $this->assertNull($this->findDocumentWithId($response, $documentId));
     }
 
@@ -144,7 +146,7 @@ class DocumentsTest extends TestCase
         $index->waitForPendingUpdate($promise['updateId']);
         $response = $index->getDocuments();
 
-        $this->assertCount(count(self::DOCUMENTS) - 1, $response);
+        $this->assertCount(\count(self::DOCUMENTS) - 1, $response);
         $this->assertNull($this->findDocumentWithId($response, $documentId));
     }
 
@@ -161,7 +163,7 @@ class DocumentsTest extends TestCase
         $index->waitForPendingUpdate($promise['updateId']);
         $response = $index->getDocuments();
 
-        $this->assertCount(count(self::DOCUMENTS) - 2, $response);
+        $this->assertCount(\count(self::DOCUMENTS) - 2, $response);
         $this->assertNull($this->findDocumentWithId($response, $documentIds[0]));
         $this->assertNull($this->findDocumentWithId($response, $documentIds[1]));
     }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\HTTPRequestException;
@@ -21,7 +23,7 @@ class IndexTest extends TestCase
     {
         $indexB = $this->client->createIndex(
             'indexB',
-            ['primaryKey' => 'objectId'],
+            ['primaryKey' => 'objectId']
         );
 
         $this->assertNull($this->index->getPrimaryKey());
@@ -32,7 +34,7 @@ class IndexTest extends TestCase
     {
         $indexB = $this->client->createIndex(
             'indexB',
-            ['primaryKey' => 'objectId'],
+            ['primaryKey' => 'objectId']
         );
         $this->assertSame('index', $this->index->getUid());
         $this->assertSame('indexB', $indexB->getUid());
@@ -42,7 +44,7 @@ class IndexTest extends TestCase
     {
         $index = $this->client->createIndex(
             'indexB',
-            ['primaryKey' => 'objectId'],
+            ['primaryKey' => 'objectId']
         );
 
         $response = $index->show();
@@ -69,7 +71,7 @@ class IndexTest extends TestCase
     {
         $index = $this->client->createIndex(
             'indexB',
-            ['primaryKey' => 'objectId'],
+            ['primaryKey' => 'objectId']
         );
 
         $this->expectException(HTTPRequestException::class);

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Client;

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\HTTPRequestException;

--- a/tests/Endpoints/UpdatesTest.php
+++ b/tests/Endpoints/UpdatesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\HTTPRequestException;

--- a/tests/Exception/HTTPRequestExceptionTest.php
+++ b/tests/Exception/HTTPRequestExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Exception;
 
 use MeiliSearch\Exceptions\HTTPRequestException;

--- a/tests/Settings/AcceptNewFieldsTest.php
+++ b/tests/Settings/AcceptNewFieldsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/AttributesForFacetingTest.php
+++ b/tests/Settings/AttributesForFacetingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;
@@ -30,7 +32,7 @@ class SettingsTest extends TestCase
         $settingB = $this->client
             ->createIndex(
                 'indexB',
-                ['primaryKey' => $primaryKey],
+                ['primaryKey' => $primaryKey]
             )->getSettings();
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingA['rankingRules']);

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Settings;
 
 use Tests\TestCase;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use MeiliSearch\Client;


### PR DESCRIPTION
* Applied to all code base 
* Optional: added declare_strict_types since we require PHP 7.2 :smile: (I can also remove it if we have a problem)
* Removed redundant directives from `.editorconfig` since they are provided from root `[*]`
* Moved linting before running tests.

Fixing https://github.com/meilisearch/meilisearch-php/issues/53