### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -170,7 +170,6 @@ get_indexes_stats_1: |-
   $client->stats();
 get_health_1: |-
   $client->health();
-update_health_1: |-
 get_version_1: |-
   $client->version();
 distinct_attribute_guide_1: |-

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $index->search('hobbit', ['filters' => 'title = "The Hitchhiker\'s Guide to the 
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## 💡 Learn More
 

--- a/tests/Endpoints/DumpTest.php
+++ b/tests/Endpoints/DumpTest.php
@@ -15,7 +15,7 @@ final class DumpTest extends TestCase
 
         $this->assertArrayHasKey('uid', $dump);
         $this->assertArrayHasKey('status', $dump);
-        $this->assertEquals('processing', $dump['status']);
+        $this->assertEquals('in_progress', $dump['status']);
 
         $dump = $this->client->getDumpStatus($dump['uid']);
 


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/52

- [x] Update README
- [x] Update tests #112 
- [x] Remove `update_health` #113 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.