### PR TITLE
Update version for the next release v0.20.0

### DIFF
--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -6,5 +6,5 @@ namespace MeiliSearch;
 
 class MeiliSearch
 {
-    public const VERSION = '0.19.3';
+    public const VERSION = '0.20.0';
 }


### PR DESCRIPTION
This version is breaking since the current changes in the code base related to the new error handler will make the users of MeiliSaerch v0.23.1 and older to break their code.