### PR TITLE
Make use of environment variable in PHPUnit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,4 @@
 bors.toml export-ignore
 CONTRIBUTING.md export-ignore
 phpstan.neon export-ignore
-phpunit.xml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-composer.lock
 /vendor/
-.php-cs-fixer.cache
 .vscode/
 .idea/
+.php-cs-fixer.cache
+composer.lock
+phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,8 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="HOST" value="http://localhost:7700"/>
+        <env name="API_KEY" value="masterKey"/>
+    </php>
 </phpunit>

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -25,7 +25,7 @@ final class KeysAndPermissionsTest extends TestCase
 
     public function testExceptionIfNoMasterKeyProvided(): void
     {
-        $newClient = new Client(self::HOST);
+        $newClient = new Client($this->host);
 
         $this->expectException(ApiException::class);
         $newClient->index('index')->search('test');
@@ -37,7 +37,7 @@ final class KeysAndPermissionsTest extends TestCase
         $response = $this->client->index('index')->getSettings();
         $this->assertEquals(['*'], $response['searchableAttributes']);
 
-        $newClient = new Client(self::HOST, 'bad-key');
+        $newClient = new Client($this->host, 'bad-key');
 
         $this->expectException(ApiException::class);
         $newClient->index('index')->getSettings();
@@ -46,7 +46,7 @@ final class KeysAndPermissionsTest extends TestCase
     public function testExceptionIfBadKeyProvidedToGetKeys(): void
     {
         $this->expectException(ApiException::class);
-        $client = new Client(self::HOST, 'bad-key');
+        $client = new Client($this->host, 'bad-key');
         $client->getKeys();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,10 +20,6 @@ abstract class TestCase extends BaseTestCase
         ['id' => 42, 'title' => 'The Hitchhiker\'s Guide to the Galaxy'],
     ];
 
-    protected const HOST = 'http://localhost:7700';
-
-    protected const DEFAULT_KEY = 'masterKey';
-
     protected const INFO_KEY = [
         'description' => 'test',
         'actions' => ['search'],
@@ -35,11 +31,14 @@ abstract class TestCase extends BaseTestCase
      * @var Client
      */
     protected $client;
+    protected $host;
+    protected $defaultKey;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = new Client(self::HOST, self::DEFAULT_KEY);
+        $this->host = getenv('HOST');
+        $this->client = new Client($this->host, getenv('API_KEY'));
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
# Pull Request

## What does this PR do?
DX enhancement

This will make it possible to override the default HOST and APIKEY parameter without modifying the base `TestCase` class. If you run multiple instances of meilisearch locally you just need to copy the `phpunit.xml.dist` to `phpunit.xml` and override the appropriate value. `phpunit.xml` is ignored by git. PHPunit will use `phpunit.xml.dist` only if `phpunit.xml` doesn't exist.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
