### PR TITLE
Separate tests that ignored second test

### DIFF
--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -231,11 +231,14 @@ final class ClientTest extends TestCase
         $this->client->createIndex('index');
     }
 
-    public function testExceptionIfNoUidWhenCreating(): void
+    public function testExceptionIfUidIsNullWhenCreating(): void
     {
         $this->expectException(\TypeError::class);
         $this->client->createIndex(null);
+    }
 
+    public function testExceptionIfUidIsEmptyStringWhenCreating(): void
+    {
         $this->expectException(ApiException::class);
         $this->client->createIndex('');
     }


### PR DESCRIPTION
In these tests since the first test throws an error the second is ignored. Separating them to test uid empty string case. 