### PR TITLE
Fix docblock in Http\Client

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 class Client implements Http
 {
     /**
-     * @var Http
+     * @var ClientInterface
      */
     private $http;
 


### PR DESCRIPTION
The docblock of the property `$http` in `Http\Client` should be of type `ClientInterface`. This fixes linting on the call to `$this->http->sendRequest()`.