### PR TITLE
Changes about the MeiliSearch's next release (v0.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Array
 ## 🤖 Compatibility with MeiliSearch
 
 This package is compatible with the following MeiliSearch versions:
+- `v0.15.X`
 - `v0.14.X`
 - `v0.13.X`
 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,7 @@ $index->search('hobbit', ['limit' => 2, 'filters' => 'title = "The Hitchhiker\'s
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package is compatible with the following MeiliSearch versions:
-- `v0.15.X`
-- `v0.14.X`
-- `v0.13.X`
+This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
 
 ## 📖 Documentation and Examples
 

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -40,7 +40,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertCount(0, $response['hits']);
+        $this->assertCount(7, $response['hits']);
     }
 
     public function testBasicPlaceholderSearch(): void


### PR DESCRIPTION
- [x] Update README
- [x] Update the tests

This PR:
- will fail in this CI until the MeiliSearch's release v0.15.0 is out
- should work locally with the [prerelease v0.15.0rc0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0rc0)


⚠️ This PR should not be merged until the MeiliSearch's release v0.15.0 is out.