### PR TITLE
fix HTTPRequestException when body is null

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -178,7 +178,7 @@ class Client implements Http
     private function parseResponse(ResponseInterface $response)
     {
         if ($response->getStatusCode() >= 300) {
-            $body = json_decode($response->getBody()->getContents(), true);
+            $body = json_decode($response->getBody()->getContents(), true) ?? $response->getReasonPhrase();
             throw new HTTPRequestException($response->getStatusCode(), $body);
         }
 


### PR DESCRIPTION
sometimes the body response is `null` and even if `null` looks like authorized it will throw this error:

```bash
Error : Wrong parameters for MeiliSearch\Exceptions\HTTPRequestException([string $message [, long $code [, Throwable $previous = NULL]]])
 .../meilisearch-php/src/Exceptions/HTTPRequestException.php:21
```

by returning `$response->getReasonPhrase()` the error should not happen again

```php
....
* @return string Reason phrase; must return an empty string if none present.
*/
public function getReasonPhrase();
```
In my test case:
using a wrong url -> http://localhost instead of http://localhost:7700 will return

```bash
MeiliSearch\Exceptions\HTTPRequestException : Not Found
.../meilisearch/meilisearch-php/src/Http/Client.php:183
```

I guess this will also solve https://github.com/meilisearch/meilisearch-laravel-scout/issues/37