### PR TITLE
Extract functionality to a more specific class

### DIFF
--- a/src/Exceptions/JsonDecodingException.php
+++ b/src/Exceptions/JsonDecodingException.php
@@ -7,7 +7,7 @@ namespace MeiliSearch\Exceptions;
 use Exception;
 use Throwable;
 
-final class FailedJsonEncodingException extends Exception
+final class JsonDecodingException extends Exception
 {
     public function __construct(string $message, int $code = 0, ?Throwable $previous = null)
     {

--- a/src/Exceptions/JsonEncodingException.php
+++ b/src/Exceptions/JsonEncodingException.php
@@ -7,7 +7,7 @@ namespace MeiliSearch\Exceptions;
 use Exception;
 use Throwable;
 
-final class FailedJsonDecodingException extends Exception
+final class JsonEncodingException extends Exception
 {
     public function __construct(string $message, int $code = 0, ?Throwable $previous = null)
     {

--- a/src/Http/Serialize/Json.php
+++ b/src/Http/Serialize/Json.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Http\Serialize;
+
+use JsonException;
+use MeiliSearch\Exceptions\JsonDecodingException;
+use MeiliSearch\Exceptions\JsonEncodingException;
+
+class Json implements SerializerInterface
+{
+    private const JSON_ENCODE_ERROR_MESSAGE = 'Encoding payload to json failed: "%s".';
+    private const JSON_DECODE_ERROR_MESSAGE = 'Decoding payload to json failed: "%s".';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function serialize($data)
+    {
+        try {
+            $encoded = json_encode($data, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new JsonEncodingException(sprintf(self::JSON_ENCODE_ERROR_MESSAGE, $e->getMessage()), $e->getCode(), $e);
+        }
+
+        return $encoded;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unserialize($string)
+    {
+        try {
+            $decoded = json_decode($string, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new JsonDecodingException(sprintf(self::JSON_DECODE_ERROR_MESSAGE, $e->getMessage()), $e->getCode(), $e);
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Http/Serialize/SerializerInterface.php
+++ b/src/Http/Serialize/SerializerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Http\Serialize;
+
+use MeiliSearch\Exceptions\JsonDecodingException;
+use MeiliSearch\Exceptions\JsonEncodingException;
+
+interface SerializerInterface
+{
+    /**
+     * Serialize data into string.
+     *
+     * @param string|int|float|bool|array|null $data
+     *
+     * @return string|bool
+     *
+     * @throws JsonEncodingException
+     */
+    public function serialize($data);
+
+    /**
+     * Unserialize the given string.
+     *
+     * @param string $string
+     *
+     * @return string|int|float|bool|array|null
+     *
+     * @throws JsonDecodingException
+     */
+    public function unserialize($string);
+}

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\FailedJsonEncodingException;
 use MeiliSearch\Exceptions\InvalidArgumentException;
+use MeiliSearch\Exceptions\JsonEncodingException;
 use Tests\TestCase;
 
 final class DocumentsTest extends TestCase
@@ -128,7 +128,7 @@ final class DocumentsTest extends TestCase
 
     public function testCannotAddDocumentWhenJsonEncodingFails(): void
     {
-        $this->expectException(FailedJsonEncodingException::class);
+        $this->expectException(JsonEncodingException::class);
         $this->expectExceptionMessage('Encoding payload to json failed: "Malformed UTF-8 characters, possibly incorrectly encoded".');
 
         $documents = ["\xB1\x31"];

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Http;
 
 use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\FailedJsonDecodingException;
-use MeiliSearch\Exceptions\FailedJsonEncodingException;
 use MeiliSearch\Exceptions\InvalidResponseBodyException;
+use MeiliSearch\Exceptions\JsonDecodingException;
+use MeiliSearch\Exceptions\JsonEncodingException;
 use MeiliSearch\Http\Client;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -42,7 +42,7 @@ class ClientTest extends TestCase
     {
         $client = new Client('https://localhost');
 
-        $this->expectException(FailedJsonEncodingException::class);
+        $this->expectException(JsonEncodingException::class);
         $this->expectExceptionMessage('Encoding payload to json failed: "Malformed UTF-8 characters, possibly incorrectly encoded".');
 
         $client->post('/', "{'Bad JSON':\xB1\x31}");
@@ -57,8 +57,8 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
-        $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
+        $this->expectException(JsonDecodingException::class);
+        $this->expectExceptionMessage('Decoding payload to json failed: "Syntax error"');
 
         $client->post('/', '');
     }
@@ -89,7 +89,7 @@ class ClientTest extends TestCase
     {
         $client = new Client('https://localhost');
 
-        $this->expectException(FailedJsonEncodingException::class);
+        $this->expectException(JsonEncodingException::class);
         $this->expectExceptionMessage('Encoding payload to json failed: "Malformed UTF-8 characters, possibly incorrectly encoded".');
 
         $client->put('/', "{'Bad JSON':\xB1\x31}");
@@ -104,8 +104,8 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
-        $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
+        $this->expectException(JsonDecodingException::class);
+        $this->expectExceptionMessage('Decoding payload to json failed: "Syntax error"');
 
         $client->put('/', '');
     }
@@ -136,7 +136,7 @@ class ClientTest extends TestCase
     {
         $client = new Client('https://localhost');
 
-        $this->expectException(FailedJsonEncodingException::class);
+        $this->expectException(JsonEncodingException::class);
         $this->expectExceptionMessage('Encoding payload to json failed: "Malformed UTF-8 characters, possibly incorrectly encoded".');
 
         $client->patch('/', "{'Bad JSON':\xB1\x31}");
@@ -151,8 +151,8 @@ class ClientTest extends TestCase
 
         $client = new Client('https://localhost', null, $httpClient);
 
-        $this->expectException(FailedJsonDecodingException::class);
-        $this->expectExceptionMessage('Decoding json payload failed: "Syntax error".');
+        $this->expectException(JsonDecodingException::class);
+        $this->expectExceptionMessage('Decoding payload to json failed: "Syntax error"');
 
         $client->put('/', '');
     }

--- a/tests/Http/Serialize/JsonTest.php
+++ b/tests/Http/Serialize/JsonTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Http\Serialize;
+
+use MeiliSearch\Exceptions\JsonDecodingException;
+use MeiliSearch\Exceptions\JsonEncodingException;
+use MeiliSearch\Http\Serialize\Json;
+use PHPUnit\Framework\TestCase;
+
+class JsonTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $data = ['id' => 287947, 'title' => 'Some ID'];
+        $json = new Json();
+        $this->assertEquals(json_encode($data), $json->serialize($data));
+    }
+
+    public function testSerializeWithInvalidData(): void
+    {
+        $data = ['id' => NAN, 'title' => NAN];
+        $json = new Json();
+        $this->expectException(JsonEncodingException::class);
+        $this->expectExceptionMessage('Encoding payload to json failed: "Inf and NaN cannot be JSON encoded".');
+        $this->assertEquals(json_encode($data), $json->serialize($data));
+    }
+
+    public function testUnserialize(): void
+    {
+        $data = '{"id":287947,"title":"Some ID"}';
+        $json = new Json();
+        $this->assertEquals(['id' => 287947, 'title' => 'Some ID'], $json->unserialize($data));
+    }
+
+    public function testUnserializeWithInvalidData(): void
+    {
+        $data = "{'id':287947,'title':'\xB1\x31'}";
+        $json = new Json();
+        $this->expectException(JsonDecodingException::class);
+        $this->expectExceptionMessage('Decoding payload to json failed: "Syntax error"');
+        $this->assertEquals(['id' => 287947, 'title' => 'Some ID'], $json->unserialize($data));
+    }
+}


### PR DESCRIPTION
# Pull Request
This PR is a copy of #270  to check the pipeline.

## What does this PR do?
 Applies clean code.
- Rename FailedJsonDecodingException to JsonDecodingException and FailedJsonEncodingException to JsonEncodingException, due to the Exception already making clear that it's a failure.
- Created a unique separated class to be used as JSON encode/decode across the system.
- Standardized the JSON Exception return messages.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
