### PR TITLE
Check response Content-Type header in HTTP client

### DIFF
--- a/src/Exceptions/InvalidResponseBodyException.php
+++ b/src/Exceptions/InvalidResponseBodyException.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Exceptions;
+
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+
+class InvalidResponseBodyException extends Exception
+{
+    public $httpStatus = 0;
+    public $httpBody = null;
+    public $message = null;
+
+    public function __construct(ResponseInterface $response, $httpBody, $previous = null)
+    {
+        $this->httpStatus = $response->getStatusCode();
+        $this->httpBody = $httpBody;
+        $this->message = $this->getMessageFromHttpBody() ?? $response->getReasonPhrase();
+
+        parent::__construct($this->message, $this->httpStatus, $previous);
+    }
+
+    public function __toString()
+    {
+        $base = 'MeiliSearch InvalidResponseBodyException: Http Status: '.$this->httpStatus;
+
+        if ($this->message) {
+            $base .= ' - Message: '.$this->message;
+        }
+
+        return $base;
+    }
+
+    public function getMessageFromHttpBody(): ?string
+    {
+        if (null !== $this->httpBody) {
+            $rawText = strip_tags($this->httpBody);
+
+            if (!ctype_space($rawText)) {
+                return substr(trim($rawText), 0, 100);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -13,6 +13,7 @@ use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\CommunicationException;
 use MeiliSearch\Exceptions\FailedJsonDecodingException;
 use MeiliSearch\Exceptions\FailedJsonEncodingException;
+use MeiliSearch\Exceptions\InvalidResponseBodyException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -191,6 +192,10 @@ class Client implements Http
     {
         if (204 === $response->getStatusCode()) {
             return null;
+        }
+
+        if (!\in_array('application/json', $response->getHeader('content-type'), true)) {
+            throw new InvalidResponseBodyException($response, $response->getBody()->getContents());
         }
 
         if ($response->getStatusCode() >= 300) {

--- a/tests/Exceptions/InvalidResponseBodyExceptionTest.php
+++ b/tests/Exceptions/InvalidResponseBodyExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Exceptions;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use MeiliSearch\Exceptions\InvalidResponseBodyException;
+use Tests\TestCase;
+
+final class InvalidResponseBodyExceptionTest extends TestCase
+{
+    public function testException(): void
+    {
+        $httpBodyExample = '<b>Gateway Timeout</b>';
+        $statusCode = 504;
+
+        try {
+            $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+            $responseBodyStream = $streamFactory->createStream($httpBodyExample);
+
+            $responseFactory = Psr17FactoryDiscovery::findResponseFactory();
+            $response = $responseFactory->createResponse($statusCode)->withBody($responseBodyStream);
+
+            throw new InvalidResponseBodyException($response, $httpBodyExample);
+        } catch (InvalidResponseBodyException $invalidResponseBodyException) {
+            $this->assertEquals($statusCode, $invalidResponseBodyException->httpStatus);
+            $this->assertEquals('Gateway Timeout', $invalidResponseBodyException->message);
+
+            $expectedExceptionToString = "MeiliSearch InvalidResponseBodyException: Http Status: {$statusCode} - Message: Gateway Timeout";
+            $this->assertEquals($expectedExceptionToString, (string) $invalidResponseBodyException);
+        }
+    }
+
+    public function testExceptionWithNoHttpBody(): void
+    {
+        $statusCode = 504;
+        $responseFactory = Psr17FactoryDiscovery::findResponseFactory();
+        $response = $responseFactory->createResponse($statusCode);
+
+        try {
+            throw new InvalidResponseBodyException($response, null);
+        } catch (InvalidResponseBodyException $invalidResponseBodyException) {
+            $this->assertEquals($statusCode, $invalidResponseBodyException->httpStatus);
+            $this->assertEquals($response->getReasonPhrase(), $invalidResponseBodyException->message);
+
+            $expectedExceptionToString = "MeiliSearch InvalidResponseBodyException: Http Status: {$statusCode} - Message: {$response->getReasonPhrase()}";
+            $this->assertEquals($expectedExceptionToString, (string) $invalidResponseBodyException);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #211 

This implements a new exception `InvalidResponseBodyException` which is thrown when parsing an HTTP response which does not have the Content-Type header `application/json`.

Based on my testing and research, the Meilisearch server will always send `application/json` as the Content-Type except on responses where the status code is `204`. The check is naive and assumes that the Meilisearch server will stick to this convention. If we want the check to be more robust (i.e. case-insensitive, able to handle charset being specified) I can adjust it as necessary.