### PR TITLE
Fix composer lint command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,5 +71,5 @@ jobs:
         composer require --dev kriswallsmith/buzz nyholm/psr7
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
-    - name: PHPStan
+    - name: Run types tests with PHPStan
       run: php ./vendor/bin/phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
       - name: Run linter
-        run: vendor/bin/php-cs-fixer fix -v --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --allow-risky=yes
+        run: composer lint
 
   tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,4 +72,4 @@ jobs:
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
     - name: Run types tests with PHPStan
-      run: php ./vendor/bin/phpstan
+      run: composer types

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,4 +72,4 @@ jobs:
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
     - name: Run types tests with PHPStan
-      run: composer types
+      run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -45,14 +45,16 @@
     },
     "scripts": {
         "lint": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no --dry-run"
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no --dry-run --diff"
         ],
         "lint:fix": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no"
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no  --diff"
+        ],
+        "types": [
+            "php ./vendor/bin/phpstan"
         ],
         "test": [
-            "sh scripts/tests.sh",
-            "php ./vendor/bin/phpstan"
+            "sh scripts/tests.sh"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -45,13 +45,14 @@
     },
     "scripts": {
         "lint": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --dry-run --using-cache=yes --allow-risky=yes"
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no --dry-run"
         ],
         "lint:fix": [
-            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=./.php_cs.dist --diff --show-progress=estimating --using-cache=no --allow-risky=yes"
+            "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no"
         ],
         "test": [
-            "sh scripts/tests.sh"
+            "sh scripts/tests.sh",
+            "php ./vendor/bin/phpstan"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "lint:fix": [
             "./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --config=.php-cs-fixer.dist.php --using-cache=no  --diff"
         ],
-        "types": [
+        "phpstan": [
             "php ./vendor/bin/phpstan"
         ],
         "test": [

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -133,7 +133,7 @@ class SearchResult implements Countable, IteratorAggregate
             $filterOneFacet = function (array $facet): array {
                 return array_filter(
                     $facet,
-                    function ($v, $k): bool { return 0 !== $v; },
+                    function (int $facetValue): bool { return 0 !== $facetValue; },
                     ARRAY_FILTER_USE_BOTH
                 );
             };

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -501,7 +501,7 @@ final class SearchTest extends TestCase
             $filterOneFacet = function (array $facet): array {
                 return array_filter(
                     $facet,
-                    function ($v, $k): bool { return $v > 1; },
+                    function (int $facetValue): bool { return 1 < $facetValue; },
                     ARRAY_FILTER_USE_BOTH
                 );
             };


### PR DESCRIPTION
The lint composer command pointed to a non existing config file resulting in the following error: 
`  Cannot read config file "./.php_cs.dist".    `

Path has been updated. 
`composer lint` and `composer lint:fix` are now functional

I changed the scripts used in github actions with the ones from `composer` file.

I'm wondering why it wasn't used before. Am I relying on composer when I shouln't be?