### PR TITLE
Make composer lint command work

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
       - name: Run linter
-        run: vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --allow-risky=yes
+        run: composer lint
 
   tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
     },
     "scripts": {
         "lint": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --dry-run --using-cache=yes --allow-risky=yes"
+            "sh scripts/lint.sh"
         ],
         "lint:fix": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --using-cache=no --allow-risky=yes"
+            "sh scripts/lintfix.sh"
         ],
         "test": [
             "sh scripts/tests.sh"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Launching linting..."
+vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --allow-risky=yes
+

--- a/scripts/lintfix.sh
+++ b/scripts/lintfix.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Launching linting in fix mode..."
+vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --allow-risky=yes
+


### PR DESCRIPTION
Running `composer lint` locally would not work. In the CI it was not used as well, instead it was using the working command : 

```
vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --allow-risky=yes
```
