### PR TITLE
Remove update_health from code-samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -170,7 +170,6 @@ get_indexes_stats_1: |-
   $client->stats();
 get_health_1: |-
   $client->health();
-update_health_1: |-
 get_version_1: |-
   $client->version();
 distinct_attribute_guide_1: |-


### PR DESCRIPTION
The PHP SDK did not contain any method for the `PUT health/` route, so, only the code-samples have to be removed.