### PR TITLE
Fix ApiException constructor crashing when HTTP body is empty

### DIFF
--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Exceptions;
 
 use Exception;
+use Psr\Http\Message\ResponseInterface;
 
 class ApiException extends Exception
 {
@@ -15,11 +16,11 @@ class ApiException extends Exception
     public $errorLink = null;
     public $httpBody = null;
 
-    public function __construct($httpStatus, $httpBody, $previous = null)
+    public function __construct(ResponseInterface $response, $httpBody, $previous = null)
     {
         $this->httpBody = $httpBody;
-        $this->httpStatus = $httpStatus;
-        $this->message = $this->getMessageFromHttpBody();
+        $this->httpStatus = $response->getStatusCode();
+        $this->message = $this->getMessageFromHttpBody() ?? $response->getReasonPhrase();
         $this->errorCode = $this->getErrorCodeFromHttpBody();
         $this->errorLink = $this->getErrorLinkFromHttpBody();
         $this->errorType = $this->getErrorTypeFromHttpBody();

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -187,7 +187,7 @@ class Client implements Http
     {
         if ($response->getStatusCode() >= 300) {
             $body = json_decode($response->getBody()->getContents(), true) ?? $response->getReasonPhrase();
-            throw new ApiException($response->getStatusCode(), $body);
+            throw new ApiException($response, $body);
         }
 
         return json_decode($response->getBody()->getContents(), true);

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Exceptions;
 
+use Http\Discovery\Psr17FactoryDiscovery;
 use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
 
@@ -20,11 +21,16 @@ final class ApiExceptionTest extends TestCase
         $statusCode = 400;
 
         try {
-            throw new ApiException($statusCode, $httpBodyExample);
+            $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+            $responseBodyStream = $streamFactory->createStream(json_encode($httpBodyExample));
+
+            $responseFactory = Psr17FactoryDiscovery::findResponseFactory();
+            $response = $responseFactory->createResponse($statusCode)->withBody($responseBodyStream);
+
+            throw new ApiException($response, $httpBodyExample);
         } catch (ApiException $apiException) {
             $this->assertEquals($statusCode, $apiException->httpStatus);
-            $this->assertEquals($httpBodyExample['message'],
-                $apiException->message);
+            $this->assertEquals($httpBodyExample['message'], $apiException->message);
             $this->assertEquals($httpBodyExample['errorCode'], $apiException->errorCode);
             $this->assertEquals($httpBodyExample['errorType'], $apiException->errorType);
             $this->assertEquals($httpBodyExample['errorLink'], $apiException->errorLink);

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -39,4 +39,24 @@ final class ApiExceptionTest extends TestCase
             $this->assertEquals($expectedExceptionToString, (string) $apiException);
         }
     }
+
+    public function testExceptionWithNoHttpBody(): void
+    {
+        $statusCode = 400;
+        $responseFactory = Psr17FactoryDiscovery::findResponseFactory();
+        $response = $responseFactory->createResponse($statusCode);
+
+        try {
+            throw new ApiException($response, null);
+        } catch (ApiException $apiException) {
+            $this->assertEquals($statusCode, $apiException->httpStatus);
+            $this->assertEquals($response->getReasonPhrase(), $apiException->message);
+            $this->assertNull($apiException->errorCode);
+            $this->assertNull($apiException->errorType);
+            $this->assertNull($apiException->errorLink);
+
+            $expectedExceptionToString = "MeiliSearch HTTPRequestException: Http Status: {$statusCode} - Message: {$response->getReasonPhrase()}";
+            $this->assertEquals($expectedExceptionToString, (string) $apiException);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #171

This PR includes:
- Reworked ApiException constructor, the first argument is now of `ResponseInterface` type
- Fixed all uses of `ApiException`
- Changed `ApiException` tests to use the new constructor
- Added new test that validates that ApiException constructor does not crash with an empty response