### PR TITLE
Exception when improper utf8 chars

### DIFF
--- a/src/Exceptions/FailedJsonEncodingException.php
+++ b/src/Exceptions/FailedJsonEncodingException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Exceptions;
+
+use Exception;
+
+final class FailedJsonEncodingException extends Exception
+{
+    public function __construct($message = "")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Exceptions/FailedJsonEncodingException.php
+++ b/src/Exceptions/FailedJsonEncodingException.php
@@ -8,7 +8,7 @@ use Exception;
 
 final class FailedJsonEncodingException extends Exception
 {
-    public function __construct($message = "")
+    public function __construct($message = '')
     {
         parent::__construct($message);
     }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -9,6 +9,7 @@ use Http\Discovery\Psr18ClientDiscovery;
 use MeiliSearch\Contracts\Http;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
+use MeiliSearch\Exceptions\FailedJsonEncodingException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -84,21 +85,27 @@ class Client implements Http
     }
 
     /**
-     * @param string $path
-     * @param null   $body
-     * @param array  $query
+     * @param null|mixed $body
      *
      * @return mixed
      *
-     * @throws ClientExceptionInterface
      * @throws ApiException
+     * @throws ClientExceptionInterface
+     * @throws CommunicationException
+     * @throws FailedJsonEncodingException
      */
-    public function post($path, $body = null, $query = [])
+    public function post(string $path, $body = null, array $query = [])
     {
+        $content = json_encode($body);
+
+        if($content === false) {
+            throw new FailedJsonEncodingException('Encoding payload to json failed. ' . json_last_error_msg());
+        }
+
         $request = $this->requestFactory->createRequest(
             'POST',
             $this->baseUrl.$path.$this->buildQueryString($query)
-        )->withBody($this->streamFactory->createStream(json_encode($body)));
+        )->withBody($this->streamFactory->createStream($content));
 
         return $this->execute($request);
     }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -85,7 +85,7 @@ class Client implements Http
     }
 
     /**
-     * @param null|mixed $body
+     * @param mixed|null $body
      *
      * @return mixed
      *
@@ -98,8 +98,8 @@ class Client implements Http
     {
         $content = json_encode($body);
 
-        if($content === false) {
-            throw new FailedJsonEncodingException('Encoding payload to json failed. ' . json_last_error_msg());
+        if (false === $content) {
+            throw new FailedJsonEncodingException('Encoding payload to json failed. '.json_last_error_msg());
         }
 
         $request = $this->requestFactory->createRequest(

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -27,9 +27,9 @@ final class DocumentsTest extends TestCase
     public function testAddDocumentWithSpecialChars(): void
     {
         $documents = [
-            [ 'title' => 'Sehr schön!', 'comment' => 'ßöüä', ], // German
-            [ 'title' => 'Très bien!', 'comment' => 'éèê', ], // French
-            [ 'title' => 'Очень красивый!', 'comment' => '', ], // Russian
+            ['title' => 'Sehr schön!', 'comment' => 'ßöüä'], // German
+            ['title' => 'Très bien!', 'comment' => 'éèê'], // French
+            ['title' => 'Очень красивый!', 'comment' => ''], // Russian
         ];
 
         $index = $this->client->createIndex('documents');

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -27,9 +27,9 @@ final class DocumentsTest extends TestCase
     public function testAddDocumentWithSpecialChars(): void
     {
         $documents = [
-            [ 'id' => 60, 'title' => 'Sehr schön!', 'comment' => 'ßöüä'], // German
-            [ 'id' => 61, 'title' => 'Très bien!', 'comment' => 'éèê'], // French
-            [ 'id' => 62, 'title' => 'Очень красивый!', 'comment' => ''], // Russian
+            ['id' => 60, 'title' => 'Sehr schön!', 'comment' => 'ßöüä'], // German
+            ['id' => 61, 'title' => 'Très bien!', 'comment' => 'éèê'], // French
+            ['id' => 62, 'title' => 'Очень красивый!', 'comment' => ''], // Russian
         ];
 
         $index = $this->client->createIndex('documents');

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -27,9 +27,9 @@ final class DocumentsTest extends TestCase
     public function testAddDocumentWithSpecialChars(): void
     {
         $documents = [
-            ['title' => 'Sehr schön!', 'comment' => 'ßöüä'], // German
-            ['title' => 'Très bien!', 'comment' => 'éèê'], // French
-            ['title' => 'Очень красивый!', 'comment' => ''], // Russian
+            [ 'id' => 60, 'title' => 'Sehr schön!', 'comment' => 'ßöüä'], // German
+            [ 'id' => 61, 'title' => 'Très bien!', 'comment' => 'éèê'], // French
+            [ 'id' => 62, 'title' => 'Очень красивый!', 'comment' => ''], // Russian
         ];
 
         $index = $this->client->createIndex('documents');


### PR DESCRIPTION
Fix #180 

This PR adds some more tests for properly checking the import of documtens with special characters like they occur in German, French or Russian.

Further it adds a check whether the `json_encode`, that is called to encode the payload sent to MS, fails and throw an exception.