### PR TITLE
Add .gitattributes file for smaller archive size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+/.github export-ignore
+/scripts export-ignore
+/tests export-ignore
+.code-samples.meilisearch.yaml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+bors.toml export-ignore
+CONTRIBUTING.md export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This is not a fix for any occuring issue but rather an enhancement. Many PHP projects and librarys (e.g. Symfony and Laravel) make use of the .gitattributes file to generate smaller bundles for packagist/composer. When installing the library via composer, the composer command will get the zip archive by default (--prefer-dist) which previously included the `tests` directory and other unnecessary files. With this PR the exported files are `src/`, `composer.json`, `README.md`

You can compare the archive sizes with these links:

[Origin branch ZIP-export](https://github.com/meilisearch/meilisearch-php/archive/refs/heads/main.zip)
[Updated branch ZIP-export](https://github.com/mmachatschek/meilisearch-php/archive/refs/heads/add_git_attributes.zip)

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
