### PR TITLE
Improve the $options parameter in search() method

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -46,10 +46,14 @@ delete_one_document_1: |-
 delete_documents_1: |-
   $client->index('movies')->deleteDocuments([23488, 153738, 437035, 363869]);
 search_1: |-
-  $searchResults = $client->index('movies')->search('american ninja')
-  $searchResults->getHits();
-  $searchResults->getFacetsDistribution();
-  $searchResults->getRaw(); // The JSON response returned by MeiliSearch
+  // Do a search
+  $searchResults = $client->index('movies')->search('american ninja');
+
+  // Get results in an Array using a getter
+  $hits = $searchResults->getHits();
+
+  // Get the decoded response of MeiliSearch, see response below
+  $response = $searchResults->getRaw();
 get_update_1: |-
   $client->index('movies')->getUpdateStatus(1);
 get_all_updates_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -46,7 +46,10 @@ delete_one_document_1: |-
 delete_documents_1: |-
   $client->index('movies')->deleteDocuments([23488, 153738, 437035, 363869]);
 search_1: |-
-  $client->index('movies')->search('american ninja');
+  $searchResults = $client->index('movies')->search('american ninja')
+  $searchResults->getHits();
+  $searchResults->getFacetsDistribution();
+  $searchResults->getRaw(); // The JSON response returned by MeiliSearch
 get_update_1: |-
   $client->index('movies')->getUpdateStatus(1);
 get_all_updates_1: |-

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ With the `updateId`, you can check the status (`enqueued`, `processed` or `faile
 
 ```php
 // MeiliSearch is typo-tolerant:
-print_r($index->search('harry pottre'));
+print_r($index->search('harry pottre')->getHits());
 ```
 
 Output:
@@ -118,20 +118,11 @@ Output:
 ```php
 Array
 (
-    [hits] => Array
+    [0] => Array
         (
-            [0] => Array
-                (
-                    [id] => 4
-                    [title] => Harry Potter and the Half-Blood Prince
-                )
-
+            [id] => 4
+            [title] => Harry Potter and the Half-Blood Prince
         )
-
-    [offset] => 0
-    [limit] => 20
-    [processingTimeMs] => 1
-    [query] => harry pottre
 )
 ```
 
@@ -139,14 +130,19 @@ Array
 
 All the supported options are described in the [search parameters](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html) section of the documentation.
 
+💡 **More about the `search()` method in [the Wiki](https://github.com/meilisearch/meilisearch-php/wiki/Search).**
+
 ```php
-$index->search('prince',
+$index->search(
+    'prince',
     [
         'attributesToHighlight' => ['*'],
         'filters' => 'book_id > 10'
     ]
-);
+)->getRaw();
 ```
+
+JSON output:
 
 ```json
 {
@@ -161,15 +157,6 @@ $index->search('prince',
     "processingTimeMs": 10,
     "query": "prince"
 }
-```
-
-With `filters`, both single and double quotes are supported.
-```php
-// Enclosing with double quotes
-$index->search('prince', ['filters' => "title = 'Le Petit Prince' OR author = 'J. R. R. Tolkien'"]);
-
-// Enclosing with single quotes
-$index->search('hobbit', ['filters' => 'title = "The Hitchhiker\'s Guide to the Galaxy" OR author = "J. R. R. Tolkien"']);
 ```
 
 ## 🤖 Compatibility with MeiliSearch

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ With the `updateId`, you can check the status (`enqueued`, `processed` or `faile
 
 ```php
 // MeiliSearch is typo-tolerant:
-print_r($index->search('harry pottre')->getHits());
+$hits = $index->search('harry pottre')->getHits();
+print_r($hits);
 ```
 
 Output:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $index->search(
         'attributesToHighlight' => ['*'],
         'filters' => 'book_id > 10'
     ]
-)->getRaw();
+)->getRaw(); // Return in Array format
 ```
 
 JSON output:

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -152,7 +152,7 @@ class Indexes extends Endpoint
         }
 
         $searchResult = new SearchResult($result);
-        $searchResult = $searchResult->applyOptions($options);
+        $searchResult->applyOptions($options);
 
         return $searchResult;
     }

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -140,29 +140,39 @@ class Indexes extends Endpoint
 
     /**
      * @param string $query
+     * @param array $searchParams
+     * @param array $options
      *
      * @return SearchResult|array
      */
     public function search($query, array $searchParams = [], array $options = [])
     {
-        $parameters = array_merge(
-            ['q' => $query],
-            $searchParams
-        );
-
-        $result = $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
+        $result = $this->rawSearch($query, $searchParams);
 
         if (\array_key_exists('raw', $options) && $options['raw']) {
             return $result;
         }
 
         $searchResult = new SearchResult($result);
-
-        if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
-            $searchResult = $searchResult->filter($options['transformHits']);
-        }
+        $searchResult = $searchResult->applyOptions($options);
 
         return $searchResult;
+    }
+
+    /**
+     * @param string $query
+     * @param array $searchParams
+     *
+     * @return array
+     */
+    public function rawSearch($query, array $searchParams = [])
+    {
+        $parameters = array_merge(
+            ['q' => $query],
+            $searchParams
+        );
+
+        return $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
     }
 
     // Stats

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -140,8 +140,6 @@ class Indexes extends Endpoint
 
     /**
      * @param string $query
-     * @param array $searchParams
-     * @param array $options
      *
      * @return SearchResult|array
      */
@@ -161,7 +159,6 @@ class Indexes extends Endpoint
 
     /**
      * @param string $query
-     * @param array $searchParams
      *
      * @return array
      */

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -28,8 +28,16 @@ class SearchResult implements Countable, IteratorAggregate
 
     /**
      * @var int
+     * `nbHits` is the attributes returned by the MeiliSearch server
+     * and its value will not be modified by the methods in this class.
+     * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
      */
     private $nbHits;
+
+    /**
+     * @var int
+     */
+    private $hitsCount;
 
     /**
      * @var bool
@@ -67,6 +75,7 @@ class SearchResult implements Countable, IteratorAggregate
         $this->offset = $body['offset'];
         $this->limit = $body['limit'];
         $this->nbHits = $body['nbHits'];
+        $this->hitsCount = \count($body['hits']);
         $this->exhaustiveNbHits = $body['exhaustiveNbHits'] ?? false;
         $this->processingTimeMs = $body['processingTimeMs'];
         $this->query = $body['query'];
@@ -84,14 +93,48 @@ class SearchResult implements Countable, IteratorAggregate
      *
      * @return SearchResult
      */
-    public function filter(callable $callback): self
+    public function applyOptions($options): self
     {
-        $results = array_filter($this->hits, $callback, ARRAY_FILTER_USE_BOTH);
-
-        $this->hits = $results;
-        $this->nbHits = \count($results);
+        if (\array_key_exists('removeZeroFacets', $options) && $options['removeZeroFacets'] === true) {
+            $this->removeZeroFacets();
+        }
+        if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
+            $this->transformHits($options['transformHits']);
+        }
+        if (\array_key_exists('transformFacetsDistribution', $options) && \is_callable($options['transformFacetsDistribution'])) {
+            $this->transformFacetsDistribution($options['transformFacetsDistribution']);
+        }
 
         return $this;
+    }
+
+    public function transformHits(callable $callback): self
+    {
+        $this->hits = $callback($this->hits);
+        $this->hitsCount = \count($this->hits);
+        return $this;
+    }
+
+    public function transformFacetsDistribution(callable $callback): self
+    {
+        $this->facetsDistribution = $callback($this->facetsDistribution);
+        return $this;
+    }
+
+    public function removeZeroFacets(): self
+    {
+        $filterAllFacets = function (array $facets) {
+            $filterOneFacet = function (array $facet) {
+                return array_filter(
+                    $facet,
+                    function($v, $k) { return $v !== 0; },
+                    ARRAY_FILTER_USE_BOTH
+                );
+            };
+            return array_map($filterOneFacet, $facets);
+        };
+
+        return $this->transformFacetsDistribution($filterAllFacets);
     }
 
     public function getHit(int $key, $default = null)
@@ -119,12 +162,17 @@ class SearchResult implements Countable, IteratorAggregate
 
     public function getHitsCount(): int
     {
-        return $this->nbHits;
+        return $this->hitsCount;
+    }
+
+    public function count(): int
+    {
+        return $this->hitsCount;
     }
 
     public function getNbHits(): int
     {
-        return \count($this->hits);
+        return $this->nbHits;
     }
 
     public function getExhaustiveNbHits(): bool
@@ -160,7 +208,7 @@ class SearchResult implements Countable, IteratorAggregate
      *
      * @return array<string, mixed>
      */
-    public function fetchRawInfo(): array
+    public function getRaw(): array
     {
         return $this->raw;
     }
@@ -172,7 +220,7 @@ class SearchResult implements Countable, IteratorAggregate
             'offset' => $this->offset,
             'limit' => $this->limit,
             'nbHits' => $this->nbHits,
-            'hitsCount' => \count($this->hits),
+            'hitsCount' => $this->hitsCount,
             'exhaustiveNbHits' => $this->exhaustiveNbHits,
             'processingTimeMs' => $this->processingTimeMs,
             'query' => $this->query,
@@ -181,7 +229,7 @@ class SearchResult implements Countable, IteratorAggregate
         ];
     }
 
-    public function toJson(): string
+    public function toJSON(): string
     {
         return \json_encode($this->toArray(), JSON_PRETTY_PRINT);
     }
@@ -191,8 +239,4 @@ class SearchResult implements Countable, IteratorAggregate
         return new ArrayIterator($this->hits);
     }
 
-    public function count(): int
-    {
-        return \count($this->hits);
-    }
 }

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -86,11 +86,14 @@ class SearchResult implements Countable, IteratorAggregate
     }
 
     /**
-     * Return a new {@see SearchResult} instance with the hits filtered using `array_filter($this->hits, $callback, ARRAY_FILTER_USE_BOTH)`.
+     * Return a new {@see SearchResult} instance.
      *
-     * The $callback receives both the current hit and the key, in that order.
+     * The $options parameter is an array, and the following keys are accepted:
+     * - removeZeroFacets (boolean)
+     * - transformFacetsDistribution (callable)
+     * - transformHits (callable)
      *
-     * The method DOES not trigger a new search.
+     * The method does NOT trigger a new search.
      *
      * @return SearchResult
      */

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -27,10 +27,11 @@ class SearchResult implements Countable, IteratorAggregate
     private $limit;
 
     /**
-     * @var int
      * `nbHits` is the attributes returned by the MeiliSearch server
      * and its value will not be modified by the methods in this class.
      * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
+     *
+     * @var int
      */
     private $nbHits;
 
@@ -95,7 +96,7 @@ class SearchResult implements Countable, IteratorAggregate
      */
     public function applyOptions($options): self
     {
-        if (\array_key_exists('removeZeroFacets', $options) && $options['removeZeroFacets'] === true) {
+        if (\array_key_exists('removeZeroFacets', $options) && true === $options['removeZeroFacets']) {
             $this->removeZeroFacets();
         }
         if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
@@ -112,12 +113,14 @@ class SearchResult implements Countable, IteratorAggregate
     {
         $this->hits = $callback($this->hits);
         $this->hitsCount = \count($this->hits);
+
         return $this;
     }
 
     public function transformFacetsDistribution(callable $callback): self
     {
         $this->facetsDistribution = $callback($this->facetsDistribution);
+
         return $this;
     }
 
@@ -127,10 +130,11 @@ class SearchResult implements Countable, IteratorAggregate
             $filterOneFacet = function (array $facet) {
                 return array_filter(
                     $facet,
-                    function($v, $k) { return $v !== 0; },
+                    function ($v, $k) { return 0 !== $v; },
                     ARRAY_FILTER_USE_BOTH
                 );
             };
+
             return array_map($filterOneFacet, $facets);
         };
 
@@ -238,5 +242,4 @@ class SearchResult implements Countable, IteratorAggregate
     {
         return new ArrayIterator($this->hits);
     }
-
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -367,7 +367,7 @@ final class SearchTest extends TestCase
             );
         };
 
-        $response = $this->index->search('prince', [], $options = ['transformHits' => $keepLePetitPrinceFunc ]);
+        $response = $this->index->search('prince', [], $options = ['transformHits' => $keepLePetitPrinceFunc]);
 
         $this->assertArrayHasKey('hits', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
@@ -386,6 +386,7 @@ final class SearchTest extends TestCase
             return array_map(
                 function (array $hit) {
                     $hit['title'] = strtoupper($hit['title']);
+
                     return $hit;
                 },
                 $hits
@@ -416,7 +417,7 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search('prince', [], [
             'raw' => true,
-            'transformHits' => $keepLePetitPrinceFunc
+            'transformHits' => $keepLePetitPrinceFunc,
         ]);
 
         $this->assertArrayHasKey('hits', $response);
@@ -500,10 +501,11 @@ final class SearchTest extends TestCase
             $filterOneFacet = function (array $facet) {
                 return array_filter(
                     $facet,
-                    function($v, $k) { return $v > 1; },
+                    function ($v, $k) { return $v > 1; },
                     ARRAY_FILTER_USE_BOTH
                 );
             };
+
             return array_map($filterOneFacet, $facets);
         };
 
@@ -538,8 +540,10 @@ final class SearchTest extends TestCase
                 foreach ($facet as $k => $v) {
                     $result[strtoupper($k)] = $v;
                 }
+
                 return $result;
             };
+
             return array_map($changeOneFacet, $facets);
         };
 
@@ -571,8 +575,10 @@ final class SearchTest extends TestCase
         $facetsToUpperFunc = function (array $facets) {
             $sortOneFacet = function (array $facet) {
                 ksort($facet);
+
                 return $facet;
             };
+
             return array_map($sortOneFacet, $facets);
         };
 
@@ -596,5 +602,4 @@ final class SearchTest extends TestCase
         $this->assertEquals(2, $response->getFacetsDistribution()['genre']['fantasy']);
         $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
     }
-
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -260,8 +260,8 @@ final class SearchTest extends TestCase
             'facetFilters' => [['genre:fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -284,8 +284,8 @@ final class SearchTest extends TestCase
             'facetFilters' => ['genre:fantasy', ['genre:fantasy', 'genre:fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -309,8 +309,8 @@ final class SearchTest extends TestCase
             'attributesToRetrieve' => ['id', 'title'],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->fetchRawInfo());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->fetchRawInfo());
+        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
+        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
         $this->assertArrayHasKey('id', $response->getHit(0));
         $this->assertArrayHasKey('title', $response->getHit(0));
@@ -331,30 +331,92 @@ final class SearchTest extends TestCase
         $this->assertArrayNotHasKey('comment', $response['hits'][0]);
     }
 
-    public function testBasicSearchCanBeFiltered(): void
+    public function testBasicSerachWithRawSearch(): void
     {
-        $response = $this->index->search('prince', [], [
-            'transformHits' => function (array $hit, int $_): bool {
-                return 'AMERICAN SNIPER' === strtoupper($hit['title']);
-            },
-        ]);
+        $response = $this->index->rawSearch('prince');
+
+        $this->assertArrayHasKey('hits', $response);
+        $this->assertArrayHasKey('offset', $response);
+        $this->assertArrayHasKey('limit', $response);
+        $this->assertArrayHasKey('processingTimeMs', $response);
+        $this->assertArrayHasKey('query', $response);
+        $this->assertSame(2, $response['nbHits']);
+        $this->assertCount(2, $response['hits']);
+        $this->assertEquals('Le Petit Prince', $response['hits'][0]['title']);
+    }
+
+    public function testBasicSearchWithRawOption(): void
+    {
+        $response = $this->index->search('prince', [], ['raw' => true]);
+
+        $this->assertArrayHasKey('hits', $response);
+        $this->assertArrayHasKey('offset', $response);
+        $this->assertArrayHasKey('limit', $response);
+        $this->assertArrayHasKey('processingTimeMs', $response);
+        $this->assertArrayHasKey('query', $response);
+        $this->assertSame(2, $response['nbHits']);
+        $this->assertCount(2, $response['hits']);
+    }
+
+    public function testBasicSearchWithTransformHitsOptionToFilter(): void
+    {
+        $keepLePetitPrinceFunc = function (array $hits) {
+            return array_filter(
+                $hits,
+                function (array $hit) { return 'Le Petit Prince' === $hit['title']; }
+            );
+        };
+
+        $response = $this->index->search('prince', [], $options = ['transformHits' => $keepLePetitPrinceFunc ]);
 
         $this->assertArrayHasKey('hits', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(0, $response->getNbHits());
-        $this->assertCount(0, $response->getHits());
+        $this->assertSame('Le Petit Prince', $response->getHit(0)['title']);
+        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(1, $response->getHitsCount());
+        $this->assertSame(1, $response->count());
+    }
+
+    public function testBasicSearchWithTransformHitsOptionToMap(): void
+    {
+        $titlesToUpperCaseFunc = function (array $hits) {
+            return array_map(
+                function (array $hit) {
+                    $hit['title'] = strtoupper($hit['title']);
+                    return $hit;
+                },
+                $hits
+            );
+        };
+
+        $response = $this->index->search('prince', [], ['transformHits' => $titlesToUpperCaseFunc]);
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(2, $response->getHitsCount());
+        $this->assertCount(2, $response->getHits());
+        $this->assertSame('LE PETIT PRINCE', $response->getHits()[0]['title']);
     }
 
     public function testBasicSearchCannotBeFilteredOnRawResult(): void
     {
+        $keepLePetitPrinceFunc = function (array $hits) {
+            return array_filter(
+                $hits,
+                function (array $hit) { return 'Le Petit Prince' === $hit['title']; }
+            );
+        };
+
         $response = $this->index->search('prince', [], [
             'raw' => true,
-            'transformHits' => function (array $hit, int $_): bool {
-                return 'AMERICAN SNIPER' === strtoupper($hit['title']);
-            },
+            'transformHits' => $keepLePetitPrinceFunc
         ]);
 
         $this->assertArrayHasKey('hits', $response);
@@ -363,5 +425,176 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
         $this->assertSame(2, $response['nbHits']);
+        $this->assertCount(2, $response['hits']);
     }
+
+    public function testBasicSearchCanBeFilteredOnRawResultIfUsingToArray(): void
+    {
+        $keepLePetitPrinceFunc = function (array $hits) {
+            return array_filter(
+                $hits,
+                function (array $hit) { return 'Le Petit Prince' === $hit['title']; }
+            );
+        };
+
+        $response = $this->index->search('prince', [], ['transformHits' => $keepLePetitPrinceFunc])->toArray();
+
+        $this->assertArrayHasKey('hits', $response);
+        $this->assertArrayHasKey('offset', $response);
+        $this->assertArrayHasKey('limit', $response);
+        $this->assertArrayHasKey('processingTimeMs', $response);
+        $this->assertArrayHasKey('query', $response);
+        $this->assertSame(2, $response['nbHits']);
+        $this->assertCount(1, $response['hits']);
+        $this->assertEquals('Le Petit Prince', $response['hits'][0]['title']);
+    }
+
+    public function testBasicSearchWithRemoveZeroFacetsOption(): void
+    {
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $response = $this->index->search(
+            'prince',
+            ['facetsDistribution' => ['genre']],
+            ['removeZeroFacets' => true]
+        );
+
+        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['fantasy']);
+        $this->assertCount(3, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+    }
+
+    public function testBasicSearchWithRemoveZeroFacetsOptionAndMultipleFacets(): void
+    {
+        $response = $this->index->addDocuments([['id' => 32, 'title' => 'The Witcher', 'genre' => 'adventure', 'adaptation' => 'video game']]);
+        $this->index->waitForPendingUpdate($response['updateId']);
+        $response = $this->index->updateAttributesForFaceting(['genre', 'adaptation']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $response = $this->index->search(
+            'prince',
+            ['facetsDistribution' => ['genre', 'adaptation']],
+            ['removeZeroFacets' => true]
+        );
+
+        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['fantasy']);
+        $this->assertEquals([], $response->getFacetsDistribution()['adaptation']);
+        $this->assertCount(1, $response->getRaw()['facetsDistribution']['adaptation']);
+        $this->assertCount(3, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+    }
+
+    public function testBasicSearchWithTransformFacetsDritributionOptionToFilter(): void
+    {
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $filterAllFacets = function (array $facets) {
+            $filterOneFacet = function (array $facet) {
+                return array_filter(
+                    $facet,
+                    function($v, $k) { return $v > 1; },
+                    ARRAY_FILTER_USE_BOTH
+                );
+            };
+            return array_map($filterOneFacet, $facets);
+        };
+
+        $response = $this->index->search(
+            null,
+            ['facetsDistribution' => ['genre']],
+            ['transformFacetsDistribution' => $filterAllFacets]
+        );
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertCount(3, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['romance']);
+        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['fantasy']);
+    }
+
+    public function testBasicSearchWithTransformFacetsDritributionOptionToMap(): void
+    {
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $facetsToUpperFunc = function (array $facets) {
+            $changeOneFacet = function (array $facet) {
+                $result = [];
+                foreach ($facet as $k => $v) {
+                    $result[strtoupper($k)] = $v;
+                }
+                return $result;
+            };
+            return array_map($changeOneFacet, $facets);
+        };
+
+        $response = $this->index->search(
+            null,
+            ['facetsDistribution' => ['genre']],
+            ['transformFacetsDistribution' => $facetsToUpperFunc]
+        );
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertCount(3, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['ROMANCE']);
+        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['FANTASY']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['ADVENTURE']);
+    }
+
+    public function testBasicSearchWithTransformFacetsDritributionOptionToOder(): void
+    {
+        $response = $this->index->updateAttributesForFaceting(['genre']);
+        $this->index->waitForPendingUpdate($response['updateId']);
+
+        $facetsToUpperFunc = function (array $facets) {
+            $sortOneFacet = function (array $facet) {
+                ksort($facet);
+                return $facet;
+            };
+            return array_map($sortOneFacet, $facets);
+        };
+
+        $response = $this->index->search(
+            null,
+            ['facetsDistribution' => ['genre']],
+            ['transformFacetsDistribution' => $facetsToUpperFunc]
+        );
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertEquals('adventure', array_key_first($response->getFacetsDistribution()['genre']));
+        $this->assertEquals('romance', array_key_last($response->getFacetsDistribution()['genre']));
+        $this->assertCount(3, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['romance']);
+        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['fantasy']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
+    }
+
 }

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -35,7 +35,7 @@ final class SearchResultTest extends TestCase
             'nbHits' => 976,
             'exhaustiveNbHits' => false,
             'processingTimeMs' => 35,
-            'query' => 'american'
+            'query' => 'american',
         ];
         $this->basicResult = new SearchResult($this->basicServerResponse);
         $this->serverResponseWithFacets = [
@@ -44,14 +44,14 @@ final class SearchResultTest extends TestCase
                     'genre' => 'adventure',
                     'id' => 456,
                     'title' => 'Le Petit Prince',
-                    'author' => 'Antoine de Saint-Exupéry'
+                    'author' => 'Antoine de Saint-Exupéry',
                 ],
                 [
                     'genre' => 'fantasy',
                     'id' => 4,
                     'title' => 'Harry Potter and the Half-Blood Prince',
-                    'author' => 'J. K. Rowling'
-                ]
+                    'author' => 'J. K. Rowling',
+                ],
             ],
             'offset' => 0,
             'limit' => 20,
@@ -63,10 +63,10 @@ final class SearchResultTest extends TestCase
                 'genre' => [
                     'fantasy' => 1,
                     'romance' => 0,
-                    'adventure' => 1
-                ]
+                    'adventure' => 1,
+                ],
             ],
-            'exhaustiveFacetsCount' => true
+            'exhaustiveFacetsCount' => true,
         ];
         $this->resultWithFacets = new SearchResult($this->serverResponseWithFacets);
     }
@@ -190,8 +190,10 @@ final class SearchResultTest extends TestCase
                 foreach ($facet as $k => $v) {
                     $result[strtoupper($k)] = $v;
                 }
+
                 return $result;
             };
+
             return array_map($changeOneFacet, $facets);
         };
 

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -10,11 +10,13 @@ use function strtoupper;
 
 final class SearchResultTest extends TestCase
 {
-    public function testResultCanBeBuilt(): void
+    protected function setUp(): void
     {
-        $result = new SearchResult([
+        parent::setUp();
+        $this->basicServerResponse = [
             'hits' => [
                 [
+                    'id' => '1',
                     'title' => 'American Pie 2',
                     'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
                     'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
@@ -33,126 +35,191 @@ final class SearchResultTest extends TestCase
             'nbHits' => 976,
             'exhaustiveNbHits' => false,
             'processingTimeMs' => 35,
-            'query' => 'american',
-        ]);
+            'query' => 'american'
+        ];
+        $this->basicResult = new SearchResult($this->basicServerResponse);
+        $this->serverResponseWithFacets = [
+            'hits' => [
+                [
+                    'genre' => 'adventure',
+                    'id' => 456,
+                    'title' => 'Le Petit Prince',
+                    'author' => 'Antoine de Saint-Exupéry'
+                ],
+                [
+                    'genre' => 'fantasy',
+                    'id' => 4,
+                    'title' => 'Harry Potter and the Half-Blood Prince',
+                    'author' => 'J. K. Rowling'
+                ]
+            ],
+            'offset' => 0,
+            'limit' => 20,
+            'nbHits' => 2,
+            'exhaustiveNbHits' => false,
+            'processingTimeMs' => 1,
+            'query' => 'prinec',
+            'facetsDistribution' => [
+                'genre' => [
+                    'fantasy' => 1,
+                    'romance' => 0,
+                    'adventure' => 1
+                ]
+            ],
+            'exhaustiveFacetsCount' => true
+        ];
+        $this->resultWithFacets = new SearchResult($this->serverResponseWithFacets);
+    }
 
-        static::assertSame(2, $result->count());
-        static::assertNotEmpty($result->getHits());
+    public function testResultCanBeBuilt(): void
+    {
+        $this->assertSame(2, $this->basicResult->count());
+        $this->assertNotEmpty($this->basicResult->getHits());
 
-        static::assertEquals([
+        $this->assertEquals([
+            'id' => '1',
             'title' => 'American Pie 2',
             'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
             'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
             'release_date' => 997405200,
-        ], $result->getHit(0));
-        static::assertEquals([
+        ], $this->basicResult->getHit(0));
+        $this->assertEquals([
             'id' => '190859',
             'title' => 'American Sniper',
             'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
             'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
             'release_date' => 1418256000,
-        ], $result->getHit(1));
-        static::assertNull($result->getHit(2));
-        static::assertSame(0, $result->getOffset());
-        static::assertSame(20, $result->getLimit());
-        static::assertSame(2, $result->getNbHits());
-        static::assertSame(976, $result->getHitsCount());
-        static::assertFalse($result->getExhaustiveNbHits());
-        static::assertSame(35, $result->getProcessingTimeMs());
-        static::assertSame('american', $result->getQuery());
-        static::assertNull($result->getExhaustiveFacetsCount());
-        static::assertEmpty($result->getFacetsDistribution());
-        static::assertSame(2, $result->getIterator()->count());
+        ], $this->basicResult->getHit(1));
+        $this->assertNull($this->basicResult->getHit(2));
+        $this->assertSame(0, $this->basicResult->getOffset());
+        $this->assertSame(20, $this->basicResult->getLimit());
+        $this->assertSame(2, $this->basicResult->getHitsCount());
+        $this->assertSame(976, $this->basicResult->getNbHits());
+        $this->assertFalse($this->basicResult->getExhaustiveNbHits());
+        $this->assertSame(35, $this->basicResult->getProcessingTimeMs());
+        $this->assertSame('american', $this->basicResult->getQuery());
+        $this->assertNull($this->basicResult->getExhaustiveFacetsCount());
+        $this->assertEmpty($this->basicResult->getFacetsDistribution());
+        $this->assertSame(2, $this->basicResult->getIterator()->count());
 
-        static::assertArrayHasKey('hits', $result->toArray());
-        static::assertArrayHasKey('offset', $result->toArray());
-        static::assertArrayHasKey('limit', $result->toArray());
-        static::assertArrayHasKey('nbHits', $result->toArray());
-        static::assertArrayHasKey('exhaustiveNbHits', $result->toArray());
-        static::assertArrayHasKey('processingTimeMs', $result->toArray());
-        static::assertArrayHasKey('query', $result->toArray());
-        static::assertArrayHasKey('exhaustiveFacetsCount', $result->toArray());
-        static::assertArrayHasKey('facetsDistribution', $result->toArray());
+        $this->assertArrayHasKey('hits', $this->basicResult->toArray());
+        $this->assertArrayHasKey('offset', $this->basicResult->toArray());
+        $this->assertArrayHasKey('limit', $this->basicResult->toArray());
+        $this->assertArrayHasKey('nbHits', $this->basicResult->toArray());
+        $this->assertArrayHasKey('hitsCount', $this->basicResult->toArray());
+        $this->assertArrayHasKey('exhaustiveNbHits', $this->basicResult->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $this->basicResult->toArray());
+        $this->assertArrayHasKey('query', $this->basicResult->toArray());
+        $this->assertArrayHasKey('exhaustiveFacetsCount', $this->basicResult->toArray());
+        $this->assertArrayHasKey('facetsDistribution', $this->basicResult->toArray());
     }
 
     public function testSearchResultCanBeFiltered(): void
     {
-        $result = new SearchResult([
-            'hits' => [
-                [
-                    'title' => 'American Pie 2',
-                    'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
-                    'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
-                    'release_date' => 997405200,
-                ],
-                [
-                    'id' => '190859',
-                    'title' => 'American Sniper',
-                    'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
-                    'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
-                    'release_date' => 1418256000,
-                ],
-            ],
-            'offset' => 0,
-            'limit' => 20,
-            'nbHits' => 976,
-            'exhaustiveNbHits' => false,
-            'processingTimeMs' => 35,
-            'query' => 'american',
-        ]);
+        $keepAmericanSniperFunc = function (array $hits) {
+            return array_filter(
+                $hits,
+                function (array $hit) { return 'American Sniper' === $hit['title']; }
+            );
+        };
 
-        $filteredResults = $result->filter(function (array $hit, int $_): bool {
-            return 'AMERICAN SNIPER' === strtoupper($hit['title']);
-        });
+        $options = ['transformHits' => $keepAmericanSniperFunc];
 
-        static::assertSame(1, $filteredResults->count());
-        static::assertNull($result->getHit(0));
-        static::assertEquals([
+        $filteredResults = $this->basicResult->applyOptions($options);
+
+        $this->assertSame(1, $filteredResults->count());
+        $this->assertSame(1, $filteredResults->getHitsCount());
+        $this->assertSame(976, $filteredResults->getNbHits());
+        $this->assertEquals([
             'id' => '190859',
             'title' => 'American Sniper',
             'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
             'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
             'release_date' => 1418256000,
-        ], $result->getHit(1));
+        ], $filteredResults->getHit(1)); // Not getHits(0) because array_filter() does not reorder the indexes after filtering.
     }
 
     public function testResultCanBeReturnedAsJson(): void
     {
-        $result = new SearchResult([
-            'hits' => [
-                [
-                    'title' => 'American Pie 2',
-                    'poster' => 'https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg',
-                    'overview' => 'The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...',
-                    'release_date' => 997405200,
-                ],
-                [
-                    'id' => '190859',
-                    'title' => 'American Sniper',
-                    'poster' => 'https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg',
-                    'overview' => 'U.S. Navy SEAL Chris Kyle takes his sole mission—protect his comrades—to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...',
-                    'release_date' => 1418256000,
-                ],
-            ],
-            'offset' => 0,
-            'limit' => 20,
-            'nbHits' => 976,
-            'exhaustiveNbHits' => false,
-            'processingTimeMs' => 35,
-            'query' => 'american',
-        ]);
+        $json = $this->basicResult->toJSON();
 
-        $json = $result->toJson();
+        $this->assertStringContainsString('hits', $json);
+        $this->assertStringContainsString('offset', $json);
+        $this->assertStringContainsString('limit', $json);
+        $this->assertStringContainsString('hitsCount', $json);
+        $this->assertStringContainsString('nbHits', $json);
+        $this->assertStringContainsString('exhaustiveNbHits', $json);
+        $this->assertStringContainsString('processingTimeMs', $json);
+        $this->assertStringContainsString('query', $json);
+        $this->assertStringContainsString('exhaustiveFacetsCount', $json);
+        $this->assertStringContainsString('facetsDistribution', $json);
+    }
 
-        static::assertStringContainsString('hits', $json);
-        static::assertStringContainsString('offset', $json);
-        static::assertStringContainsString('limit', $json);
-        static::assertStringContainsString('hitsCount', $json);
-        static::assertStringContainsString('nbHits', $json);
-        static::assertStringContainsString('exhaustiveNbHits', $json);
-        static::assertStringContainsString('processingTimeMs', $json);
-        static::assertStringContainsString('query', $json);
-        static::assertStringContainsString('exhaustiveFacetsCount', $json);
-        static::assertStringContainsString('facetsDistribution', $json);
+    public function testGetRaw(): void
+    {
+        $this->assertEquals($this->basicServerResponse, $this->basicResult->getRaw());
+    }
+
+    public function testTransformHitsMethod(): void
+    {
+        $keepAmericanSniperFunc = function (array $hits) {
+            return array_filter(
+                $hits,
+                function (array $hit) { return 'American Sniper' === $hit['title']; }
+            );
+        };
+
+        $response = $this->basicResult->transformHits($keepAmericanSniperFunc);
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame('American Sniper', $response->getHit(1)['title']); // Not getHits(0) because array_filter() does not reorder the indexes after filtering.
+        $this->assertSame(976, $response->getNbHits());
+        $this->assertSame(1, $response->getHitsCount());
+        $this->assertSame(1, $response->count());
+    }
+
+    public function testTransformFacetsDritributionMethod(): void
+    {
+        $facetsToUpperFunc = function (array $facets) {
+            $changeOneFacet = function (array $facet) {
+                $result = [];
+                foreach ($facet as $k => $v) {
+                    $result[strtoupper($k)] = $v;
+                }
+                return $result;
+            };
+            return array_map($changeOneFacet, $facets);
+        };
+
+        $response = $this->resultWithFacets->transformFacetsDistribution($facetsToUpperFunc);
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertCount(3, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(0, $response->getFacetsDistribution()['genre']['ROMANCE']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['FANTASY']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['ADVENTURE']);
+    }
+
+    public function testRemoveZeroFacetsMethod(): void
+    {
+        $response = $this->resultWithFacets->removeZeroFacets();
+
+        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['fantasy']);
+        $this->assertCount(3, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertEquals($response->getRaw()['hits'], $response->getHits());
+        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
     }
 }


### PR DESCRIPTION
- rename `toJson` into `toJSON`: same naming as Stripe and Twilio
- add `rawSearch()` method
- `transformHits` callback can take any callback to completely transform the hits
- Add `transformFacetsDistribution` option in `search()` method (type: callback)
- Add `removeZeroFacets` option in `search()` method (type: boolean)
- Add `transformHits()`, `transformFacetsDistribution()` and `removeZeroFacets()` methods.

### Usage

```php
$searchResult = $index->search('prince');
$searchResult->removeZeroFacets()

// OR

$searchResult = $index->search('prince', [], ['removeZeroFacets' => true]);
```

```php
$keepAmericanSniperFunc = function (array $hits) {
    return array_filter(
        $hits,
        function (array $hit) { return 'American Sniper' === $hit['title']; }
    );
};

$searchResult = $index->search('american');
$searchResult->transformHits($keepAmericanSniperFunc)

// OR

$response = $this->index->search('prince', [], $options = ['transformHits' => $keepAmericanSniperFunc]);
```
