### PR TITLE
Addition related to API keys

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ namespace MeiliSearch;
 use MeiliSearch\Delegates\HandlesIndex;
 use MeiliSearch\Delegates\HandlesSystem;
 use MeiliSearch\Endpoints\Delegates\HandlesDumps;
+use MeiliSearch\Endpoints\Delegates\HandlesKeys;
 use MeiliSearch\Endpoints\Delegates\HandlesTasks;
 use MeiliSearch\Endpoints\Dumps;
 use MeiliSearch\Endpoints\Health;
@@ -22,6 +23,7 @@ class Client
     use HandlesDumps;
     use HandlesIndex;
     use HandlesTasks;
+    use HandlesKeys;
     use HandlesSystem;
 
     private $http;

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -44,9 +44,4 @@ trait HandlesSystem
     {
         return $this->stats->show();
     }
-
-    public function getKeys(): array
-    {
-        return $this->keys->show();
-    }
 }

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -13,7 +13,7 @@ trait HandlesKeys
 {
     public function getKeys(): array
     {
-        return $this->keys->show();
+        return $this->keys->all();
     }
 
     public function getKey($key): array

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Endpoints\Delegates;
+
+use MeiliSearch\Endpoints\Keys;
+
+/**
+ * @property Keys index
+ */
+trait HandlesKeys
+{
+    public function getKeys(): array
+    {
+        return $this->keys->show();
+    }
+
+    public function getKey($key): array
+    {
+        return $this->keys->get($key);
+    }
+
+    public function createKey(array $options = []): array
+    {
+        return $this->keys->create($options);
+    }
+
+    public function updateKey(string $key, array $options = []): array
+    {
+        return $this->keys->update($key, $options);
+    }
+
+    public function deleteKey(string $key): array
+    {
+        return $this->keys->delete($key) ?? [];
+    }
+}

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -15,6 +15,11 @@ class Keys extends Endpoint
         return $this->http->get(self::PATH.'/'.$key);
     }
 
