### PR TITLE
Add a func to main class with qualified version

### DIFF
--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -7,4 +7,9 @@ namespace MeiliSearch;
 class MeiliSearch
 {
     public const VERSION = '0.21.0';
+
+    public static function qualifiedVersion()
+    {
+        return sprintf('Meilisearch PHP (v%s)', MeiliSearch::VERSION);
+    }
 }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use MeiliSearch\MeiliSearch;
+
+class VersionTest extends TestCase
+{
+    public function testQualifiedVersion(): void
+    {
+        $qualifiedVersion = sprintf('Meilisearch PHP (v%s)', MeiliSearch::VERSION);
+
+        $this->assertEquals(MeiliSearch::qualifiedVersion(), $qualifiedVersion);
+    }
+}


### PR DESCRIPTION
- Add a function to respond with the full qualified version for the PHP SDK: `"Meilisearch PHP (v0.21.0)"`.

Related to https://github.com/meilisearch/integration-guides/issues/150