### PR TITLE
Remove php 7.2 support

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
     name: integration-tests-against-rc (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0']
     name: integration-tests (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,5 @@
 status = [
     'linter-check',
-    'integration-tests (PHP 7.2)',
     'integration-tests (PHP 7.3)',
     'integration-tests (PHP 7.4)',
     'integration-tests (PHP 8.0)'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "php-http/discovery": "^1.7",
         "php-http/httplug": "^2.1",
@@ -33,7 +33,7 @@
         "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^2.16",
         "guzzlehttp/guzzle": "^7.1",
         "http-interop/http-factory-guzzle": "^1.0"


### PR DESCRIPTION
Closes #165 

This PR remove the compat with php 7.2. It also uses the most recent version of phpunit to date.

@curquiza In [`MeiliSearch.php`](https://github.com/meilisearch/meilisearch-php/blob/main/src/MeiliSearch.php#L9) the current version is hardcoded. This still needs to be updated when decided which version is next.