+    public function all(): array
+    {
+        return $this->http->get(self::PATH.'/');
+    }
+
     public function create(array $options = []): array
     {
         return $this->http->post(self::PATH, $options);

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -9,4 +9,24 @@ use MeiliSearch\Contracts\Endpoint;
 class Keys extends Endpoint
 {
     protected const PATH = '/keys';
+
+    public function get($key): array
+    {
+        return $this->http->get(self::PATH.'/'.$key);
+    }
+
+    public function create(array $options = []): array
+    {
+        return $this->http->post(self::PATH, $options);
+    }
+
+    public function update(string $key, array $options = []): array
+    {
+        return $this->http->patch(self::PATH.'/'.$key, $options);
+    }
+
+    public function delete(string $key): array
+    {
+        return $this->http->delete(self::PATH.'/'.$key) ?? [];
+    }
 }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -6,7 +6,6 @@ namespace Tests\Endpoints;
 
 use DateTimeInterface;
 use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\TimeOutException;
 use Tests\TestCase;
 

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -10,34 +10,17 @@ use Tests\TestCase;
 
 final class KeysAndPermissionsTest extends TestCase
 {
-    public function testGetKeys(): void
+    public function testGetKeysDefault(): void
     {
         $response = $this->client->getKeys();
 
-        $this->assertArrayHasKey('private', $response);
-        $this->assertArrayHasKey('public', $response);
-        $this->assertIsString($response['private']);
-        $this->assertNotNull($response['private']);
-        $this->assertIsString($response['public']);
-        $this->assertNotNull($response['public']);
-    }
-
-    public function testSearchingIfPublicKeyProvided(): void
-    {
-        $this->client->createIndex('index');
-
-        $newClient = new Client(self::HOST, $this->getKeys()['public']);
-        $response = $newClient->index('index')->search('test');
-        $this->assertArrayHasKey('hits', $response->toArray());
-    }
-
-    public function testGetSettingsIfPrivateKeyProvided(): void
-    {
-        $this->client->createIndex('index');
-        $newClient = new Client(self::HOST, $this->getKeys()['private']);
-        $response = $newClient->index('index')->getSettings();
-
-        $this->assertEquals(['*'], $response['searchableAttributes']);
+        $this->assertIsArray($response);
+        $this->assertCount(2, $response);
+        $this->assertArrayHasKey('actions', $response[0]);
+        $this->assertArrayHasKey('indexes', $response[0]);
+        $this->assertArrayHasKey('createdAt', $response[0]);
+        $this->assertArrayHasKey('expiresAt', $response[0]);
+        $this->assertArrayHasKey('updatedAt', $response[0]);
     }
 
     public function testExceptionIfNoMasterKeyProvided(): void
@@ -50,7 +33,7 @@ final class KeysAndPermissionsTest extends TestCase
 
     public function testExceptionIfBadKeyProvidedToGetSettings(): void
     {
-        $this->client->createIndex('index');
+        $this->createEmptyIndex('index');
         $response = $this->client->index('index')->getSettings();
         $this->assertEquals(['*'], $response['searchableAttributes']);
 
@@ -67,8 +50,128 @@ final class KeysAndPermissionsTest extends TestCase
         $client->getKeys();
     }
 
-    private function getKeys(): array
+    public function testGetKey(): void
     {
-        return $this->client->getKeys();
+        $key = $this->client->createKey(self::INFO_KEY);
+        $response = $this->client->getKey($key['key']);
+
+        $this->assertArrayHasKey('key', $response);
+        $this->assertArrayHasKey('actions', $response);
+        $this->assertIsArray($response['actions']);
+        $this->assertIsArray($response['indexes']);
+        $this->assertArrayHasKey('indexes', $response);
+        $this->assertArrayHasKey('createdAt', $response);
+        $this->assertArrayHasKey('expiresAt', $response);
+        $this->assertArrayHasKey('updatedAt', $response);
+
+        $this->client->deleteKey($key['key']);
+    }
+
+    public function testExceptionIfKeyDoesntExist(): void
+    {
+        $this->expectException(ApiException::class);
+        $this->client->getKey('No existing key');
+    }
+
+    public function testCreateKey(): void
+    {
+        $key = $this->client->createKey(self::INFO_KEY);
+
+        $this->assertArrayHasKey('key', $key);
+        $this->assertArrayHasKey('actions', $key);
+        $this->assertIsArray($key['actions']);
+        $this->assertSame($key['actions'], self::INFO_KEY['actions']);
+        $this->assertIsArray($key['indexes']);
+        $this->assertArrayHasKey('indexes', $key);
+        $this->assertSame($key['indexes'], self::INFO_KEY['indexes']);
+        $this->assertArrayHasKey('createdAt', $key);
+        $this->assertNotNull($key['createdAt']);
+        $this->assertArrayHasKey('expiresAt', $key);
+        $this->assertNull($key['expiresAt']);
+        $this->assertArrayHasKey('updatedAt', $key);
+        $this->assertNotNull($key['updatedAt']);
+
+        $this->client->deleteKey($key['key']);
+    }
+
+    public function testCreateKeyWithOptions(): void
+    {
+        $key = [
+            'description' => 'test create',
+            'actions' => ['search'],
+            'indexes' => ['index'],
+            'expiresAt' => date('Y-m-d', strtotime('+1 day')),
+        ];
+        $response = $this->client->createKey($key);
+
+        $this->assertArrayHasKey('key', $response);
+        $this->assertArrayHasKey('description', $response);
+        $this->assertSame($response['description'], 'test create');
+        $this->assertArrayHasKey('actions', $response);
+        $this->assertIsArray($response['actions']);
+        $this->assertSame($response['actions'], ['search']);
+        $this->assertIsArray($response['indexes']);
+        $this->assertArrayHasKey('indexes', $response);
+        $this->assertSame($response['indexes'], ['index']);
+        $this->assertArrayHasKey('createdAt', $response);
+        $this->assertNotNull($response['createdAt']);
+        $this->assertArrayHasKey('expiresAt', $response);
+        $this->assertNotNull($response['expiresAt']);
+        $this->assertArrayHasKey('updatedAt', $response);
+        $this->assertNotNull($response['updatedAt']);
+
+        $this->client->deleteKey($response['key']);
+    }
+
+    public function testCreateKeyWithoutActions(): void
+    {
+        $this->expectException(ApiException::class);
+        $this->client->createKey([
+            'description' => 'test create',
+            'indexes' => ['index'],
+            'expiresAt' => null,
+        ]);
+    }
+
+    public function testUpdateKey(): void
+    {
+        $key = $this->client->createKey(self::INFO_KEY);
+        $response = $this->client->updateKey($key['key'], [
+            'description' => 'test update',
+            'indexes' => ['*'],
+            'expiresAt' => date('Y-m-d', strtotime('+1 day')),
+        ]);
+
+        $this->assertArrayHasKey('key', $response);
+        $this->assertArrayHasKey('description', $response);
+        $this->assertSame($response['description'], 'test update');
+        $this->assertArrayHasKey('actions', $response);
+        $this->assertIsArray($response['actions']);
+        $this->assertSame($response['actions'], self::INFO_KEY['actions']);
+        $this->assertIsArray($response['indexes']);
+        $this->assertArrayHasKey('indexes', $response);
+        $this->assertSame($response['indexes'], ['*']);
+        $this->assertArrayHasKey('createdAt', $response);
+        $this->assertNotNull($response['createdAt']);
+        $this->assertArrayHasKey('expiresAt', $response);
+        $this->assertNotNull($response['expiresAt']);
+        $this->assertArrayHasKey('updatedAt', $response);
+        $this->assertNotNull($response['updatedAt']);
+
+        $this->client->deleteKey($response['key']);
+    }
+
+    public function testDeleteKey(): void
+    {
+        $key = $this->client->createKey(self::INFO_KEY);
+        $this->client->deleteKey($key['key']);
+        $this->expectException(ApiException::class);
+        $this->client->getKey($key['key']);
+    }
+
+    public function testInextistingDeleteKey(): void
+    {
+        $this->expectException(ApiException::class);
+        $this->client->deleteKey('No existing key');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,13 @@ abstract class TestCase extends BaseTestCase
 
     protected const DEFAULT_KEY = 'masterKey';
 
+    protected const INFO_KEY = [
+        'description' => 'test',
+        'actions' => ['search'],
+        'indexes' => ['index'],
+        'expiresAt' => null,
+    ];
+
     /**
      * @var Client
      */


### PR DESCRIPTION
### Breaking Changes

Granular management of API keys is now added to MeiliSearch. New methods have been created to manage this:
- `http.patch` use by `updateKey`
- `client.getKey` get information about a specific API key.
- `client.createKey` create a new API key.
- `client.deleteKey` delete an API key.
- `client.updateKey` update an API key.