### PR TITLE
Fixing issue when send synonyms as empty array

### DIFF
--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -109,6 +109,7 @@ trait HandlesSettings
         if (empty($synonyms)) {
             $synonyms = null;
         }
+
         return $this->http->post(self::PATH.'/'.$this->uid.'/settings/synonyms', $synonyms);
     }
 

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -106,6 +106,7 @@ trait HandlesSettings
     public function updateSynonyms(array $synonyms): array
     {
         // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204.
+        // Should be removed when implementing https://github.com/meilisearch/meilisearch-php/issues/209
         if (0 == \count($synonyms)) {
             $synonyms = null;
         }

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -106,7 +106,7 @@ trait HandlesSettings
     public function updateSynonyms(array $synonyms): array
     {
         // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204.
-        if (empty($synonyms)) {
+        if (0 == \count($synonyms)) {
             $synonyms = null;
         }
 

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -105,6 +105,10 @@ trait HandlesSettings
 
     public function updateSynonyms(array $synonyms): array
     {
+        // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204.
+        if (empty($synonyms)) {
+            $synonyms = null;
+        }
         return $this->http->post(self::PATH.'/'.$this->uid.'/settings/synonyms', $synonyms);
     }
 

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -182,6 +182,7 @@ class Indexes extends Endpoint
     public function updateSettings($settings): array
     {
         // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204
+        // Should be removed when implementing https://github.com/meilisearch/meilisearch-php/issues/209
         if (\array_key_exists('synonyms', $settings) && 0 == \count($settings['synonyms'])) {
             $settings['synonyms'] = null;
         }

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -182,9 +182,10 @@ class Indexes extends Endpoint
     public function updateSettings($settings): array
     {
         // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204
-        if (array_key_exists("synonyms", $settings) && empty($settings["synonyms"])) {
-            $settings["synonyms"] = null;
+        if (\array_key_exists('synonyms', $settings) && 0 == \count($settings['synonyms'])) {
+            $settings['synonyms'] = null;
         }
+
         return $this->http->post(self::PATH.'/'.$this->uid.'/settings', $settings);
     }
 

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -181,6 +181,10 @@ class Indexes extends Endpoint
 
     public function updateSettings($settings): array
     {
+        // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204
+        if (array_key_exists("synonyms", $settings) && empty($settings["synonyms"])) {
+            $settings["synonyms"] = null;
+        }
         return $this->http->post(self::PATH.'/'.$this->uid.'/settings', $settings);
     }
 

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -158,7 +158,7 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settings['sortableAttributes']);
     }
 
-    // Here to test for regressions related to https://github.com/meilisearch/meilisearch-php/issues/204.
+    // Here the test to prevent https://github.com/meilisearch/meilisearch-php/issues/204.
     public function testGetThenUpdateSettings(): void
     {
         $index = $this->client->createIndex('index');

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -157,4 +157,19 @@ final class SettingsTest extends TestCase
         $this->assertIsArray($settings['sortableAttributes']);
         $this->assertEmpty($settings['sortableAttributes']);
     }
+
+    // Here to test for regressions related to https://github.com/meilisearch/meilisearch-php/issues/204.
+    public function testGetThenUpdateSettings(): void
+    {
+        $index = $this->client->createIndex('index');
+
+        $resetPromise = $index->resetSettings();
+        $this->assertIsValidPromise($resetPromise);
+        $index->waitForPendingUpdate($resetPromise['updateId']);
+
+        $settings = $index->getSettings();
+        $promise = $index->updateSettings($settings);
+        $this->assertIsValidPromise($promise);
+        $index->waitForPendingUpdate($promise['updateId']);
+    }
 }


### PR DESCRIPTION
This PR is a patch for this [issue](#204).
But it could be interesting to implement a complete JSONSerializer for this SDK see #209.
closed #204.