### PR TITLE
add phpstorm folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 /vendor/
 .php_cs.cache
 .vscode/
+.idea/


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This pull request adds to .gitignore the files generated by the PHPStorm, which is one of the most used PHP IDE.

I was thinking of using the [Gitignore.io](https://www.gitignore.io/) to generate it but I don't know if all those need to be added for this project, [here is the complete list for PHPStorm](https://www.toptal.com/developers/gitignore/api/phpstorm).

If you want, I can recreate the PR with the complete items added to `.gitignore`, just let me know so I can change, otherwise, we can merge with only the `.idea`.
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
