### PR TITLE
Increase FD limit to avoid `Too many open files` error

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-echo 'Setting FDs limit to 1000'
-ulimit -Sn 1000
+echo 'Setting FDs limit to 10000'
+ulimit -Sn 10000
 
 echo "Launching tests..."
 vendor/bin/phpunit --color tests/


### PR DESCRIPTION
When launching tests multiple times, I get `Too many open files` error with MeiliSearch. Increase the soft FDs limit reduces this issue.