### PR TITLE
Make settings and synonyms be classes so they can be serialized properly

### DIFF
--- a/src/Contracts/Data.php
+++ b/src/Contracts/Data.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+class Data implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    protected $data = [];
+
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->data[$offset]) || \array_key_exists($offset, $this->data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->data[$offset]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function offsetGet($offset)
+    {
+        if (isset($this->data[$offset])) {
+            return $this->data[$offset];
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->data);
+    }
+}

--- a/src/Contracts/Index/Settings.php
+++ b/src/Contracts/Index/Settings.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts\Index;
+
+use MeiliSearch\Contracts\Data;
+
+class Settings extends Data implements \JsonSerializable
+{
+    public function __construct(array $data = [])
+    {
+        $data['synonyms'] = new Synonyms($data['synonyms'] ?? []);
+        parent::__construct($data);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->getIterator()->getArrayCopy();
+    }
+}

--- a/src/Contracts/Index/Synonyms.php
+++ b/src/Contracts/Index/Synonyms.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts\Index;
+
+use MeiliSearch\Contracts\Data;
+
+class Synonyms extends Data implements \JsonSerializable
+{
+    public function jsonSerialize(): object
+    {
+        return (object) $this->getIterator()->getArrayCopy();
+    }
+}

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints\Delegates;
 
+use MeiliSearch\Contracts\Index\Synonyms;
+
 trait HandlesSettings
 {
     // Settings - Ranking rules
@@ -95,18 +97,13 @@ trait HandlesSettings
 
     public function getSynonyms(): array
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/settings/synonyms');
+        return (new Synonyms($this->http->get(self::PATH.'/'.$this->uid.'/settings/synonyms')))
+            ->getIterator()->getArrayCopy();
     }
 
     public function updateSynonyms(array $synonyms): array
     {
-        // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204.
-        // Should be removed when implementing https://github.com/meilisearch/meilisearch-php/issues/209
-        if (0 === \count($synonyms)) {
-            $synonyms = null;
-        }
-
-        return $this->http->post(self::PATH.'/'.$this->uid.'/settings/synonyms', $synonyms);
+        return $this->http->post(self::PATH.'/'.$this->uid.'/settings/synonyms', new Synonyms($synonyms));
     }
 
     public function resetSynonyms(): array

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -8,6 +8,7 @@ use DateTime;
 use Exception;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Contracts\Http;
+use MeiliSearch\Contracts\Index\Settings;
 use MeiliSearch\Endpoints\Delegates\HandlesDocuments;
 use MeiliSearch\Endpoints\Delegates\HandlesSettings;
 use MeiliSearch\Endpoints\Delegates\HandlesTasks;
@@ -198,17 +199,12 @@ class Indexes extends Endpoint
 
     public function getSettings(): array
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/settings');
+        return (new Settings($this->http->get(self::PATH.'/'.$this->uid.'/settings')))
+            ->getIterator()->getArrayCopy();
     }
 
     public function updateSettings($settings): array
     {
-        // Patch related to https://github.com/meilisearch/meilisearch-php/issues/204
-        // Should be removed when implementing https://github.com/meilisearch/meilisearch-php/issues/209
-        if (\array_key_exists('synonyms', $settings) && 0 == \count($settings['synonyms'])) {
-            $settings['synonyms'] = null;
-        }
-
         return $this->http->post(self::PATH.'/'.$this->uid.'/settings', $settings);
     }
 

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -40,7 +40,7 @@ final class SettingsTest extends TestCase
         $this->assertEquals(self::DEFAULT_DISPLAYED_ATTRIBUTES, $settingA['displayedAttributes']);
         $this->assertIsArray($settingA['stopWords']);
         $this->assertEmpty($settingA['stopWords']);
-        $this->assertIsArray($settingA['synonyms']);
+        $this->assertIsIterable($settingA['synonyms']);
         $this->assertEmpty($settingA['synonyms']);
         $this->assertIsArray($settingA['filterableAttributes']);
         $this->assertEmpty($settingA['filterableAttributes']);
@@ -53,7 +53,7 @@ final class SettingsTest extends TestCase
         $this->assertEquals(self::DEFAULT_DISPLAYED_ATTRIBUTES, $settingB['displayedAttributes']);
         $this->assertIsArray($settingB['stopWords']);
         $this->assertEmpty($settingB['stopWords']);
-        $this->assertIsArray($settingB['synonyms']);
+        $this->assertIsIterable($settingB['synonyms']);
         $this->assertEmpty($settingB['synonyms']);
         $this->assertIsArray($settingB['filterableAttributes']);
         $this->assertEmpty($settingB['filterableAttributes']);
@@ -81,7 +81,7 @@ final class SettingsTest extends TestCase
         $this->assertIsArray($settings['displayedAttributes']);
         $this->assertEquals(self::DEFAULT_DISPLAYED_ATTRIBUTES, $settings['displayedAttributes']);
         $this->assertEquals(['the'], $settings['stopWords']);
-        $this->assertIsArray($settings['synonyms']);
+        $this->assertIsIterable($settings['synonyms']);
         $this->assertEmpty($settings['synonyms']);
         $this->assertIsArray($settings['filterableAttributes']);
         $this->assertEmpty($settings['filterableAttributes']);
@@ -116,7 +116,7 @@ final class SettingsTest extends TestCase
         $this->assertIsArray($settings['displayedAttributes']);
         $this->assertEquals(self::DEFAULT_SEARCHABLE_ATTRIBUTES, $settings['displayedAttributes']);
         $this->assertEquals(['the'], $settings['stopWords']);
-        $this->assertIsArray($settings['synonyms']);
+        $this->assertIsIterable($settings['synonyms']);
         $this->assertEmpty($settings['synonyms']);
         $this->assertIsArray($settings['filterableAttributes']);
         $this->assertEmpty($settings['filterableAttributes']);
@@ -150,7 +150,7 @@ final class SettingsTest extends TestCase
         $this->assertEquals(self::DEFAULT_SEARCHABLE_ATTRIBUTES, $settings['displayedAttributes']);
         $this->assertIsArray($settings['stopWords']);
         $this->assertEmpty($settings['stopWords']);
-        $this->assertIsArray($settings['synonyms']);
+        $this->assertIsIterable($settings['synonyms']);
         $this->assertEmpty($settings['synonyms']);
         $this->assertIsArray($settings['filterableAttributes']);
         $this->assertEmpty($settings['filterableAttributes']);

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -20,6 +20,9 @@ final class SynonymsTest extends TestCase
     public function testGetDefaultSynonyms(): void
     {
         $this->assertEmpty($this->index->getSynonyms());
+        $response = $this->index->getSynonyms();
+
+        $this->assertEmpty($response);
     }
 
     public function testUpdateSynonyms(): void


### PR DESCRIPTION
This pull request introduces 2 new classes to the Project: Settings and Synonyms.
Both extend from Data, the Data class act as a container to support the other 2 so we can have array access.

# Pull Request

## What does this PR do?
Fixes #209
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
