### PR TITLE
Should throw exception if httpBody empty

### DIFF
--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -61,10 +61,11 @@ trait HandlesIndex
         try {
             $index = $this->getIndex($uid, $options);
         } catch (HTTPRequestException $e) {
-            if (\is_array($e->httpBody) && 'index_not_found' !== $e->httpBody['errorCode']) {
+            if (\is_array($e->httpBody) && 'index_not_found' === $e->httpBody['errorCode']) {
+                $index = $this->createIndex($uid, $options);
+            } else {
                 throw $e;
             }
-            $index = $this->createIndex($uid, $options);
         }
 
         return $index;


### PR DESCRIPTION
I've been seeing the occasional error in my app saying "index already exists". I traced that error back to the "getOrCreateIndex" method.

When the response from meilisearch is empty, it should not try to create the index because we don't know for sure that the index "not found".