### PR TITLE
Adding generateTenantToken method to the client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -15,6 +15,7 @@ use MeiliSearch\Endpoints\Indexes;
 use MeiliSearch\Endpoints\Keys;
 use MeiliSearch\Endpoints\Stats;
 use MeiliSearch\Endpoints\Tasks;
+use MeiliSearch\Endpoints\TenantToken;
 use MeiliSearch\Endpoints\Version;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -35,6 +36,7 @@ class Client
     private Stats $stats;
     private Tasks $tasks;
     private Dumps $dumps;
+    private TenantToken $tenantToken;
 
     public function __construct(
         string $url,
@@ -42,7 +44,6 @@ class Client
         ClientInterface $httpClient = null,
         RequestFactoryInterface $requestFactory = null
     ) {
-        $this->apiKey = $apiKey;
         $this->http = new Http\Client($url, $apiKey, $httpClient, $requestFactory);
         $this->index = new Indexes($this->http);
         $this->health = new Health($this->http);
@@ -51,5 +52,6 @@ class Client
         $this->tasks = new Tasks($this->http);
         $this->keys = new Keys($this->http);
         $this->dumps = new Dumps($this->http);
+        $this->tenantToken = new TenantToken($this->http, $apiKey);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -42,6 +42,7 @@ class Client
         ClientInterface $httpClient = null,
         RequestFactoryInterface $requestFactory = null
     ) {
+        $this->apiKey = $apiKey;
         $this->http = new Http\Client($url, $apiKey, $httpClient, $requestFactory);
         $this->index = new Indexes($this->http);
         $this->health = new Health($this->http);

--- a/src/Contracts/Endpoint.php
+++ b/src/Contracts/Endpoint.php
@@ -8,10 +8,12 @@ abstract class Endpoint
 {
     protected const PATH = '';
     protected Http $http;
+    protected ?string $apiKey;
 
-    public function __construct(Http $http)
+    public function __construct(Http $http, ?string $apiKey = null)
     {
         $this->http = $http;
+        $this->apiKey = $apiKey;
     }
 
     public function show(): ?array

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace MeiliSearch\Delegates;
+use MeiliSearch\Http\Serialize\Json;
 
 trait HandlesSystem
 {
@@ -30,5 +31,46 @@ trait HandlesSystem
     public function stats(): array
     {
         return $this->stats->show();
+    }
+
+    function base64url_encode($data) {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    public function generateTenantToken($parentApiKey, $payload)
+    {
+        $json = new Json();
+
+        // Standar JWT header for encryption with SHA256/HS256 algorithm
+        $header = array(
+            "typ"=> "JWT",
+            "alg"=> "HS256"
+          );
+
+        // Add the required fields with the prefix of the key
+        $payload['apiKeyPrefix'] = substr($parentApiKey, 0, 8);
+
+        // Serialize the Header
+        $jsonHeader = $json->serialize($header);
+
+        // Serialize the Payload
+        $jsonPayload = $json->serialize($payload);
+
+        // Encode Header to Base64Url String
+        $encodedHeader = $this->base64url_encode($jsonHeader);
+
+        // Encode Payload to Base64Url String
+        $encodedPayload = $this->base64url_encode($jsonPayload);
+
+        // Create Signature Hash
+        $signature = hash_hmac('sha256', $encodedHeader . "." . $encodedPayload, $parentApiKey, true);
+
+        // Encode Signature to Base64Url String
+        $encodedSignature = $this->base64url_encode($signature);
+
+        // Create JWT
+        $jwtToken = $encodedHeader . "." . $encodedPayload . "." . $encodedSignature;
+
+        return $jwtToken;
     }
 }

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -34,12 +34,12 @@ trait HandlesSystem
         return $this->stats->show();
     }
 
-    public static function base64url_encode($data)
+    public function base64url_encode($data)
     {
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
-    public function generateTenantToken($options, ?string $apiKey = null)
+    public function generateTenantToken($searchRules, ?string $expiresAt = null, ?string $apiKey = null): string
     {
         $json = new Json();
 
@@ -49,18 +49,22 @@ trait HandlesSystem
             'alg' => 'HS256',
           ];
 
-        if (!$apiKey) {
+        if (null == $apiKey) {
             $apiKey = $this->apiKey;
         }
 
-        // Add the required fields with the prefix of the key
-        $options['apiKeyPrefix'] = substr($apiKey, 0, 8);
+        // Add the required fields to the payload
+        $payload['apiKeyPrefix'] = substr($apiKey, 0, 8);
+        $payload['searchRules'] = $searchRules;
+        if ($expiresAt) {
+            $payload['exp'] = $expiredAt;
+        }
 
         // Serialize the Header
         $jsonHeader = $json->serialize($header);
 
         // Serialize the Payload
-        $jsonPayload = $json->serialize($options);
+        $jsonPayload = $json->serialize($payload);
 
         // Encode Header to Base64Url String
         $encodedHeader = $this->base64url_encode($jsonHeader);

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -39,11 +39,11 @@ trait HandlesSystem
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
-    public function generateTenantToken($searchRules, ?string $expiresAt = null, ?string $apiKey = null): string
+    public function generateTenantToken($searchRules, ?int $expiresAt = null, ?string $apiKey = null): string
     {
         $json = new Json();
 
-        // Standar JWT header for encryption with SHA256/HS256 algorithm
+        // Standard JWT header for encryption with SHA256/HS256 algorithm
         $header = [
             'typ' => 'JWT',
             'alg' => 'HS256',
@@ -57,7 +57,7 @@ trait HandlesSystem
         $payload['apiKeyPrefix'] = substr($apiKey, 0, 8);
         $payload['searchRules'] = $searchRules;
         if ($expiresAt) {
-            $payload['exp'] = $expiredAt;
+            $payload['exp'] = $expiresAt;
         }
 
         // Serialize the Header

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Delegates;
 
-use DateTime;
-use MeiliSearch\Exceptions\InvalidArgumentException;
-use MeiliSearch\Http\Serialize\Json;
-
 trait HandlesSystem
 {
     public function health(): ?array
@@ -36,71 +32,8 @@ trait HandlesSystem
         return $this->stats->show();
     }
 
-    public function base64url_encode($data)
-    {
-        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
-    }
-
-    /**
-     * Generate a new tenant token.
-     *
-     * The $options parameter is an array, and the following keys are accepted:
-     * - apiKey: The API key parent of the token. If you leave it empty the client API Key will be used.
-     * - expiresAt: A DateTime when the key will expire. Note that if an expiresAt value is included it should be in UTC time.
-     */
     public function generateTenantToken($searchRules, ?array $options = []): string
     {
-        // Validate every fields
-        if (!\array_key_exists('apiKey', $options) && null == $this->apiKey) {
-            throw InvalidArgumentException::emptyArgument('api key');
-        }
-        if (null == $searchRules) {
-            throw InvalidArgumentException::emptyArgument('search rules');
-        }
-        if (\array_key_exists('expiresAt', $options) && new DateTime() > $options['expiresAt']) {
-            throw InvalidArgumentException::dateIsExpired($options['expiresAt']);
-        }
-
-        $json = new Json();
-
-        // Standard JWT header for encryption with SHA256/HS256 algorithm
-        $header = [
-            'typ' => 'JWT',
-            'alg' => 'HS256',
-          ];
-
-        if (!\array_key_exists('apiKey', $options)) {
-            $options['apiKey'] = $this->apiKey;
-        }
-
-        // Add the required fields to the payload
-        $payload['apiKeyPrefix'] = substr($options['apiKey'], 0, 8);
-        $payload['searchRules'] = $searchRules;
-        if (\array_key_exists('expiresAt', $options)) {
-            $payload['exp'] = $options['expiresAt']->getTimestamp();
-        }
-
-        // Serialize the Header
-        $jsonHeader = $json->serialize($header);
-
-        // Serialize the Payload
-        $jsonPayload = $json->serialize($payload);
-
-        // Encode Header to Base64Url String
-        $encodedHeader = $this->base64url_encode($jsonHeader);
-
-        // Encode Payload to Base64Url String
-        $encodedPayload = $this->base64url_encode($jsonPayload);
-
-        // Create Signature Hash
-        $signature = hash_hmac('sha256', $encodedHeader.'.'.$encodedPayload, $options['apiKey'], true);
-
-        // Encode Signature to Base64Url String
-        $encodedSignature = $this->base64url_encode($signature);
-
-        // Create JWT
-        $jwtToken = $encodedHeader.'.'.$encodedPayload.'.'.$encodedSignature;
-
-        return $jwtToken;
+        return $this->tenantToken->generateTenantToken($searchRules, $options);
     }
 }

--- a/src/Endpoints/TenantToken.php
+++ b/src/Endpoints/TenantToken.php
@@ -20,7 +20,7 @@ class TenantToken extends Endpoint
         if (!\array_key_exists('apiKey', $options) || '' == $options['apiKey'] || strlen($options['apiKey']) <= 8) {
             throw InvalidArgumentException::emptyArgument('api key');
         }
-        if (null == $searchRules) {
+        if ((!is_array($searchRules) && !is_object($searchRules)) || null == $searchRules) {
             throw InvalidArgumentException::emptyArgument('search rules');
         }
         if (\array_key_exists('expiresAt', $options) && new DateTime() > $options['expiresAt']) {

--- a/src/Endpoints/TenantToken.php
+++ b/src/Endpoints/TenantToken.php
@@ -25,7 +25,7 @@ class TenantToken extends Endpoint
      */
     public function generateTenantToken($searchRules, ?array $options = []): string
     {
-        // Validate every fields
+        // Validate every field
         if ((!\array_key_exists('apiKey', $options) || '' == $options['apiKey']) && \is_null($this->apiKey)) {
             throw InvalidArgumentException::emptyArgument('api key');
         }

--- a/src/Endpoints/TenantToken.php
+++ b/src/Endpoints/TenantToken.php
@@ -16,17 +16,19 @@ class TenantToken extends Endpoint
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
-    private function validateTenantTokenArguments($searchRules, ?array $options = []) {
-        if (!\array_key_exists('apiKey', $options) || '' == $options['apiKey'] || strlen($options['apiKey']) <= 8) {
+    private function validateTenantTokenArguments($searchRules, ?array $options = []): void
+    {
+        if (!\array_key_exists('apiKey', $options) || '' == $options['apiKey'] || \strlen($options['apiKey']) <= 8) {
             throw InvalidArgumentException::emptyArgument('api key');
         }
-        if ((!is_array($searchRules) && !is_object($searchRules)) || null == $searchRules) {
+        if ((!\is_array($searchRules) && !\is_object($searchRules)) || null == $searchRules) {
             throw InvalidArgumentException::emptyArgument('search rules');
         }
         if (\array_key_exists('expiresAt', $options) && new DateTime() > $options['expiresAt']) {
             throw InvalidArgumentException::dateIsExpired($options['expiresAt']);
         }
     }
+
     /**
      * Generate a new tenant token.
      *

--- a/src/Endpoints/TenantToken.php
+++ b/src/Endpoints/TenantToken.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Endpoints;
+
+use DateTime;
+use MeiliSearch\Contracts\Endpoint;
+use MeiliSearch\Exceptions\InvalidArgumentException;
+use MeiliSearch\Http\Serialize\Json;
+
+class TenantToken extends Endpoint
+{
+    private function base64url_encode($data)
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Generate a new tenant token.
+     *
+     * The $options parameter is an array, and the following keys are accepted:
+     * - apiKey: The API key parent of the token. If you leave it empty the client API Key will be used.
+     * - expiresAt: A DateTime when the key will expire. Note that if an expiresAt value is included it should be in UTC time.
+     */
+    public function generateTenantToken($searchRules, ?array $options = []): string
+    {
+        // Validate every fields
+        if ((!\array_key_exists('apiKey', $options) || '' == $options['apiKey']) && \is_null($this->apiKey)) {
+            throw InvalidArgumentException::emptyArgument('api key');
+        }
+        if (null == $searchRules) {
+            throw InvalidArgumentException::emptyArgument('search rules');
+        }
+        if (\array_key_exists('expiresAt', $options) && new DateTime() > $options['expiresAt']) {
+            throw InvalidArgumentException::dateIsExpired($options['expiresAt']);
+        }
+
+        $json = new Json();
+
+        // Standard JWT header for encryption with SHA256/HS256 algorithm
+        $header = [
+            'typ' => 'JWT',
+            'alg' => 'HS256',
+          ];
+
+        if (!\array_key_exists('apiKey', $options)) {
+            $options['apiKey'] = $this->apiKey;
+        }
+
+        // Add the required fields to the payload
+        $payload = [];
+        $payload['apiKeyPrefix'] = substr($options['apiKey'], 0, 8);
+        $payload['searchRules'] = $searchRules;
+        if (\array_key_exists('expiresAt', $options)) {
+            $payload['exp'] = $options['expiresAt']->getTimestamp();
+        }
+
+        // Serialize the Header
+        $jsonHeader = $json->serialize($header);
+
+        // Serialize the Payload
+        $jsonPayload = $json->serialize($payload);
+
+        // Encode Header to Base64Url String
+        $encodedHeader = $this->base64url_encode($jsonHeader);
+
+        // Encode Payload to Base64Url String
+        $encodedPayload = $this->base64url_encode($jsonPayload);
+
+        // Create Signature Hash
+        $signature = hash_hmac('sha256', $encodedHeader.'.'.$encodedPayload, $options['apiKey'], true);
+
+        // Encode Signature to Base64Url String
+        $encodedSignature = $this->base64url_encode($signature);
+
+        // Create JWT
+        $jwtToken = $encodedHeader.'.'.$encodedPayload.'.'.$encodedSignature;
+
+        return $jwtToken;
+    }
+}

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Exceptions;
 
+use DateTime;
 use Exception;
 
 final class InvalidArgumentException extends Exception
@@ -21,6 +22,15 @@ final class InvalidArgumentException extends Exception
     {
         return new self(
             sprintf('Argument "%s" is empty.', $argumentName),
+            400,
+            null
+        );
+    }
+
+    public static function dateIsExpired(DateTime $date): self
+    {
+        return new self(
+            sprintf('DateTime "%s" is expired. The date expiresAt should be in the future.', $date->format('Y-m-d H:i:s')),
             400,
             null
         );

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -79,6 +79,7 @@ final class KeysAndPermissionsTest extends TestCase
         $response = $this->client->getKey($key->getKey());
 
         $this->assertNotNull($response->getKey());
+        $this->assertNull($response->getDescription());
         $this->assertIsArray($response->getActions());
         $this->assertIsArray($response->getIndexes());
         $this->assertNull($response->getExpiresAt());
@@ -99,6 +100,7 @@ final class KeysAndPermissionsTest extends TestCase
         $key = $this->client->createKey(self::INFO_KEY);
 
         $this->assertNotNull($key->getKey());
+        $this->assertNull($key->getDescription());
         $this->assertIsArray($key->getActions());
         $this->assertSame($key->getActions(), self::INFO_KEY['actions']);
         $this->assertIsArray($key->getIndexes());

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -22,9 +22,9 @@ final class TenantTokenTest extends TestCase
         $this->createEmptyIndex('tenantToken');
 
         $response = $this->client->getKeys();
-        $this->privateKey = array_reduce($response['results'], function ($carry, $item) {
-            if (array_key_exists('description', $item) && $item['description'] && str_contains($item['description'], 'Default Admin API')) {
-                return $item['key'];
+        $this->privateKey = array_reduce($response, function ($carry, $item) {
+            if ($item->getDescription() && str_contains($item->getDescription(), 'Default Admin API')) {
+                return $item->getKey();
             }
         });
         $this->privateClient = new Client($this->host, $this->privateKey);

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -40,11 +40,6 @@ final class TenantTokenTest extends TestCase
         $response = $tokenClient->index('tenantToken')->search('');
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('offset', $response->toArray());
-        $this->assertArrayHasKey('limit', $response->toArray());
-        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
-        $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(7, $response->getNbHits());
         $this->assertCount(7, $response->getHits());
     }
 
@@ -58,11 +53,6 @@ final class TenantTokenTest extends TestCase
         $response = $tokenClient->index('tenantToken')->search('');
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('offset', $response->toArray());
-        $this->assertArrayHasKey('limit', $response->toArray());
-        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
-        $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(7, $response->getNbHits());
         $this->assertCount(7, $response->getHits());
     }
 
@@ -80,17 +70,13 @@ final class TenantTokenTest extends TestCase
         $response = $tokenClient->index('tenantToken')->search('');
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('offset', $response->toArray());
-        $this->assertArrayHasKey('limit', $response->toArray());
-        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
-        $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(4, $response->getNbHits());
         $this->assertCount(4, $response->getHits());
     }
 
     public function testGenerateTenantTokenWithSearchRulesOnOneIndex(): void
     {
         $this->createEmptyIndex('tenantTokenDuplicate');
+
         $token = $this->privateClient->generateTenantToken(['tenantToken']);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
@@ -98,7 +84,7 @@ final class TenantTokenTest extends TestCase
         $this->assertArrayHasKey('hits', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->expectException(ApiException::class);
-        $response = $tokenClient->index('tenantTokenDuplicate')->search('');
+        $tokenClient->index('tenantTokenDuplicate')->search('');
     }
 
     public function testGenerateTenantTokenWithApiKey(): void
@@ -106,15 +92,12 @@ final class TenantTokenTest extends TestCase
         $options = [
             'apiKey' => $this->privateKey,
         ];
+
         $token = $this->client->generateTenantToken(['*'], $options);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('offset', $response->toArray());
-        $this->assertArrayHasKey('limit', $response->toArray());
-        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
-        $this->assertArrayHasKey('query', $response->toArray());
     }
 
     public function testGenerateTenantTokenWithExpiresAt(): void
@@ -125,21 +108,18 @@ final class TenantTokenTest extends TestCase
         $options = [
             'expiresAt' => $tomorrow,
         ];
+
         $token = $this->privateClient->generateTenantToken(['*'], $options);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('offset', $response->toArray());
-        $this->assertArrayHasKey('limit', $response->toArray());
-        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
-        $this->assertArrayHasKey('query', $response->toArray());
     }
 
     public function testGenerateTenantTokenWithSearchRulesEmptyArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $token = $this->privateClient->generateTenantToken([]);
+        $this->privateClient->generateTenantToken([]);
     }
 
     public function testGenerateTenantTokenWithBadExpiresAt(): void
@@ -152,20 +132,22 @@ final class TenantTokenTest extends TestCase
         ];
 
         $this->expectException(InvalidArgumentException::class);
-        $token = $this->privateClient->generateTenantToken(['*'], $options);
+        $this->privateClient->generateTenantToken(['*'], $options);
     }
 
     public function testGenerateTenantTokenWithNoApiKey(): void
     {
         $client = new Client($this->host);
+
         $this->expectException(InvalidArgumentException::class);
-        $token = $client->generateTenantToken(['*']);
+        $client->generateTenantToken(['*']);
     }
 
     public function testGenerateTenantTokenWithEmptyApiKey(): void
     {
         $client = new Client($this->host);
+
         $this->expectException(InvalidArgumentException::class);
-        $token = $client->generateTenantToken(['*'], ['apiKey' => '']);
+        $client->generateTenantToken(['*'], ['apiKey' => '']);
     }
 }

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -34,7 +34,7 @@ final class TenantTokenTest extends TestCase
         $promise = $this->client->index('tenantToken')->addDocuments(self::DOCUMENTS);
         $this->client->waitForTask($promise['uid']);
 
-        $token = $this->privateClient->generateTenantToken(searchRules: ['*']);
+        $token = $this->privateClient->generateTenantToken(['*']);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
@@ -50,7 +50,7 @@ final class TenantTokenTest extends TestCase
     public function testGenerateTenantTokenWithSearchRulesOnOneIndex(): void
     {
         $this->createEmptyIndex('tenantTokenDuplicate');
-        $token = $this->privateClient->generateTenantToken(searchRules: ['tenantToken']);
+        $token = $this->privateClient->generateTenantToken(['tenantToken']);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
@@ -62,7 +62,10 @@ final class TenantTokenTest extends TestCase
 
     public function testGenerateTenantTokenWithApiKey(): void
     {
-        $token = $this->client->generateTenantToken(searchRules: ['*'], apiKey: $this->privateKey);
+        $options = [
+            'apiKey' => $this->privateKey,
+        ];
+        $token = $this->client->generateTenantToken(['*'], $options);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
@@ -77,8 +80,10 @@ final class TenantTokenTest extends TestCase
     {
         $date = new DateTime();
         $tomorrow = $date->modify('+1 day');
-
-        $token = $this->privateClient->generateTenantToken(searchRules: ['*'], expiresAt: $tomorrow);
+        $options = [
+            'expiresAt' => $tomorrow,
+        ];
+        $token = $this->privateClient->generateTenantToken(['*'], $options);
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
@@ -92,28 +97,31 @@ final class TenantTokenTest extends TestCase
     public function testGenerateTenantTokenWithEmptySearchRules(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $token = $this->privateClient->generateTenantToken(searchRules: '');
+        $token = $this->privateClient->generateTenantToken('');
     }
 
     public function testGenerateTenantTokenWithSearchRulesEmptyArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $token = $this->privateClient->generateTenantToken(searchRules: []);
+        $token = $this->privateClient->generateTenantToken([]);
     }
 
     public function testGenerateTenantTokenWithBadExpiresAt(): void
     {
         $date = new DateTime();
         $yesterday = $date->modify('-1 day');
+        $options = [
+            'expiresAt' => $yesterday,
+        ];
 
         $this->expectException(InvalidArgumentException::class);
-        $token = $this->privateClient->generateTenantToken(searchRules: ['*'], expiresAt: $yesterday);
+        $token = $this->privateClient->generateTenantToken(['*'], $options);
     }
 
     public function testGenerateTenantTokenWithNoApiKey(): void
     {
         $client = new Client($this->host);
         $this->expectException(InvalidArgumentException::class);
-        $token = $client->generateTenantToken(searchRules: ['*']);
+        $token = $client->generateTenantToken(['*']);
     }
 }

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -124,6 +124,8 @@ final class TenantTokenTest extends TestCase
 
     public function testGenerateTenantTokenWithBadExpiresAt(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+
         /* @phpstan-ignore-next-line */
         $date = new DateTime();
         $yesterday = $date->modify('-1 day');
@@ -131,7 +133,6 @@ final class TenantTokenTest extends TestCase
             'expiresAt' => $yesterday,
         ];
 
-        $this->expectException(InvalidArgumentException::class);
         $this->privateClient->generateTenantToken(['*'], $options);
     }
 

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Endpoints;
+
+use DateTimeInterface;
+use Tests\TestCase;
+use MeiliSearch\Client;
+use MeiliSearch\Exceptions\ApiException;
+use \Datetime;
+
+final class TenantTokenTest extends TestCase
+{
+    private string $privateKey;
+    private Client $privateClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $index = $this->createEmptyIndex('tenantToken');
+        $promise = $index->addDocuments(self::DOCUMENTS);
+        $index->waitForTask($promise['uid']);
+
+        $response = $this->client->getKeys();
+        $this->privateKey = array_reduce($response['results'], function ($carry, $item) {
+            if (str_contains($item['description'], 'Default Admin API')) {
+                return $item['key'];
+            }
+        });
+        $this->privateClient = new Client($this->host, $this->privateKey);
+    }
+
+    public function testGenerateTenantTokenWithSearchRulesOnly(): void
+    {
+        $token = $this->privateClient->generateTenantToken(searchRules: array('*'));
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+        $response = $tokenClient->index('tenantToken')->search('');
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame(7, $response->getNbHits());
+        $this->assertCount(7, $response->getHits());
+    }
+
+    public function testGenerateTenantTokenWithApiKey(): void
+    {
+        $token = $this->client->generateTenantToken(searchRules: array('*'), apiKey: $this->privateKey);
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+        $response = $tokenClient->index('tenantToken')->search('');
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame(7, $response->getNbHits());
+        $this->assertCount(7, $response->getHits());
+    }
+
+    public function testGenerateTenantTokenWithExpiresAt(): void
+    {
+        $date = new DateTime();
+        $tomorrow = $date->modify('+1 day')->getTimestamp();
+
+        $token = $this->privateClient->generateTenantToken(searchRules: array('*'), expiresAt: $tomorrow);
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+        $response = $tokenClient->index('tenantToken')->search('');
+
+        $this->assertArrayHasKey('hits', $response->toArray());
+        $this->assertArrayHasKey('offset', $response->toArray());
+        $this->assertArrayHasKey('limit', $response->toArray());
+        $this->assertArrayHasKey('processingTimeMs', $response->toArray());
+        $this->assertArrayHasKey('query', $response->toArray());
+        $this->assertSame(7, $response->getNbHits());
+        $this->assertCount(7, $response->getHits());
+    }
+
+
+    public function testGenerateTenantTokenWithoutSearchRules(): void
+    {
+        $token = $this->privateClient->generateTenantToken(searchRules: '');
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+
+        $this->expectException(ApiException::class);
+        $tokenClient->index('tenantToken')->search('');
+    }
+
+
+    public function testGenerateTenantTokenWithMasterKey(): void
+    {
+        $token = $this->client->generateTenantToken(array('*'));
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+
+        $this->expectException(ApiException::class);
+        $tokenClient->index('tenantToken')->search('');
+    }
+
+    public function testGenerateTenantTokenWithBadExpiresAt(): void
+    {
+        $date = new DateTime();
+        $yesterday = $date->modify('-2 day')->getTimestamp();
+
+        $token = $this->privateClient->generateTenantToken(searchRules: array('*'), expiresAt: $yesterday);
+        $tokenClient = new Client('http://127.0.0.1:7700', $token);
+
+        $this->expectException(ApiException::class);
+        $tokenClient->index('tenantToken')->search('');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,6 @@ abstract class TestCase extends BaseTestCase
     ];
 
     protected const INFO_KEY = [
-        'description' => 'test',
         'actions' => ['search'],
         'indexes' => ['index'],
         'expiresAt' => null,


### PR DESCRIPTION
## Tenant tokens

Introduction of the new method `generateTenantToken`  in order to facilitate the generation of the tenant token.

Related to:
- this issue: https://github.com/meilisearch/meilisearch/issues/1991
- this spec: https://github.com/meilisearch/specifications/pull/89
