### PR TITLE
Rename MeiliSearch\HTTPRequestException into MeiliSearch\ApiException

### DIFF
--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Delegates;
 
 use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 
 /**
  * @property Indexes index
@@ -54,13 +54,13 @@ trait HandlesIndex
     }
 
     /**
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     public function getOrCreateIndex(string $uid, array $options = []): Indexes
     {
         try {
             $index = $this->getIndex($uid, $options);
-        } catch (HTTPRequestException $e) {
+        } catch (ApiException $e) {
             if (\is_array($e->httpBody) && 'index_not_found' !== $e->httpBody['errorCode']) {
                 throw $e;
             }

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -9,7 +9,7 @@ use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Contracts\Http;
 use MeiliSearch\Endpoints\Delegates\HandlesDocuments;
 use MeiliSearch\Endpoints\Delegates\HandlesSettings;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\TimeOutException;
 use MeiliSearch\Search\SearchResult;
 
@@ -36,7 +36,7 @@ class Indexes extends Endpoint
     /**
      * @return $this
      *
-     * @throws Exception|HTTPRequestException
+     * @throws Exception|ApiException
      */
     public function create(string $uid, array $options = []): self
     {

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -6,7 +6,7 @@ namespace MeiliSearch\Exceptions;
 
 use Exception;
 
-class HTTPRequestException extends Exception
+class ApiException extends Exception
 {
     public $httpStatus = 0;
     public $httpMessage = null;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -7,7 +7,7 @@ namespace MeiliSearch\Http;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use MeiliSearch\Contracts\Http;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -69,7 +69,7 @@ class Client implements Http
      * @return mixed
      *
      * @throws ClientExceptionInterface
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     public function get($path, $query = [])
     {
@@ -89,7 +89,7 @@ class Client implements Http
      * @return mixed
      *
      * @throws ClientExceptionInterface
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     public function post($path, $body = null, $query = [])
     {
@@ -119,7 +119,7 @@ class Client implements Http
      * @return mixed
      *
      * @throws ClientExceptionInterface
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     public function patch($path, $body = null, $query = [])
     {
@@ -138,7 +138,7 @@ class Client implements Http
      * @return mixed
      *
      * @throws ClientExceptionInterface
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     public function delete($path, $query = [])
     {
@@ -154,7 +154,7 @@ class Client implements Http
      * @return mixed
      *
      * @throws ClientExceptionInterface
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     private function execute(RequestInterface $request)
     {
@@ -173,13 +173,13 @@ class Client implements Http
     /**
      * @return mixed
      *
-     * @throws HTTPRequestException
+     * @throws ApiException
      */
     private function parseResponse(ResponseInterface $response)
     {
         if ($response->getStatusCode() >= 300) {
             $body = json_decode($response->getBody()->getContents(), true) ?? $response->getReasonPhrase();
-            throw new HTTPRequestException($response->getStatusCode(), $body);
+            throw new ApiException($response->getStatusCode(), $body);
         }
 
         return json_decode($response->getBody()->getContents(), true);

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -6,7 +6,7 @@ namespace Tests\Endpoints;
 
 use MeiliSearch\Client;
 use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class ClientTest extends TestCase
@@ -207,14 +207,14 @@ final class ClientTest extends TestCase
             ['primaryKey' => 'objectId']
         );
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->client->updateIndex('indexB', ['primaryKey' => 'objectID']);
     }
 
     public function testExceptionIsThrownWhenUpdateIndexUseANoneExistingIndex(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->client->updateIndex(
             'IndexNotExist',
@@ -226,7 +226,7 @@ final class ClientTest extends TestCase
     {
         $this->client->createIndex('index');
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->client->createIndex('index');
     }
@@ -236,19 +236,19 @@ final class ClientTest extends TestCase
         $this->expectException(\TypeError::class);
         $this->client->createIndex(null);
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->client->createIndex('');
     }
 
     public function testExceptionIfNoIndexWhenShowing(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->client->getIndex('a-non-existing-index');
     }
 
     public function testExceptionIfNoIndexWhenDeleting(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->client->deleteIndex('a-non-existing-index');
     }
 

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\InvalidArgumentException;
 use Tests\TestCase;
 
@@ -228,7 +228,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->client->createIndex('new-index');
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $index->getDocument(1);
     }

--- a/tests/Endpoints/DumpTest.php
+++ b/tests/Endpoints/DumpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class DumpTest extends TestCase
@@ -25,7 +25,7 @@ final class DumpTest extends TestCase
 
     public function testDumpNotFound(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->client->getDumpStatus('not-found');
     }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\TimeOutException;
 use Tests\TestCase;
 
@@ -77,7 +77,7 @@ final class IndexTest extends TestCase
             ['primaryKey' => 'objectId']
         );
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $index->update(['primaryKey' => 'objectID']);
     }
@@ -192,7 +192,7 @@ final class IndexTest extends TestCase
     {
         $this->index->delete();
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $this->index->fetchInfo();
     }
@@ -201,7 +201,7 @@ final class IndexTest extends TestCase
     {
         $this->index->delete();
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->index->update(['primaryKey' => 'objectID']);
     }
 
@@ -209,7 +209,7 @@ final class IndexTest extends TestCase
     {
         $this->index->delete();
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->index->delete();
     }
 }

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use MeiliSearch\Client;
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class KeysAndPermissionsTest extends TestCase
@@ -44,7 +44,7 @@ final class KeysAndPermissionsTest extends TestCase
     {
         $newClient = new Client(self::HOST);
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $newClient->index('index')->search('test');
     }
 
@@ -56,13 +56,13 @@ final class KeysAndPermissionsTest extends TestCase
 
         $newClient = new Client(self::HOST, 'bad-key');
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $newClient->index('index')->getSettings();
     }
 
     public function testExceptionIfBadKeyProvidedToGetKeys(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $client = new Client(self::HOST, 'bad-key');
         $client->getKeys();
     }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class SearchTest extends TestCase
@@ -132,7 +132,7 @@ final class SearchTest extends TestCase
         $index = $this->client->createIndex('another-index');
         $index->delete();
 
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
 
         $index->search('prince');
     }

--- a/tests/Endpoints/UpdatesTest.php
+++ b/tests/Endpoints/UpdatesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Exceptions\HTTPRequestException;
+use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class UpdatesTest extends TestCase
@@ -49,7 +49,7 @@ final class UpdatesTest extends TestCase
 
     public function testExceptionIfNoUpdateIdWhenGetting(): void
     {
-        $this->expectException(HTTPRequestException::class);
+        $this->expectException(ApiException::class);
         $this->index->getUpdateStatus(10000);
     }
 


### PR DESCRIPTION
Rename `MeiliSearch\HTTPRequestException` into `MeiliSearch\ApiException`

Explained here https://github.com/meilisearch/integration-guides/issues/19 and discussed here https://github.com/meilisearch/meilisearch-php/issues/50.  

I hope I understood correctly your intention :smiley: 