### PR TITLE
Remove delete if exist method

### DIFF
--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -45,20 +45,6 @@ trait HandlesIndex
         return $this->index($uid)->delete();
     }
 
-    public function deleteIndexIfExists(string $uid): bool
-    {
-        try {
-            $this->deleteIndex($uid);
-
-            return true;
-        } catch (ApiException $e) {
-            if ('index_not_found' === $e->errorCode) {
-                return false;
-            }
-            throw ($e);
-        }
-    }
-
     public function deleteAllIndexes(): void
     {
         $indexes = $this->getAllIndexes();

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -141,43 +141,6 @@ final class ClientTest extends TestCase
         $this->assertCount(0, $response);
     }
 
-    public function testDeleteIndexIfExistsDeletesExistingIndex(): void
-    {
-        $this->client->createIndex('index');
-
-        $response = $this->client->getAllIndexes();
-        $this->assertCount(1, $response);
-
-        $response = $this->client->deleteIndexIfExists('index');
-        $this->assertTrue($response);
-
-        $response = $this->client->getAllIndexes();
-        $this->assertCount(0, $response);
-    }
-
-    public function testDeleteIndexIfExistsReturnsFalseIfNotExists(): void
-    {
-        $this->client->createIndex('index');
-
-        $response = $this->client->getAllIndexes();
-        $this->assertCount(1, $response);
-
-        $response = $this->client->deleteIndexIfExists('foo');
-        $this->assertFalse($response);
-
-        $response = $this->client->getAllIndexes();
-        $this->assertCount(1, $response);
-    }
-
-    public function testApiExceptionOtherThanIndexNotFoundIsThrownFromDeleteIndexIfExists(): void
-    {
-        $client = new Client(self::HOST);
-
-        $this->expectException(ApiException::class);
-
-        $client->deleteIndexIfExists('index');
-    }
-
     public function testDeleteAllIndexes(): void
     {
         $this->client->createIndex('index-1');


### PR DESCRIPTION
### Breaking Changes
Removing `delete_if_exist` method.
All the actions on indexes are now asynchronous, the method delete_if_exist is now useless.
