### PR TITLE
 Changes due to the implicit index creation

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  $client->index('movies')->getRaw();
+  $client->index('movies')->fetchRawInfo();
 list_all_indexes_1: |-
   $client->getAllIndexes();
 create_an_index_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  $client->getIndex('movies');
+  $client->index('movies')->getRaw();
 list_all_indexes_1: |-
   $client->getAllIndexes();
 create_an_index_1: |-
@@ -12,17 +12,17 @@ create_an_index_1: |-
 update_an_index_1: |-
   $client->updateIndex('movies', ['primaryKey' => 'movie_id']);
   // OR
-  $client->getIndex('movies')->update(['primaryKey' => 'movie_id']);
+  $client->index('movies')->update(['primaryKey' => 'movie_id']);
 delete_an_index_1: |-
   $client->deleteIndex('movies');
   // OR
-  $client->getIndex('movies')->delete();
+  $client->index('movies')->delete();
 get_one_document_1: |-
-  $client->getIndex('movies')->getDocument(25684);
+  $client->index('movies')->getDocument(25684);
 get_documents_1: |-
-  $client->getIndex('movies')->getDocuments(['limit' => 2]);
+  $client->index('movies')->getDocuments(['limit' => 2]);
 add_or_replace_documents_1: |-
-  $client->getIndex('movies')->addDocuments([
+  $client->index('movies')->addDocuments([
     [
       'id' => 287947
       'title' => 'Shazam',
@@ -32,7 +32,7 @@ add_or_replace_documents_1: |-
     ]
   ]);
 add_or_update_documents_1: |-
-  $client->getIndex('movies')->updateDocuments([
+  $client->index('movies')->updateDocuments([
     [
       'id' => 287947
       'title' => 'Shazam ⚡️',
@@ -40,23 +40,23 @@ add_or_update_documents_1: |-
     ]
   ]);
 delete_all_documents_1: |-
-  $client->getIndex('movies')->deleteAllDocuments();
+  $client->index('movies')->deleteAllDocuments();
 delete_one_document_1: |-
-  $client->getIndex('movies')->deleteDocument(25684);
+  $client->index('movies')->deleteDocument(25684);
 delete_documents_1: |-
-  $client->getIndex('movies')->deleteDocuments([23488, 153738, 437035, 363869]);
+  $client->index('movies')->deleteDocuments([23488, 153738, 437035, 363869]);
 search_1: |-
-  $client->getIndex('movies')->search('american ninja');
+  $client->index('movies')->search('american ninja');
 get_update_1: |-
-  $client->getIndex('movies')->getUpdateStatus(1);
+  $client->index('movies')->getUpdateStatus(1);
 get_all_updates_1: |-
-  $client->getIndex('movies')->getAllUpdateStatus();
+  $client->index('movies')->getAllUpdateStatus();
 get_keys_1: |-
   $client->getKeys();
 get_settings_1: |-
-  $client->getIndex('movies')->getSettings();
+  $client->index('movies')->getSettings();
 update_settings_1: |-
-  $client->getIndex('movies')->updateSettings([
+  $client->index('movies')->updateSettings([
     'rankingRules' => [
       'typo',
       'words',
@@ -95,27 +95,27 @@ update_settings_1: |-
     ]
   ]);
 reset_settings_1: |-
-  $client->getIndex('movies')->resetSettings();
+  $client->index('movies')->resetSettings();
 get_synonyms_1: |-
-  $client->getIndex('movies')->getSynonyms();
+  $client->index('movies')->getSynonyms();
 update_synonyms_1: |-
-  $client->getIndex('movies')->updateSynonyms([
+  $client->index('movies')->updateSynonyms([
     'wolverine': ['xmen', 'logan'],
     'logan': ['wolverine', 'xmen'],
     'wow': ['world of warcraft']
   ]);
 reset_synonyms_1: |-
-  $client->getIndex('movies')->resetSynonyms();
+  $client->index('movies')->resetSynonyms();
 get_stop_words_1: |-
-  $client->getIndex('movies')->getStopWords();
+  $client->index('movies')->getStopWords();
 update_stop_words_1: |-
-  $client->getIndex('movies')->updateStopWords(['the', 'of', 'to']);
+  $client->index('movies')->updateStopWords(['the', 'of', 'to']);
 reset_stop_words_1: |-
-  $client->getIndex('movies')->resetStopWords();
+  $client->index('movies')->resetStopWords();
 get_ranking_rules_1: |-
-  $client->getIndex('movies')->getRankingRules();
+  $client->index('movies')->getRankingRules();
 update_ranking_rules_1: |-
-  $client->getIndex('movies')->updateRankingRules([
+  $client->index('movies')->updateRankingRules([
     'typo',
     'words',
     'proximity',
@@ -126,36 +126,36 @@ update_ranking_rules_1: |-
     'desc(rank)'
   ]);
 reset_ranking_rules_1: |-
-  $client->getIndex('movies')->resetRankingRules();
+  $client->index('movies')->resetRankingRules();
 get_distinct_attribute_1: |-
-  $client->getIndex('movies')->getDistinctAttribute();
+  $client->index('movies')->getDistinctAttribute();
 update_distinct_attribute_1: |-
-  $client->getIndex('movies')->updateDistinctAttribute('movie_id');
+  $client->index('movies')->updateDistinctAttribute('movie_id');
 reset_distinct_attribute_1: |-
-  $client->getIndex('movies')->resetDistinctAttribute();
+  $client->index('movies')->resetDistinctAttribute();
 get_searchable_attributes_1: |-
-  $client->getIndex('movies')->getSearchableAttributes();
+  $client->index('movies')->getSearchableAttributes();
 update_searchable_attributes_1: |-
-  $client->getIndex('movies')->updateSearchableAttributes([
+  $client->index('movies')->updateSearchableAttributes([
     'title',
     'description',
     'uid'
   ]);
 reset_searchable_attributes_1: |-
-  $client->getIndex('movies')->resetSearchableAttributes();
+  $client->index('movies')->resetSearchableAttributes();
 get_attributes_for_faceting_1: |-
-  $client->getIndex('movies')->getAttributesForFaceting();
+  $client->index('movies')->getAttributesForFaceting();
 update_attributes_for_faceting_1: |-
-  $client->getIndex('movies')->updateAttributesForFaceting([
+  $client->index('movies')->updateAttributesForFaceting([
     'genres',
     'director'
   ]);
 reset_attributes_for_faceting_1: |-
-  $client->getIndex('movies')->resetAttributesForFaceting();
+  $client->index('movies')->resetAttributesForFaceting();
 get_displayed_attributes_1: |-
-  $client->getIndex('movies')->getDisplayedAttributes();
+  $client->index('movies')->getDisplayedAttributes();
 update_displayed_attributes_1: |-
-  $client->getIndex('movies')->updateDisplayedAttributes([
+  $client->index('movies')->updateDisplayedAttributes([
     'title',
     'description',
     'release_date',
@@ -163,9 +163,9 @@ update_displayed_attributes_1: |-
     'poster'
   ]);
 reset_displayed_attributes_1: |-
-  $client->getIndex('movies')->resetDisplayedAttributes();
+  $client->index('movies')->resetDisplayedAttributes();
 get_index_stats_1: |-
-  $client->getIndex('movies')->stats();
+  $client->index('movies')->stats();
 get_indexes_stats_1: |-
   $client->stats();
 get_health_1: |-
@@ -173,9 +173,9 @@ get_health_1: |-
 get_version_1: |-
   $client->version();
 distinct_attribute_guide_1: |-
-  $client->getIndex('jackets')->updateDistinctAttribute('product_id');
+  $client->index('jackets')->updateDistinctAttribute('product_id');
 field_properties_guide_searchable_1: |-
-  $client->getIndex('movies')->updateSearchableAttributes([
+  $client->index('movies')->updateSearchableAttributes([
     'uid',
     'movie_id',
     'title',
@@ -185,7 +185,7 @@ field_properties_guide_searchable_1: |-
     'rank'
   ]);
 field_properties_guide_displayed_1: |-
-  $client->getIndex('movies')->updateDisplayedAttributes([
+  $client->index('movies')->updateDisplayedAttributes([
     'title',
     'description',
     'poster',
@@ -193,37 +193,37 @@ field_properties_guide_displayed_1: |-
     'rank',
   ]);
 filtering_guide_1: |-
-  $client->getIndex('movies')->search('Avengers', ['filters' => 'release_date > 795484800']);
+  $client->index('movies')->search('Avengers', ['filters' => 'release_date > 795484800']);
 filtering_guide_2: |-
-  $client->getIndex('movies')->search('Avengers', ['filters' => 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")']);
+  $client->index('movies')->search('Avengers', ['filters' => 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")']);
 filtering_guide_3: |-
-  $client->getIndex('movies')->search('horror', ['filters' => 'director = "Jordan Peele"']);
+  $client->index('movies')->search('horror', ['filters' => 'director = "Jordan Peele"']);
 filtering_guide_4: |-
-  $client->getIndex('movies')->search('Planet of the Apes', ['filters' => 'rating >= 3 AND (NOT director = "Tim Burton")']);
+  $client->index('movies')->search('Planet of the Apes', ['filters' => 'rating >= 3 AND (NOT director = "Tim Burton")']);
 search_parameter_guide_query_1: |-
-  $client->getIndex('movies')->search('shifu');
+  $client->index('movies')->search('shifu');
 search_parameter_guide_offset_1: |-
-  $client->getIndex('movies')->search('shifu', ['offset' => 1]);
+  $client->index('movies')->search('shifu', ['offset' => 1]);
 search_parameter_guide_limit_1: |-
-  $client->getIndex('movies')->search('shifu', ['limit' => 1]);
+  $client->index('movies')->search('shifu', ['limit' => 1]);
 search_parameter_guide_retrieve_1: |-
-  $client->getIndex('movies')->search('shifu', ['attributesToRetrieve' => ['overview', 'title']]);
+  $client->index('movies')->search('shifu', ['attributesToRetrieve' => ['overview', 'title']]);
 search_parameter_guide_crop_1: |-
-  $client->getIndex('movies')->search('shifu', ['attributesToCrop' => ['overview'], 'cropLength' => 10]);
+  $client->index('movies')->search('shifu', ['attributesToCrop' => ['overview'], 'cropLength' => 10]);
 search_parameter_guide_highlight_1: |-
-  $client->getIndex('movies')->search('shifu', ['attributesToHighlight' => ['overview']]);
+  $client->index('movies')->search('shifu', ['attributesToHighlight' => ['overview']]);
 search_parameter_guide_filter_1: |-
-  $client->getIndex('movies')->search('n', ['filters' => 'title = Nightshift']);
+  $client->index('movies')->search('n', ['filters' => 'title = Nightshift']);
 search_parameter_guide_filter_2: |-
-  $client->getIndex('movies')->search('shifu', ['filters' => 'title="Kung Fu Panda"']);
+  $client->index('movies')->search('shifu', ['filters' => 'title="Kung Fu Panda"']);
 search_parameter_guide_matches_1: |-
-  $client->getIndex('movies')->search('shifu', ['attributesToHighlight' => ['overview'], 'matches' => true]);
+  $client->index('movies')->search('shifu', ['attributesToHighlight' => ['overview'], 'matches' => true]);
 settings_guide_synonyms_1: |-
-  $client->getIndex('tops')->updateSynonyms(['sweater' => ['jumper'], 'jumper' => ['sweater']]);
+  $client->index('tops')->updateSynonyms(['sweater' => ['jumper'], 'jumper' => ['sweater']]);
 settings_guide_stop_words_1: |-
-  $client->getIndex('movies')->updateStopWords(['the', 'a', 'an']);
+  $client->index('movies')->updateStopWords(['the', 'a', 'an']);
 settings_guide_ranking_rules_1: |-
-  $client->getIndex('movies')->updateRankingRules([
+  $client->index('movies')->updateRankingRules([
     'typo',
     'words',
     'proximity',
@@ -234,9 +234,9 @@ settings_guide_ranking_rules_1: |-
     'desc(rank)'
   ]);
 settings_guide_distinct_1: |-
-  $client->getIndex('jackets')->updateDistinctAttribute('product_id');
+  $client->index('jackets')->updateDistinctAttribute('product_id');
 settings_guide_searchable_1: |-
-  $client->getIndex('movies')->updateSearchableAttributes([
+  $client->index('movies')->updateSearchableAttributes([
     'uid',
     'movie_id',
     'title',
@@ -246,7 +246,7 @@ settings_guide_searchable_1: |-
     'rank'
   ]);
 settings_guide_displayed_1: |-
-  $client->getIndex('movies')->updateDisplayedAttributes([
+  $client->index('movies')->updateDisplayedAttributes([
     'title',
     'description',
     'poster',
@@ -257,13 +257,13 @@ add_movies_json_1: |-
   $moviesJson = file_get_contents('movies.json');
   $movies = json_decode($moviesJson);
 
-  $client->getIndex('movies')->addDocuments($movies)
+  $client->index('movies')->addDocuments($movies)
 documents_guide_add_movie_1: |-
-  $client->getIndex('movies')->addDocuments([['movie_id' => '123sq178', 'title' => 'Amelie Poulain']]);
+  $client->index('movies')->addDocuments([['movie_id' => '123sq178', 'title' => 'Amelie Poulain']]);
 search_guide_1: |-
-  $client->getIndex('movies')->search('shifu', ['limit' => 5, 'offset' => 10]);
+  $client->index('movies')->search('shifu', ['limit' => 5, 'offset' => 10]);
 search_guide_2: |-
-  $client->getIndex('movies')->search('Avengers', ['filters' => 'release_date > 795484800']);
+  $client->index('movies')->search('Avengers', ['filters' => 'release_date > 795484800']);
 getting_started_create_index_md: |-
   Using `meilisearch-php` with the Guzzle HTTP client:
 
@@ -298,22 +298,22 @@ getting_started_search_md: |-
 
   [About this package](https://github.com/meilisearch/meilisearch-php/)
 faceted_search_update_settings_1: |-
-  $client->getIndex('movies')->updateAttributesForFaceting(['director', 'genres']);
+  $client->index('movies')->updateAttributesForFaceting(['director', 'genres']);
 faceted_search_facet_filters_1: |-
-  $client->getIndex('movies')->search('thriller', ['facetFilters' => [['genres:Horror', 'genres:Mystery']], 'director' => "Jordan Peele"']);
+  $client->index('movies')->search('thriller', ['facetFilters' => [['genres:Horror', 'genres:Mystery']], 'director' => "Jordan Peele"']);
 faceted_search_facets_distribution_1: |-
-  $client->getIndex('movies')->search('Batman', ['facetsDistribution' => ['genres']]);
+  $client->index('movies')->search('Batman', ['facetsDistribution' => ['genres']]);
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  $client->getIndex('movies')->updateAttributesForFaceting([
+  $client->index('movies')->updateAttributesForFaceting([
     'director',
     'producer',
     'genres',
     'production_companies'
   ]);
 faceted_search_walkthrough_facet_filters_1: |-
-  $client->getIndex('movies')->search('thriller', ['facetFilters' => [['genres:Horror', 'genres:Mystery']], 'director' => "Jordan Peele"]);
+  $client->index('movies')->search('thriller', ['facetFilters' => [['genres:Horror', 'genres:Mystery']], 'director' => "Jordan Peele"]);
 faceted_search_walkthrough_facets_distribution_1: |-
-  $client->getIndex('movies')->search('Batman', ['facetsDistribution' => ['genres']);
+  $client->index('movies')->search('Batman', ['facetsDistribution' => ['genres']);
 post_dump_1: |-
   $client->createDump();
 get_dump_status_1: |-

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ require_once __DIR__ . '/vendor/autoload.php';
 use MeiliSearch\Client;
 
 $client = new Client('http://127.0.0.1:7700', 'masterKey');
-$index = $client->createIndex('books'); // If your index does not exist
-$index = $client->getIndex('books');    // If you already created your index
+
+# An index is where the documents are stored.
+$index = $client->index('books');
 
 $documents = [
     ['book_id' => 123,  'title' => 'Pride and Prejudice', 'author' => 'Jane Austen'],
@@ -98,6 +99,7 @@ $documents = [
     ['book_id' => 42,   'title' => 'The Hitchhiker\'s Guide to the Galaxy', 'author' => 'Douglas Adams, Eoin Colfer, Thomas Tidholm'],
 ];
 
+# If the index 'movies' does not exist, MeiliSearch creates it when you first add the documents.
 $index->addDocuments($documents); // => { "updateId": 0 }
 ```
 

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -73,14 +73,14 @@ class Indexes extends Endpoint
         return $this->uid;
     }
 
-    public function getRaw(): ?array
+    public function fetchRawInfo(): ?array
     {
         return $this->http->get(self::PATH.'/'.$this->uid);
     }
 
     public function fetchInfo(): self
     {
-        $response = $this->getRaw();
+        $response = $this->fetchRawInfo();
         $this->uid = $response['uid'];
         $this->primaryKey = $response['primaryKey'];
 

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -24,10 +24,12 @@ class Indexes extends Endpoint
      * @var string|null
      */
     private $uid;
+    private $primaryKey;
 
-    public function __construct(Http $http, $uid = null)
+    public function __construct(Http $http, $uid = null, $primaryKey = null)
     {
         $this->uid = $uid;
+        $this->primaryKey = $primaryKey;
         parent::__construct($http);
     }
 
@@ -42,7 +44,7 @@ class Indexes extends Endpoint
 
         $response = $this->http->post(self::PATH, $options);
 
-        return new self($this->http, $response['uid']);
+        return new self($this->http, $response['uid'], $response['primaryKey']);
     }
 
     public function all(): array
@@ -58,7 +60,12 @@ class Indexes extends Endpoint
 
     public function getPrimaryKey(): ?string
     {
-        return $this->show()['primaryKey'];
+        return $this->primaryKey;
+    }
+
+    public function fetchPrimaryKey(): ?string
+    {
+        return $this->fetchInfo()->getPrimaryKey();
     }
 
     public function getUid(): ?string
@@ -66,14 +73,27 @@ class Indexes extends Endpoint
         return $this->uid;
     }
 
-    public function show(): ?array
+    public function getRaw(): ?array
     {
         return $this->http->get(self::PATH.'/'.$this->uid);
     }
 
-    public function update($body): array
+    public function fetchInfo(): self
     {
-        return $this->http->put(self::PATH.'/'.$this->uid, $body);
+        $response = $this->getRaw();
+        $this->uid = $response['uid'];
+        $this->primaryKey = $response['primaryKey'];
+
+        return $this;
+    }
+
+    public function update($body): self
+    {
+        $response = $this->http->put(self::PATH.'/'.$this->uid, $body);
+        $this->uid = $response['uid'];
+        $this->primaryKey = $response['primaryKey'];
+
+        return $this;
     }
 
     public function delete(): array

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -160,7 +160,7 @@ class SearchResult implements Countable, IteratorAggregate
      *
      * @return array<string, mixed>
      */
-    public function getRaw(): array
+    public function fetchRawInfo(): array
     {
         return $this->raw;
     }

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -248,7 +248,7 @@ final class DocumentsTest extends TestCase
         $this->assertArrayHasKey('updateId', $response);
         $index->waitForPendingUpdate($response['updateId']);
 
-        $this->assertSame('unique', $index->getPrimaryKey());
+        $this->assertSame('unique', $index->fetchPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
     }
 
@@ -268,7 +268,7 @@ final class DocumentsTest extends TestCase
 
         $index->waitForPendingUpdate($promise['updateId']);
 
-        $this->assertSame('unique', $index->getPrimaryKey());
+        $this->assertSame('unique', $index->fetchPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
     }
 

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -40,14 +40,14 @@ final class IndexTest extends TestCase
         $this->assertSame('indexB', $indexB->getUid());
     }
 
-    public function testGetRaw(): void
+    public function testfetchRawInfo(): void
     {
         $index = $this->client->createIndex(
             'indexB',
             ['primaryKey' => 'objectId']
         );
 
-        $response = $index->getRaw();
+        $response = $index->fetchRawInfo();
 
         $this->assertArrayHasKey('primaryKey', $response);
         $this->assertArrayHasKey('uid', $response);

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use MeiliSearch\Endpoints\Indexes;
 use MeiliSearch\Exceptions\HTTPRequestException;
 use MeiliSearch\Exceptions\TimeOutException;
 use Tests\TestCase;
@@ -39,14 +40,14 @@ final class IndexTest extends TestCase
         $this->assertSame('indexB', $indexB->getUid());
     }
 
-    public function testShow(): void
+    public function testGetRaw(): void
     {
         $index = $this->client->createIndex(
             'indexB',
             ['primaryKey' => 'objectId']
         );
 
-        $response = $index->show();
+        $response = $index->getRaw();
 
         $this->assertArrayHasKey('primaryKey', $response);
         $this->assertArrayHasKey('uid', $response);
@@ -60,10 +61,13 @@ final class IndexTest extends TestCase
     {
         $primaryKey = 'id';
 
-        $response = $this->index->update(['primaryKey' => $primaryKey]);
+        $index = $this->index->update(['primaryKey' => $primaryKey]);
 
-        $this->assertSame($response['primaryKey'], $primaryKey);
-        $this->assertSame('index', $response['uid']);
+        $this->assertInstanceOf(Indexes::class, $index);
+        $this->assertSame($index->getPrimaryKey(), $primaryKey);
+        $this->assertSame($index->getUid(), 'index');
+        $this->assertSame($this->index->getPrimaryKey(), $primaryKey);
+        $this->assertSame($this->index->getUid(), 'index');
     }
 
     public function testExceptionIsThrownWhenOverwritingPrimaryKey(): void
@@ -86,6 +90,37 @@ final class IndexTest extends TestCase
         $this->assertEquals(0, $stats['numberOfDocuments']);
         $this->assertArrayHasKey('isIndexing', $stats);
         $this->assertArrayHasKey('fieldsDistribution', $stats);
+    }
+
+    public function testFetchInfo(): void
+    {
+        $uid = 'indexA';
+        $this->client->createIndex(
+            $uid,
+            ['primaryKey' => 'objectID']
+        );
+
+        $index = $this->client->index($uid);
+        $this->assertInstanceOf(Indexes::class, $index);
+        $this->assertNull($index->getPrimaryKey());
+
+        $index = $index->fetchInfo();
+        $this->assertInstanceOf(Indexes::class, $index);
+        $this->assertSame('objectID', $index->getPrimaryKey());
+    }
+
+    public function testGetAndFetchPrimaryKey(): void
+    {
+        $uid = 'indexA';
+        $this->client->createIndex(
+            $uid,
+            ['primaryKey' => 'objectID']
+        );
+
+        $index = $this->client->index($uid);
+        $this->assertNull($index->getPrimaryKey());
+        $this->assertSame('objectID', $index->fetchPrimaryKey());
+        $this->assertSame('objectID', $index->getPrimaryKey());
     }
 
     public function testWaitForPendingUpdateDefault(): void
@@ -141,38 +176,6 @@ final class IndexTest extends TestCase
         $this->index->waitForPendingUpdate($res['updateId'], 0, 20);
     }
 
-    public function testUpdateIndex(): void
-    {
-        $this->client->createIndex('indexA');
-
-        $response = $this->client->updateIndex('indexA', ['primaryKey' => 'id']);
-
-        $this->assertSame($response['primaryKey'], 'id');
-        $this->assertSame($response['uid'], 'indexA');
-    }
-
-    public function testExceptionIsThrownWhenOverwritingPrimaryKeyUsingUpdateIndex(): void
-    {
-        $this->client->createIndex(
-            'indexB',
-            ['primaryKey' => 'objectId']
-        );
-
-        $this->expectException(HTTPRequestException::class);
-
-        $this->client->updateIndex('indexB', ['primaryKey' => 'objectID']);
-    }
-
-    public function testExceptionIsThrownWhenUpdateIndexUseANoneExistingIndex(): void
-    {
-        $this->expectException(HTTPRequestException::class);
-
-        $this->client->updateIndex(
-            'IndexNotExist',
-            ['primaryKey' => 'objectId']
-        );
-    }
-
     public function testDeleteIndexes(): void
     {
         $this->index = $this->client->createIndex('indexA');
@@ -191,7 +194,7 @@ final class IndexTest extends TestCase
 
         $this->expectException(HTTPRequestException::class);
 
-        $this->index->show();
+        $this->index->fetchInfo();
     }
 
     public function testExceptionIsThrownIfNoIndexWhenUpdating(): void

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -27,7 +27,7 @@ final class KeysAndPermissionsTest extends TestCase
         $this->client->createIndex('index');
 
         $newClient = new Client(self::HOST, $this->getKeys()['public']);
-        $response = $newClient->getIndex('index')->search('test');
+        $response = $newClient->index('index')->search('test');
         $this->assertArrayHasKey('hits', $response->toArray());
     }
 
@@ -35,7 +35,7 @@ final class KeysAndPermissionsTest extends TestCase
     {
         $this->client->createIndex('index');
         $newClient = new Client(self::HOST, $this->getKeys()['private']);
-        $response = $newClient->getIndex('index')->getSettings();
+        $response = $newClient->index('index')->getSettings();
 
         $this->assertEquals(['*'], $response['searchableAttributes']);
     }
@@ -45,19 +45,19 @@ final class KeysAndPermissionsTest extends TestCase
         $newClient = new Client(self::HOST);
 
         $this->expectException(HTTPRequestException::class);
-        $newClient->getIndex('index')->search('test');
+        $newClient->index('index')->search('test');
     }
 
     public function testExceptionIfBadKeyProvidedToGetSettings(): void
     {
         $this->client->createIndex('index');
-        $response = $this->client->getIndex('index')->getSettings();
+        $response = $this->client->index('index')->getSettings();
         $this->assertEquals(['*'], $response['searchableAttributes']);
 
         $newClient = new Client(self::HOST, 'bad-key');
 
         $this->expectException(HTTPRequestException::class);
-        $newClient->getIndex('index')->getSettings();
+        $newClient->index('index')->getSettings();
     }
 
     public function testExceptionIfBadKeyProvidedToGetKeys(): void

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -260,8 +260,8 @@ final class SearchTest extends TestCase
             'facetFilters' => [['genre:fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -284,8 +284,8 @@ final class SearchTest extends TestCase
             'facetFilters' => ['genre:fantasy', ['genre:fantasy', 'genre:fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -309,8 +309,8 @@ final class SearchTest extends TestCase
             'attributesToRetrieve' => ['id', 'title'],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
         $this->assertSame(4, $response->getHit(0)['id']);
         $this->assertArrayHasKey('id', $response->getHit(0));
         $this->assertArrayHasKey('title', $response->getHit(0));


### PR DESCRIPTION
Related to https://github.com/meilisearch/integration-guides/issues/48

Changes:
- New method `$client->index($uid)`: replaces `$client->getIndex($uid)`. Does not do any HTTP call but only returns an `Index` instance.
- New attribute in the `Index` class: `primaryKey`
- New method `$index->fetchRawInfo()`: returns an array of index
- New method `$index->fetchInfo()`: returns an `Index` instance

Breaking changes:
- `$client->getIndex($uid)` now does an HTTP call. Use `$client->index($uid)` instead.
- `$client->updateIndex` returns an `Index` instance.
- `$index->getPrimaryKey()` does not do any HTTP call, but only return the `primaryKey` attribute. Use `$index->fetchPrimaryKey()` if you want the same behavior as the old `$index->getPrimaryKey()`
- `$index->show()` is removed and replaced by `$index->fetchInfo()` (returns an instance) and `$index->fetchRawInfo()` (returns an array)
- `$client->showIndex($uid)` is removed. Use `$client->getIndex($uid)` (returns an instance) or `$client->index($uid)->fetchRawInfo()` (returns an array) instead.