### PR TITLE
Indexes::search() improvements

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -17,9 +17,9 @@ use Psr\Http\Client\ClientInterface;
 
 class Client
 {
+    use HandlesDumps;
     use HandlesIndex;
     use HandlesSystem;
-    use HandlesDumps;
 
     private $http;
 

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -138,8 +138,8 @@ class Indexes extends Endpoint
 
         $searchResult = new SearchResult($result);
 
-        if (\array_key_exists('filteringHits', $options) && \is_callable($options['filteringHits'])) {
-            $searchResult = $searchResult->filter($options['filteringHits']);
+        if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
+            $searchResult = $searchResult->filter($options['transformHits']);
         }
 
         return $searchResult;

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -11,6 +11,7 @@ use MeiliSearch\Endpoints\Delegates\HandlesDocuments;
 use MeiliSearch\Endpoints\Delegates\HandlesSettings;
 use MeiliSearch\Exceptions\HTTPRequestException;
 use MeiliSearch\Exceptions\TimeOutException;
+use MeiliSearch\Search\SearchResult;
 
 class Indexes extends Endpoint
 {
@@ -72,7 +73,7 @@ class Indexes extends Endpoint
 
     public function update($body): array
     {
-        return  $this->http->put(self::PATH.'/'.$this->uid, $body);
+        return $this->http->put(self::PATH.'/'.$this->uid, $body);
     }
 
     public function delete(): array
@@ -117,14 +118,31 @@ class Indexes extends Endpoint
 
     // Search
 
-    public function search($query, array $options = []): array
+    /**
+     * @param string $query
+     *
+     * @return SearchResult|array
+     */
+    public function search($query, array $searchParams = [], array $options = [])
     {
         $parameters = array_merge(
             ['q' => $query],
-            $options
+            $searchParams
         );
 
-        return $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
+        $result = $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
+
+        if (\array_key_exists('raw', $options) && $options['raw']) {
+            return $result;
+        }
+
+        $searchResult = new SearchResult($result);
+
+        if (\array_key_exists('filteringHits', $options) && \is_callable($options['filteringHits'])) {
+            $searchResult = $searchResult->filter($options['filteringHits']);
+        }
+
+        return $searchResult;
     }
 
     // Stats

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -117,7 +117,7 @@ class SearchResult implements Countable, IteratorAggregate
         return $this->limit;
     }
 
-    public function getMatches(): int
+    public function getHitsCount(): int
     {
         return $this->nbHits;
     }
@@ -171,8 +171,8 @@ class SearchResult implements Countable, IteratorAggregate
             'hits' => $this->hits,
             'offset' => $this->offset,
             'limit' => $this->limit,
-            'matches' => $this->nbHits,
-            'nbHits' => \count($this->hits),
+            'nbHits' => $this->nbHits,
+            'hitsCount' => \count($this->hits),
             'exhaustiveNbHits' => $this->exhaustiveNbHits,
             'processingTimeMs' => $this->processingTimeMs,
             'query' => $this->query,
@@ -181,7 +181,7 @@ class SearchResult implements Countable, IteratorAggregate
         ];
     }
 
