### PR TITLE
Add .idea in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 /vendor/
 .php_cs.cache
+/.idea/


### PR DESCRIPTION
If using one of the JetBrains IDEA, every time you add a file to a commit you need to pay attention to do not add the `.idea` directory.