### PR TITLE
Drop PHP 7.3 support

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
     name: integration-tests-against-rc (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
     name: integration-tests (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v1

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,6 @@
 status = [
     'linter-check',
     'phpstan-tests',
-    'integration-tests (PHP 7.3)',
     'integration-tests (PHP 7.4)',
     'integration-tests (PHP 8.0)',
     'integration-tests (PHP 8.1)'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "php-http/discovery": "^1.7",
         "php-http/httplug": "^2.1",


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #179

This sets the minimum PHP-version to 7.4 which still receives security fixes. PHP 7.3 has [reached its EOL](https://www.php.net/supported-versions.php) in december.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
