### PR TITLE
Fix code samples errors

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -247,7 +247,7 @@ settings_guide_searchable_1: |-
     'rank'
   ]);
 settings_guide_displayed_1: |-
-  $client->getIndex('movies')->updateSearchableAttributes([
+  $client->getIndex('movies')->updateDisplayedAttributes([
     'title',
     'description',
     'poster',

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -200,7 +200,7 @@ filtering_guide_2: |-
 filtering_guide_3: |-
   $client->getIndex('movies')->search('horror', ['filters' => 'director = "Jordan Peele"']);
 filtering_guide_4: |-
-  $client->getIndex('movies')->search('Planet of the Apes', ['filters' => 'rating >= 3AND (NOT director = "Tim Burton")']);
+  $client->getIndex('movies')->search('Planet of the Apes', ['filters' => 'rating >= 3 AND (NOT director = "Tim Burton")']);
 search_parameter_guide_query_1: |-
   $client->getIndex('movies')->search('shifu');
 search_parameter_guide_offset_1: |-


### PR DESCRIPTION
Fix 1:  `filtering_guide_4` -> Fix espace

There was a syntax problem.

https://docs.meilisearch.com/guides/advanced_guides/filtering.html#examples

Fix 2:  `settings_guide_displayed_1` -> Wrong method

Needs to use 'Displayed' instead of 'Searchable' Attributes

https://docs.meilisearch.com/guides/advanced_guides/settings.html#example-7