### PR TITLE
MeiliSearch Bump to v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Array
 ## 🤖 Compatibility with MeiliSearch
 
 This package is compatible with the following MeiliSearch versions:
+- `v0.14.X`
 - `v0.13.X`
 
 ## 🎬 Examples


### PR DESCRIPTION
- Update compatibility in README.md
- Tested against [v0.14.0rc0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.14.0rc0)