### PR TITLE
Throw ApiException for invalid JSON responses in HTTP Client

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -193,13 +193,18 @@ class Client implements Http
             return null;
         }
 
-        if ($response->getStatusCode() >= 300) {
-            $body = $this->jsonDecode($response->getBody()->getContents()) ?? $response->getReasonPhrase();
+        try {
+            $body = $this->jsonDecode($response->getBody()->getContents());
+        } catch (FailedJsonDecodingException $e) {
+            throw new ApiException($response, ['message' => $e->getMessage()], $e);
+        }
 
+        if ($response->getStatusCode() >= 300) {
+            $body = $body ?? $response->getReasonPhrase();
             throw new ApiException($response, $body);
         }
 
-        return $this->jsonDecode($response->getBody()->getContents());
+        return $body;
     }
 
     /**

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Http;
 
 use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\FailedJsonDecodingException;
 use MeiliSearch\Exceptions\FailedJsonEncodingException;
 use MeiliSearch\Http\Client;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -36,7 +35,7 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
+        $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
 
         $client->post('/', '');
@@ -73,7 +72,7 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
+        $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
 
         $client->put('/', '');
@@ -110,7 +109,7 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
+        $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
 
         $client->put('/', '');
@@ -149,6 +148,9 @@ class ClientTest extends TestCase
         $response->expects(self::any())
             ->method('getStatusCode')
             ->willReturn($status);
+        $response->expects(self::any())
+            ->method('getReasonPhrase')
+            ->willReturn('HTTP Status '.$status);
         $response->expects(self::once())
             ->method('getBody')
             ->willReturn($stream);


### PR DESCRIPTION
This will handle a `FailedJsonDecodingException` and convert it to an `ApiException` to provide more context (the HTTP status code).

If you think it will make more sense to check the `Content-Type` header I can refactor to use that.

Resolves #211 