-    public function json(): string
+    public function toJson(): string
     {
         return \json_encode($this->toArray(), JSON_PRETTY_PRINT);
     }

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Search;
+
+use function array_filter;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+class SearchResult implements Countable, IteratorAggregate
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private $hits;
+
+    /**
+     * @var int
+     */
+    private $offset;
+
+    /**
+     * @var int
+     */
+    private $limit;
+
+    /**
+     * @var int
+     */
+    private $nbHits;
+
+    /**
+     * @var bool
+     */
+    private $exhaustiveNbHits;
+
+    /**
+     * @var int
+     */
+    private $processingTimeMs;
+
+    /**
+     * @var string
+     */
+    private $query;
+
+    /**
+     * @var bool|null
+     */
+    private $exhaustiveFacetsCount;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $facetsDistribution;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $raw;
+
+    public function __construct(array $body)
+    {
+        $this->hits = $body['hits'] ?? [];
+        $this->offset = $body['offset'];
+        $this->limit = $body['limit'];
+        $this->nbHits = $body['nbHits'];
+        $this->exhaustiveNbHits = $body['exhaustiveNbHits'] ?? false;
+        $this->processingTimeMs = $body['processingTimeMs'];
+        $this->query = $body['query'];
+        $this->exhaustiveFacetsCount = $body['exhaustiveFacetsCount'] ?? null;
+        $this->facetsDistribution = $body['facetsDistribution'] ?? [];
+        $this->raw = $body;
+    }
+
+    /**
+     * Return a new {@see SearchResult} instance with the hits filtered using `array_filter($this->hits, $callback, ARRAY_FILTER_USE_BOTH)`.
+     *
+     * The $callback receives both the current hit and the key, in that order.
+     *
+     * The method DOES not trigger a new search.
+     *
+     * @return SearchResult
+     */
+    public function filter(callable $callback): self
+    {
+        $results = array_filter($this->hits, $callback, ARRAY_FILTER_USE_BOTH);
+
+        $this->hits = $results;
+        $this->nbHits = \count($results);
+
+        return $this;
+    }
+
+    public function getHit(int $key, $default = null)
+    {
+        return $this->hits[$key] ?? $default;
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    public function getHits(): array
+    {
+        return $this->hits;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getMatches(): int
+    {
+        return $this->nbHits;
+    }
+
+    public function getNbHits(): int
+    {
+        return \count($this->hits);
+    }
+
+    public function getExhaustiveNbHits(): bool
+    {
+        return $this->exhaustiveNbHits;
+    }
+
+    public function getProcessingTimeMs(): int
+    {
+        return $this->processingTimeMs;
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    public function getExhaustiveFacetsCount(): ?bool
+    {
+        return $this->exhaustiveFacetsCount;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFacetsDistribution(): array
+    {
+        return $this->facetsDistribution;
+    }
+
+    /**
+     * Return the original search result.
+     *
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'hits' => $this->hits,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'matches' => $this->nbHits,
+            'nbHits' => \count($this->hits),
+            'exhaustiveNbHits' => $this->exhaustiveNbHits,
+            'processingTimeMs' => $this->processingTimeMs,
+            'query' => $this->query,
+            'exhaustiveFacetsCount' => $this->exhaustiveFacetsCount,
+            'facetsDistribution' => $this->facetsDistribution,
+        ];
+    }
+
+    public function json(): string
+    {
+        return \json_encode($this->toArray(), JSON_PRETTY_PRINT);
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->hits);
+    }
+
+    public function count(): int
+    {
+        return \count($this->hits);
+    }
+}

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -28,7 +28,7 @@ final class KeysAndPermissionsTest extends TestCase
 
         $newClient = new Client(self::HOST, $this->getKeys()['public']);
         $response = $newClient->getIndex('index')->search('test');
-        $this->assertArrayHasKey('hits', $response);
+        $this->assertArrayHasKey('hits', $response->toArray());
     }
 
     public function testGetSettingsIfPrivateKeyProvided(): void

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -23,43 +23,83 @@ final class SearchTest extends TestCase
     {
         $response = $this->index->search('prince');
 
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame(2, $response->getNbHits());
+        $this->assertCount(2, $response->getHits());
+
+        $response = $this->index->search('prince', [], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('hits', $response);
         $this->assertArrayHasKey('offset', $response);
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertCount(2, $response['hits']);
+        $this->assertSame(2, $response['nbHits']);
     }
 
     public function testBasicEmptySearch(): void
     {
         $response = $this->index->search('');
 
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertCount(7, $response->getHits());
+
+        $response = $this->index->search('', [], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('hits', $response);
         $this->assertArrayHasKey('offset', $response);
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertCount(7, $response['hits']);
+        $this->assertSame(7, $response['nbHits']);
     }
 
     public function testBasicPlaceholderSearch(): void
     {
         $response = $this->index->search(null);
 
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertCount(\count(self::DOCUMENTS), $response->getHits());
+
+        $response = $this->index->search(null, [], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('hits', $response);
         $this->assertArrayHasKey('offset', $response);
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertCount(\count(self::DOCUMENTS), $response['hits']);
+        $this->assertSame(\count(self::DOCUMENTS), $response['nbHits']);
     }
 
     public function testSearchWithOptions(): void
     {
         $response = $this->index->search('prince', ['limit' => 1]);
 
-        $this->assertCount(1, $response['hits']);
+        $this->assertCount(1, $response->getHits());
+
+        $response = $this->index->search('prince', ['limit' => 1], [
+            'raw' => true,
+        ]);
+
+        $this->assertSame(1, \count($response['hits']));
     }
 
     public function testBasicSearchIfNoPrimaryKeyAndDocumentProvided(): void
@@ -68,12 +108,23 @@ final class SearchTest extends TestCase
 
         $res = $emptyIndex->search('prince');
 
+        $this->assertArrayHasKey('hits', $res->toArray());
+        $this->assertArrayHasKey('offset', $res->toArray());
+        $this->assertArrayHasKey('limit', $res->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $res->toArray());
+        $this->assertArrayHasKey('query', $res->toArray());
+        $this->assertCount(0, $res->getHits());
+
+        $res = $emptyIndex->search('prince', [], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('hits', $res);
         $this->assertArrayHasKey('offset', $res);
         $this->assertArrayHasKey('limit', $res);
         $this->assertArrayHasKey('processingTimeMs', $res);
         $this->assertArrayHasKey('query', $res);
-        $this->assertCount(0, $res['hits']);
+        $this->assertSame(0, $res['nbHits']);
     }
 
     public function testExceptionIfNoIndexWhenSearching(): void
@@ -99,6 +150,26 @@ final class SearchTest extends TestCase
             'matches' => true,
         ]);
 
+        $this->assertArrayHasKey('_matchesInfo', $response->getHit(0));
+        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertArrayNotHasKey('comment', $response->getHit(0));
+        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
+        $this->assertSame('Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('prince', [
+            'limit' => 5,
+            'offset' => 0,
+            'attributesToRetrieve' => ['id', 'title'],
+            'attributesToCrop' => ['id', 'title'],
+            'cropLength' => 6,
+            'attributesToHighlight' => ['title'],
+            'filters' => 'title = "Le Petit Prince"',
+            'matches' => true,
+        ], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('_matchesInfo', $response['hits'][0]);
         $this->assertArrayHasKey('title', $response['hits'][0]['_matchesInfo']);
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
@@ -120,6 +191,26 @@ final class SearchTest extends TestCase
             'matches' => true,
         ]);
 
+        $this->assertArrayHasKey('_matchesInfo', $response->getHit(0));
+        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertArrayHasKey('comment', $response->getHit(0));
+        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
+        $this->assertSame('Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('prince', [
+            'limit' => 5,
+            'offset' => 0,
+            'attributesToRetrieve' => ['*'],
+            'attributesToCrop' => ['*'],
+            'cropLength' => 6,
+            'attributesToHighlight' => ['*'],
+            'filters' => 'title = "Le Petit Prince"',
+            'matches' => true,
+        ], [
+            'raw' => true,
+        ]);
+
         $this->assertArrayHasKey('_matchesInfo', $response['hits'][0]);
         $this->assertArrayHasKey('title', $response['hits'][0]['_matchesInfo']);
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
@@ -135,6 +226,20 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search('prince', [
             'facetsDistribution' => ['genre'],
+        ]);
+        $this->assertSame(2, $response->getMatches());
+        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('exhaustiveFacetsCount', $response->toArray());
+        $this->assertArrayHasKey('genre', $response->getFacetsDistribution());
+        $this->assertTrue($response->getExhaustiveFacetsCount());
+        $this->assertSame($response->getFacetsDistribution()['genre']['fantasy'], 1);
+        $this->assertSame($response->getFacetsDistribution()['genre']['adventure'], 1);
+        $this->assertSame($response->getFacetsDistribution()['genre']['romance'], 0);
+
+        $response = $this->index->search('prince', [
+            'facetsDistribution' => ['genre'],
+        ], [
+            'raw' => true,
         ]);
         $this->assertSame(2, $response['nbHits']);
         $this->assertArrayHasKey('facetsDistribution', $response);
@@ -154,6 +259,16 @@ final class SearchTest extends TestCase
         $response = $this->index->search('prince', [
             'facetFilters' => [['genre:fantasy']],
         ]);
+        $this->assertSame(1, $response->getMatches());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertSame(4, $response->getHit(0)['id']);
+
+        $response = $this->index->search('prince', [
+            'facetFilters' => [['genre:fantasy']],
+        ], [
+            'raw' => true,
+        ]);
         $this->assertSame(1, $response['nbHits']);
         $this->assertArrayNotHasKey('facetsDistribution', $response);
         $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
@@ -167,6 +282,16 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search('prince', [
             'facetFilters' => ['genre:fantasy', ['genre:fantasy', 'genre:fantasy']],
+        ]);
+        $this->assertSame(1, $response->getMatches());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertSame(4, $response->getHit(0)['id']);
+
+        $response = $this->index->search('prince', [
+            'facetFilters' => ['genre:fantasy', ['genre:fantasy', 'genre:fantasy']],
+        ], [
+            'raw' => true,
         ]);
         $this->assertSame(1, $response['nbHits']);
         $this->assertArrayNotHasKey('facetsDistribution', $response);
@@ -182,6 +307,20 @@ final class SearchTest extends TestCase
         $response = $this->index->search('prince', [
             'facetFilters' => [['genre:fantasy']],
             'attributesToRetrieve' => ['id', 'title'],
+        ]);
+        $this->assertSame(1, $response->getMatches());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertSame(4, $response->getHit(0)['id']);
+        $this->assertArrayHasKey('id', $response->getHit(0));
+        $this->assertArrayHasKey('title', $response->getHit(0));
+        $this->assertArrayNotHasKey('comment', $response->getHit(0));
+
+        $response = $this->index->search('prince', [
+            'facetFilters' => [['genre:fantasy']],
+            'attributesToRetrieve' => ['id', 'title'],
+        ], [
+            'raw' => true,
         ]);
         $this->assertSame(1, $response['nbHits']);
         $this->assertArrayNotHasKey('facetsDistribution', $response);

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -56,7 +56,7 @@ final class SearchResultTest extends TestCase
         static::assertSame(0, $result->getOffset());
         static::assertSame(20, $result->getLimit());
         static::assertSame(2, $result->getNbHits());
-        static::assertSame(976, $result->getMatches());
+        static::assertSame(976, $result->getHitsCount());
         static::assertFalse($result->getExhaustiveNbHits());
         static::assertSame(35, $result->getProcessingTimeMs());
         static::assertSame('american', $result->getQuery());
@@ -142,12 +142,12 @@ final class SearchResultTest extends TestCase
             'query' => 'american',
         ]);
 
-        $json = $result->json();
+        $json = $result->toJson();
 
         static::assertStringContainsString('hits', $json);
         static::assertStringContainsString('offset', $json);
         static::assertStringContainsString('limit', $json);
-        static::assertStringContainsString('matches', $json);
+        static::assertStringContainsString('hitsCount', $json);
         static::assertStringContainsString('nbHits', $json);
         static::assertStringContainsString('exhaustiveNbHits', $json);
         static::assertStringContainsString('processingTimeMs', $json);

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Search;
+
+use MeiliSearch\Search\SearchResult;
+use PHPUnit\Framework\TestCase;
+use function strtoupper;
+
+final class SearchResultTest extends TestCase
+{
+    public function testResultCanBeBuilt(): void
+    {
+        $result = new SearchResult([
+            'hits' => [
+                [
+                    'title' => 'American Pie 2',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
+                    'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
+                    'release_date' => 997405200,
+                ],
+                [
+                    'id' => '190859',
+                    'title' => 'American Sniper',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
+                    'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
+                    'release_date' => 1418256000,
+                ],
+            ],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 976,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 35,
+            'query' => 'american',
+        ]);
+
+        static::assertSame(2, $result->count());
+        static::assertNotEmpty($result->getHits());
+
+        static::assertEquals([
+            'title' => 'American Pie 2',
+            'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
+            'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
+            'release_date' => 997405200,
+        ], $result->getHit(0));
+        static::assertEquals([
+            'id' => '190859',
+            'title' => 'American Sniper',
+            'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
+            'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
+            'release_date' => 1418256000,
+        ], $result->getHit(1));
+        static::assertNull($result->getHit(2));
+        static::assertSame(0, $result->getOffset());
+        static::assertSame(20, $result->getLimit());
+        static::assertSame(2, $result->getNbHits());
+        static::assertSame(976, $result->getMatches());
+        static::assertFalse($result->getExhaustiveNbHits());
+        static::assertSame(35, $result->getProcessingTimeMs());
+        static::assertSame('american', $result->getQuery());
+        static::assertNull($result->getExhaustiveFacetsCount());
+        static::assertEmpty($result->getFacetsDistribution());
+        static::assertSame(2, $result->getIterator()->count());
+
+        static::assertArrayHasKey('hits', $result->toArray());
+        static::assertArrayHasKey('offset', $result->toArray());
+        static::assertArrayHasKey('limit', $result->toArray());
+        static::assertArrayHasKey('nbHits', $result->toArray());
+        static::assertArrayHasKey('exhaustiveNbHits', $result->toArray());
+        static::assertArrayHasKey('processingTimeMs', $result->toArray());
+        static::assertArrayHasKey('query', $result->toArray());
+        static::assertArrayHasKey('exhaustiveFacetsCount', $result->toArray());
+        static::assertArrayHasKey('facetsDistribution', $result->toArray());
+    }
+
+    public function testSearchResultCanBeFiltered(): void
+    {
+        $result = new SearchResult([
+            'hits' => [
+                [
+                    'title' => 'American Pie 2',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
+                    'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
+                    'release_date' => 997405200,
+                ],
+                [
+                    'id' => '190859',
+                    'title' => 'American Sniper',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
+                    'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
+                    'release_date' => 1418256000,
+                ],
+            ],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 976,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 35,
+            'query' => 'american',
+        ]);
+
+        $filteredResults = $result->filter(function (array $hit, int $_): bool {
+            return 'AMERICAN SNIPER' === strtoupper($hit['title']);
+        });
+
+        static::assertSame(1, $filteredResults->count());
+        static::assertNull($result->getHit(0));
+        static::assertEquals([
+            'id' => '190859',
+            'title' => 'American Sniper',
+            'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
+            'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
+            'release_date' => 1418256000,
+        ], $result->getHit(1));
+    }
+
+    public function testResultCanBeReturnedAsJson(): void
+    {
+        $result = new SearchResult([
+            'hits' => [
+                [
+                    'title' => 'American Pie 2',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
+                    'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
+                    'release_date' => 997405200,
+                ],
+                [
+                    'id' => '190859',
+                    'title' => 'American Sniper',
+                    'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
+                    'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
+                    'release_date' => 1418256000,
+                ],
+            ],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 976,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 35,
+            'query' => 'american',
+        ]);
+
+        $json = $result->json();
+
+        static::assertStringContainsString('hits', $json);
+        static::assertStringContainsString('offset', $json);
+        static::assertStringContainsString('limit', $json);
+        static::assertStringContainsString('matches', $json);
+        static::assertStringContainsString('nbHits', $json);
+        static::assertStringContainsString('exhaustiveNbHits', $json);
+        static::assertStringContainsString('processingTimeMs', $json);
+        static::assertStringContainsString('query', $json);
+        static::assertStringContainsString('exhaustiveFacetsCount', $json);
+        static::assertStringContainsString('facetsDistribution', $json);
+    }
+}


### PR DESCRIPTION
Hi everyone 👋 

As mentioned here: https://github.com/meilisearch/meilisearch-php/issues/119, here's the `SearchResult` class and the improvements that comes with it. 

There's just a small "DX" way that I'm not sure about: 

- When using `SearchResult::filter()` should the `hits` array be reset to 0 or stay as it? 

IMO, the array could stays as it as we return a new `SearchResult` object but sometimes, it could be good idea to reset the keys from 0 (loops, etc) 🤔 

Thanks for the feedback and have a great day 🙂 