### PR TITLE
Update delete index to always return an array

### DIFF
--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -25,9 +25,9 @@ trait HandlesIndex
         return (new Indexes($this->http, $uid))->show();
     }
 
-    public function deleteIndex(string $uid): void
+    public function deleteIndex(string $uid): array
     {
-        (new Indexes($this->http, $uid))->delete();
+        return (new Indexes($this->http, $uid))->delete();
     }
 
     public function deleteAllIndexes(): void

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -75,9 +75,9 @@ class Indexes extends Endpoint
         return  $this->http->put(self::PATH.'/'.$this->uid, $body);
     }
 
-    public function delete(): void
+    public function delete(): array
     {
-        $this->http->delete(self::PATH.'/'.$this->uid);
+        return $this->http->delete(self::PATH.'/'.$this->uid) ?? [];
     }
 
     // Updates


### PR DESCRIPTION
Fixes #79
As per the discussion in the related issue, the method `HandlesIndex::deleteIndex` returns void but should return an array given that Meilisearch delete api could return an array in the future.

Added few lines to always return the array from the Meilisearch delete response, if null, returns an empty array