### PR TITLE
Changes related to the new error handler

### DIFF
--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -85,7 +85,7 @@ trait HandlesIndex
         try {
             $index = $this->getIndex($uid);
         } catch (ApiException $e) {
-            if (\is_array($e->httpBody) && 'index_not_found' === $e->httpBody['errorCode']) {
+            if (\is_array($e->httpBody) && 'index_not_found' === $e->errorCode) {
                 $index = $this->createIndex($uid, $options);
             } else {
                 throw $e;

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -37,15 +37,15 @@ class ApiException extends Exception
         }
 
         if ($this->errorCode) {
-            $base .= ' - Error code: '.$this->errorCode;
+            $base .= ' - Code: '.$this->errorCode;
         }
 
         if ($this->errorType) {
-            $base .= ' - Error type: '.$this->errorType;
+            $base .= ' - Type: '.$this->errorType;
         }
 
         if ($this->errorLink) {
-            $base .= ' - Error link: '.$this->errorLink;
+            $base .= ' - Link: '.$this->errorLink;
         }
 
         return $base;
@@ -62,8 +62,8 @@ class ApiException extends Exception
 
     private function getErrorCodeFromHttpBody(): ?string
     {
-        if (\is_array($this->httpBody) && \array_key_exists('errorCode', $this->httpBody)) {
-            return $this->httpBody['errorCode'];
+        if (\is_array($this->httpBody) && \array_key_exists('code', $this->httpBody)) {
+            return $this->httpBody['code'];
         }
 
         return null;
@@ -71,8 +71,8 @@ class ApiException extends Exception
 
     private function getErrorTypeFromHttpBody(): ?string
     {
-        if (\is_array($this->httpBody) && \array_key_exists('errorType', $this->httpBody)) {
-            return $this->httpBody['errorType'];
+        if (\is_array($this->httpBody) && \array_key_exists('type', $this->httpBody)) {
+            return $this->httpBody['type'];
         }
 
         return null;
@@ -80,8 +80,8 @@ class ApiException extends Exception
 
     private function getErrorLinkFromHttpBody(): ?string
     {
-        if (\is_array($this->httpBody) && \array_key_exists('errorLink', $this->httpBody)) {
-            return $this->httpBody['errorLink'];
+        if (\is_array($this->httpBody) && \array_key_exists('link', $this->httpBody)) {
+            return $this->httpBody['link'];
         }
 
         return null;

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -30,7 +30,6 @@ final class ClientTest extends TestCase
     public function testExceptionIsThrownOnGetRawIndexWhenIndexDoesNotExist(): void
     {
         $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('Index index not found');
         $this->expectExceptionCode(404);
 
         $this->client->getRawIndex('index');
@@ -287,18 +286,6 @@ final class ClientTest extends TestCase
         $this->expectExceptionMessage('You must have an authorization token');
 
         $client->getOrCreateIndex('index');
-    }
-
-    public function testExceptionIsThrownWhenOverwritingPrimaryKeyUsingUpdateIndex(): void
-    {
-        $this->client->createIndex(
-            'indexB',
-            ['primaryKey' => 'objectId']
-        );
-
-        $this->expectException(ApiException::class);
-
-        $this->client->updateIndex('indexB', ['primaryKey' => 'objectID']);
     }
 
     public function testExceptionIsThrownWhenUpdateIndexUseANoneExistingIndex(): void

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -105,18 +105,6 @@ final class IndexTest extends TestCase
         $this->assertSame($this->index->getUid(), 'index');
     }
 
-    public function testExceptionIsThrownWhenOverwritingPrimaryKey(): void
-    {
-        $index = $this->client->createIndex(
-            'indexB',
-            ['primaryKey' => 'objectId']
-        );
-
-        $this->expectException(ApiException::class);
-
-        $index->update(['primaryKey' => 'objectID']);
-    }
-
     public function testIndexStats(): void
     {
         $stats = $this->index->stats();

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -14,9 +14,9 @@ final class ApiExceptionTest extends TestCase
     {
         $httpBodyExample = [
             'message' => 'This is the message',
-            'errorCode' => 'this_is_the_error_code',
-            'errorType' => 'this_is_the_error_type',
-            'errorLink' => 'https://docs.meilisearch.com/errors',
+            'code' => 'this_is_the_error_code',
+            'type' => 'this_is_the_error_type',
+            'link' => 'https://docs.meilisearch.com/errors',
         ];
         $statusCode = 400;
 
@@ -31,11 +31,11 @@ final class ApiExceptionTest extends TestCase
         } catch (ApiException $apiException) {
             $this->assertEquals($statusCode, $apiException->httpStatus);
             $this->assertEquals($httpBodyExample['message'], $apiException->message);
-            $this->assertEquals($httpBodyExample['errorCode'], $apiException->errorCode);
-            $this->assertEquals($httpBodyExample['errorType'], $apiException->errorType);
-            $this->assertEquals($httpBodyExample['errorLink'], $apiException->errorLink);
+            $this->assertEquals($httpBodyExample['code'], $apiException->errorCode);
+            $this->assertEquals($httpBodyExample['type'], $apiException->errorType);
+            $this->assertEquals($httpBodyExample['link'], $apiException->errorLink);
 
-            $expectedExceptionToString = "MeiliSearch ApiException: Http Status: {$statusCode} - Message: {$httpBodyExample['message']} - Error code: {$httpBodyExample['errorCode']} - Error type: {$httpBodyExample['errorType']} - Error link: {$httpBodyExample['errorLink']}";
+            $expectedExceptionToString = "MeiliSearch ApiException: Http Status: {$statusCode} - Message: {$httpBodyExample['message']} - Code: {$httpBodyExample['code']} - Type: {$httpBodyExample['type']} - Link: {$httpBodyExample['link']}";
             $this->assertEquals($expectedExceptionToString, (string) $apiException);
         }
     }


### PR DESCRIPTION
This not breaking since `errorCode`, `errorType` and `errorLink` in `ApiException` are not renamed into `code`, `type` and `link`.
`$code` is indeed reserved to the main `Exception` class, so I cannot rename `errorCode` into `code` and use it.