### PR TITLE
Add explanation about how to fetch the MeiliSeach latest in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Each PR should pass the tests and the linter to be accepted.
 
 ```bash
 # Tests
-$ docker docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
+$ docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
 $ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
 $ sh scripts/tests.sh
 # Linter (with auto-fix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Each PR should pass the tests and the linter to be accepted.
 
 ```bash
 # Tests
+$ docker docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
 $ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
 $ sh scripts/tests.sh
 # Linter (with auto-fix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,11 @@ Each PR should pass the tests and the linter to be accepted.
 # Tests
 $ docker pull getmeili/meilisearch:latest # Fetch the latest version of MeiliSearch image from Docker Hub
 $ docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics=true
-$ sh scripts/tests.sh
+$ composer test
 # Linter (with auto-fix)
-$ vendor/bin/php-cs-fixer fix --verbose --config=.php_cs.dist
+$ composer lint:fix
 # Linter (without auto-fix)
-$ vendor/bin/php-cs-fixer fix --verbose --config=.php_cs.dist --dry-run
+$ composer lint
 ```
 
 ### Release Process


### PR DESCRIPTION
I would like to add this line in the CONTRIBUTING.md file since a contributor was lost with an error in local that he could not see on the CI. See #62.

@eskombro and @bidoubiwa I would like to add this explanation in all the other SDKs, what do you think? 🙂