### PR TITLE
Replace HttpClientDiscovery with Psr18ClientDiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ $ composer require meilisearch/meilisearch-php php-http/curl-client nyholm/psr7:
 ```
 
 - with `kriswallsmith/buzz`, run:
--
+
 ```bash
 $ composer require meilisearch/meilisearch-php kriswallsmith/buzz nyholm/psr7:^1.0
 ```

--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ $ composer require meilisearch/meilisearch-php php-http/curl-client nyholm/psr7:
 $ composer require meilisearch/meilisearch-php kriswallsmith/buzz nyholm/psr7:^1.0
 ```
 
+- with 'guzzlehttp/guzzle', run:
+
+```base
+composer require meilisearch/meilisearch-php guzzlehttp/guzzle http-interop/http-factory-guzzle
+```
+
 ## ⚙️ Development Workflow and Contributing
 
 Any new contribution is more than welcome in this project!

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ $ composer require meilisearch/meilisearch-php kriswallsmith/buzz nyholm/psr7:^1
 - with 'guzzlehttp/guzzle', run:
 
 ```base
-composer require meilisearch/meilisearch-php guzzlehttp/guzzle http-interop/http-factory-guzzle
+composer require meilisearch/meilisearch-php guzzlehttp/guzzle http-interop/http-factory-guzzle:^1.0
 ```
 
 ## ⚙️ Development Workflow and Contributing

--- a/README.md
+++ b/README.md
@@ -315,8 +315,6 @@ $ composer require meilisearch/meilisearch-php php-http/curl-client nyholm/psr7:
 $ composer require meilisearch/meilisearch-php kriswallsmith/buzz nyholm/psr7:^1.0
 ```
 
-⚠️ Guzzle 7 is not yet supported, but we don't prevent you from installing Guzzle 7 in your project.
-
 ## ⚙️ Development Workflow and Contributing
 
 Any new contribution is more than welcome in this project!

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         }
     },
     "suggest": {
-        "php-http/guzzle6-adapter": "^2.0 Allows http calls via guzzle 6"
+        "php-http/guzzle6-adapter": "^2.0 Allows http calls via guzzle 6",
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Http;
 
-use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use MeiliSearch\Contracts\Http;
 use MeiliSearch\Exceptions\HTTPRequestException;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -53,7 +53,7 @@ class Client implements Http
     {
         $this->baseUrl = $url;
         $this->apiKey = $apiKey;
-        $this->http = $httpClient ?: HttpClientDiscovery::find();
+        $this->http = $httpClient ?: Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?: Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?: Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([


### PR DESCRIPTION
As discussed in #76, instead of using `HttpClientDiscovery::find()` within the `Http\Client`, we should use `Psr18ClientDiscovery::find()`. This allows us to a variety of HTTP Clients such as:

- `kriswallsmith/buzz`
- `php-http/curl-client`
- `symfony/http-client` with `nyholm/psr7`
- `guzzle6-adapter`
- `guzzle7` with `http-interop/http-factory-guzzle`