### PR TITLE
Changes the Keys Class

### DIFF
--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints\Delegates;
 
+use MeiliSearch\Endpoints\Keys;
+
 trait HandlesKeys
 {
     public function getKeys(): array
@@ -11,17 +13,22 @@ trait HandlesKeys
         return $this->keys->all();
     }
 
-    public function getKey($key): array
+    public function getRawKeys(): array
+    {
+        return $this->keys->allRaw();
+    }
+
+    public function getKey($key): Keys
     {
         return $this->keys->get($key);
     }
 
-    public function createKey(array $options = []): array
+    public function createKey(array $options = []): Keys
     {
         return $this->keys->create($options);
     }
 
-    public function updateKey(string $key, array $options = []): array
+    public function updateKey(string $key, array $options = []): Keys
     {
         return $this->keys->update($key, $options);
     }

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints;
 
+use DateTime;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Contracts\Http;
 
@@ -15,9 +16,9 @@ class Keys extends Endpoint
     private ?string $description;
     private ?array $actions;
     private ?array $indexes;
-    private ?string $expiresAt;
-    private ?string $createdAt;
-    private ?string $updatedAt;
+    private ?DateTime $expiresAt;
+    private ?DateTime $createdAt;
+    private ?DateTime $updatedAt;
 
     public function __construct(Http $http, $key = null, $description = null, $actions = null, $indexes = null, $expiresAt = null, $createdAt = null, $updatedAt = null)
     {
@@ -25,39 +26,25 @@ class Keys extends Endpoint
         $this->description = $description;
         $this->actions = $actions;
         $this->indexes = $indexes;
-        $this->expiresAt = $expiresAt;
-        $this->createdAt = $createdAt;
-        $this->updatedAt = $updatedAt;
+        $this->expiresAt = $expiresAt ? $expiresAt->format('Y-m-d\TH:i:s\Z') : null;
+        $this->createdAt = $createdAt ? $createdAt->format('Y-m-d\TH:i:s.vu\Z') : null;
+        $this->updatedAt = $updatedAt ? $updatedAt->format('Y-m-d\TH:i:s.vu\Z') : null;
 
         parent::__construct($http);
-    }
-
-    protected function newInstance(array $attributes): self
-    {
-        return new self(
-            $this->http,
-            $attributes['key'],
-            $attributes['description'],
-            $attributes['actions'],
-            $attributes['indexes'],
-            $attributes['expiresAt'],
-            $attributes['createdAt'],
-            $attributes['updatedAt'],
-        );
     }
 
     /**
      * @return $this
      */
-    protected function fill(array $attributes): self
+    protected function newInstance(array $attributes): self
     {
         $this->key = $attributes['key'];
         $this->description = $attributes['description'];
         $this->actions = $attributes['actions'];
         $this->indexes = $attributes['indexes'];
-        $this->expiresAt = $attributes['expiresAt'];
-        $this->createdAt = $attributes['createdAt'];
-        $this->updatedAt = $attributes['updatedAt'];
+        $this->expiresAt = $attributes['expiresAt'] ? date_create_from_format('Y-m-d\TH:i:s\Z', $attributes['expiresAt']) : null;
+        $this->createdAt = $attributes['createdAt'] ? date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['createdAt']) : null;
+        $this->updatedAt = $attributes['updatedAt'] ? date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['updatedAt']) : null;
 
         return $this;
     }
@@ -82,17 +69,17 @@ class Keys extends Endpoint
         return $this->indexes;
     }
 
-    public function getExpiresAt(): ?string
+    public function getExpiresAt(): ?DateTime
     {
         return $this->expiresAt;
     }
 
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?DateTime
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?DateTime
     {
         return $this->updatedAt;
     }
@@ -101,7 +88,7 @@ class Keys extends Endpoint
     {
         $response = $this->http->get(self::PATH.'/'.$key);
 
-        return $this->fill($response);
+        return $this->newInstance($response);
     }
 
     public function all(): array
@@ -122,16 +109,22 @@ class Keys extends Endpoint
 
     public function create(array $options = []): self
     {
+        if ($options['expiresAt'] && $options['expiresAt'] instanceof DateTime) {
+            $options['expiresAt'] = $options['expiresAt']->format('Y-m-d\TH:i:s.vu\Z');
+        }
         $response = $this->http->post(self::PATH, $options);
 
-        return $this->fill($response);
+        return $this->newInstance($response);
     }
 
     public function update(string $key, array $options = []): self
     {
+        if ($options['expiresAt'] && $options['expiresAt'] instanceof DateTime) {
+            $options['expiresAt'] = $options['expiresAt'] ? $options['expiresAt']->format('Y-m-d\TH:i:s.vu\Z') : null;
+        }
         $response = $this->http->patch(self::PATH.'/'.$key, $options);
 
-        return $this->fill($response);
+        return $this->newInstance($response);
     }
 
     public function delete(string $key): array

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -5,29 +5,133 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints;
 
 use MeiliSearch\Contracts\Endpoint;
+use MeiliSearch\Contracts\Http;
 
 class Keys extends Endpoint
 {
     protected const PATH = '/keys';
 
-    public function get($key): array
+    private ?string $key;
+    private ?string $description;
+    private ?array $actions;
+    private ?array $indexes;
+    private ?string $expiresAt;
+    private ?string $createdAt;
+    private ?string $updatedAt;
+
+    public function __construct(Http $http, $key = null, $description = null, $actions = null, $indexes = null, $expiresAt = null, $createdAt = null, $updatedAt = null)
     {
-        return $this->http->get(self::PATH.'/'.$key);
+        $this->key = $key;
+        $this->description = $description;
+        $this->actions = $actions;
+        $this->indexes = $indexes;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
+
+        parent::__construct($http);
+    }
+
+    protected function newInstance(array $attributes): self
+    {
+        return new self(
+            $this->http,
+            $attributes['key'],
+            $attributes['description'],
+            $attributes['actions'],
+            $attributes['indexes'],
+            $attributes['expiresAt'],
+            $attributes['createdAt'],
+            $attributes['updatedAt'],
+        );
+    }
+
+    /**
+     * @return $this
+     */
+    protected function fill(array $attributes): self
+    {
+        $this->key = $attributes['key'];
+        $this->description = $attributes['description'];
+        $this->actions = $attributes['actions'];
+        $this->indexes = $attributes['indexes'];
+        $this->expiresAt = $attributes['expiresAt'];
+        $this->createdAt = $attributes['createdAt'];
+        $this->updatedAt = $attributes['updatedAt'];
+
+        return $this;
+    }
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getActions(): ?array
+    {
+        return $this->actions;
+    }
+
+    public function getIndexes(): ?array
+    {
+        return $this->indexes;
+    }
+
+    public function getExpiresAt(): ?string
+    {
+        return $this->expiresAt;
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->updatedAt;
+    }
+
+    public function get($key): self
+    {
+        $response = $this->http->get(self::PATH.'/'.$key);
+
+        return $this->fill($response);
     }
 
     public function all(): array
     {
+        $keys = [];
+
+        foreach ($this->allRaw()['results'] as $key) {
+            $keys[] = $this->newInstance($key);
+        }
+
+        return $keys;
+    }
+
+    public function allRaw(): array
+    {
         return $this->http->get(self::PATH.'/');
     }
 
-    public function create(array $options = []): array
+    public function create(array $options = []): self
     {
-        return $this->http->post(self::PATH, $options);
+        $response = $this->http->post(self::PATH, $options);
+
+        return $this->fill($response);
     }
 
-    public function update(string $key, array $options = []): array
+    public function update(string $key, array $options = []): self
     {
-        return $this->http->patch(self::PATH.'/'.$key, $options);
+        $response = $this->http->patch(self::PATH.'/'.$key, $options);
+
+        return $this->fill($response);
     }
 
     public function delete(string $key): array

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -26,9 +26,9 @@ class Keys extends Endpoint
         $this->description = $description;
         $this->actions = $actions;
         $this->indexes = $indexes;
-        $this->expiresAt = $expiresAt ? $expiresAt->format('Y-m-d\TH:i:s\Z') : null;
-        $this->createdAt = $createdAt ? $createdAt->format('Y-m-d\TH:i:s.vu\Z') : null;
-        $this->updatedAt = $updatedAt ? $updatedAt->format('Y-m-d\TH:i:s.vu\Z') : null;
+        $this->expiresAt = $expiresAt;
+        $this->createdAt = $createdAt;
+        $this->updatedAt = $updatedAt;
 
         parent::__construct($http);
     }
@@ -42,9 +42,15 @@ class Keys extends Endpoint
         $this->description = $attributes['description'];
         $this->actions = $attributes['actions'];
         $this->indexes = $attributes['indexes'];
-        $this->expiresAt = $attributes['expiresAt'] ? date_create_from_format('Y-m-d\TH:i:s\Z', $attributes['expiresAt']) : null;
-        $this->createdAt = $attributes['createdAt'] ? date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['createdAt']) : null;
-        $this->updatedAt = $attributes['updatedAt'] ? date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['updatedAt']) : null;
+        if ($attributes['expiresAt']) {
+            $this->expiresAt = date_create_from_format('Y-m-d\TH:i:s\Z', $attributes['expiresAt']);
+        }
+        if ($attributes['createdAt']) {
+            $this->createdAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['createdAt']);
+        }
+        if ($attributes['updatedAt']) {
+            $this->updatedAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['updatedAt']);
+        }
 
         return $this;
     }
@@ -120,7 +126,7 @@ class Keys extends Endpoint
     public function update(string $key, array $options = []): self
     {
         if ($options['expiresAt'] && $options['expiresAt'] instanceof DateTime) {
-            $options['expiresAt'] = $options['expiresAt'] ? $options['expiresAt']->format('Y-m-d\TH:i:s.vu\Z') : null;
+            $options['expiresAt'] = $options['expiresAt']->format('Y-m-d\TH:i:s.vu\Z');
         }
         $response = $this->http->patch(self::PATH.'/'.$key, $options);
 

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -110,13 +110,37 @@ final class KeysAndPermissionsTest extends TestCase
         $this->client->deleteKey($key->getKey());
     }
 
-    public function testCreateKeyWithOptions(): void
+    public function testCreateKeyWithExpInString(): void
     {
         $key = [
             'description' => 'test create',
             'actions' => ['search'],
             'indexes' => ['index'],
             'expiresAt' => date('Y-m-d', strtotime('+1 day')),
+        ];
+        $response = $this->client->createKey($key);
+
+        $this->assertNotNull($response->getKey());
+        $this->assertNotNull($response->getDescription());
+        $this->assertSame($response->getDescription(), 'test create');
+        $this->assertIsArray($response->getActions());
+        $this->assertSame($response->getActions(), ['search']);
+        $this->assertIsArray($response->getIndexes());
+        $this->assertSame($response->getIndexes(), ['index']);
+        $this->assertNotNull($response->getExpiresAt());
+        $this->assertNotNull($response->getCreatedAt());
+        $this->assertNotNull($response->getUpdatedAt());
+
+        $this->client->deleteKey($response->getKey());
+    }
+
+    public function testCreateKeyWithExpInDate(): void
+    {
+        $key = [
+            'description' => 'test create',
+            'actions' => ['search'],
+            'indexes' => ['index'],
+            'expiresAt' => date_create_from_format('Y-m-d', date('Y-m-d', strtotime('+1 day'))),
         ];
         $response = $this->client->createKey($key);
 
@@ -144,13 +168,36 @@ final class KeysAndPermissionsTest extends TestCase
         ]);
     }
 
-    public function testUpdateKey(): void
+    public function testUpdateKeyWithExpInString(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);
         $response = $this->client->updateKey($key->getKey(), [
             'description' => 'test update',
             'indexes' => ['*'],
             'expiresAt' => date('Y-m-d', strtotime('+1 day')),
+        ]);
+
+        $this->assertNotNull($response->getKey());
+        $this->assertNotNull($response->getDescription());
+        $this->assertSame($response->getDescription(), 'test update');
+        $this->assertIsArray($response->getActions());
+        $this->assertSame($response->getActions(), self::INFO_KEY['actions']);
+        $this->assertIsArray($response->getIndexes());
+        $this->assertSame($response->getIndexes(), ['*']);
+        $this->assertNotNull($response->getExpiresAt());
+        $this->assertNotNull($response->getCreatedAt());
+        $this->assertNotNull($response->getUpdatedAt());
+
+        $this->client->deleteKey($response->getKey());
+    }
+
+    public function testUpdateKeyWithExpInDate(): void
+    {
+        $key = $this->client->createKey(self::INFO_KEY);
+        $response = $this->client->updateKey($key->getKey(), [
+            'description' => 'test update',
+            'indexes' => ['*'],
+            'expiresAt' => date_create_from_format('Y-m-d', date('Y-m-d', strtotime('+1 day'))),
         ]);
 
         $this->assertNotNull($response->getKey());

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -10,6 +10,12 @@ use Tests\TestCase;
 
 final class KeysAndPermissionsTest extends TestCase
 {
+    public function testGetRawKeysAlwaysReturnsArray(): void
+    {
+        /* @phpstan-ignore-next-line */
+        $this->assertIsArray($this->client->getRawKeys());
+    }
+
     public function testGetKeysAlwaysReturnsArray(): void
     {
         /* @phpstan-ignore-next-line */
@@ -19,6 +25,18 @@ final class KeysAndPermissionsTest extends TestCase
     public function testGetKeysDefault(): void
     {
         $response = $this->client->getKeys();
+
+        $this->assertCount(2, $response);
+        $this->assertIsArray($response[0]->getActions());
+        $this->assertIsArray($response[0]->getIndexes());
+        $this->assertNull($response[0]->getExpiresAt());
+        $this->assertNotNull($response[0]->getCreatedAt());
+        $this->assertNotNull($response[0]->getUpdatedAt());
+    }
+
+    public function testGetRawKeysDefault(): void
+    {
+        $response = $this->client->getRawKeys();
 
         $this->assertCount(2, $response['results']);
         $this->assertArrayHasKey('actions', $response['results'][0]);
@@ -58,18 +76,16 @@ final class KeysAndPermissionsTest extends TestCase
     public function testGetKey(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);
-        $response = $this->client->getKey($key['key']);
+        $response = $this->client->getKey($key->getKey());
 
-        $this->assertArrayHasKey('key', $response);
-        $this->assertArrayHasKey('actions', $response);
-        $this->assertIsArray($response['actions']);
-        $this->assertIsArray($response['indexes']);
-        $this->assertArrayHasKey('indexes', $response);
-        $this->assertArrayHasKey('createdAt', $response);
-        $this->assertArrayHasKey('expiresAt', $response);
-        $this->assertArrayHasKey('updatedAt', $response);
+        $this->assertNotNull($response->getKey());
+        $this->assertIsArray($response->getActions());
+        $this->assertIsArray($response->getIndexes());
+        $this->assertNull($response->getExpiresAt());
+        $this->assertNotNull($response->getCreatedAt());
+        $this->assertNotNull($response->getUpdatedAt());
 
-        $this->client->deleteKey($key['key']);
+        $this->client->deleteKey($key->getKey());
     }
 
     public function testExceptionIfKeyDoesntExist(): void
@@ -82,21 +98,16 @@ final class KeysAndPermissionsTest extends TestCase
     {
         $key = $this->client->createKey(self::INFO_KEY);
 
-        $this->assertArrayHasKey('key', $key);
-        $this->assertArrayHasKey('actions', $key);
-        $this->assertIsArray($key['actions']);
-        $this->assertSame($key['actions'], self::INFO_KEY['actions']);
-        $this->assertIsArray($key['indexes']);
-        $this->assertArrayHasKey('indexes', $key);
-        $this->assertSame($key['indexes'], self::INFO_KEY['indexes']);
-        $this->assertArrayHasKey('createdAt', $key);
-        $this->assertNotNull($key['createdAt']);
-        $this->assertArrayHasKey('expiresAt', $key);
-        $this->assertNull($key['expiresAt']);
-        $this->assertArrayHasKey('updatedAt', $key);
-        $this->assertNotNull($key['updatedAt']);
+        $this->assertNotNull($key->getKey());
+        $this->assertIsArray($key->getActions());
+        $this->assertSame($key->getActions(), self::INFO_KEY['actions']);
+        $this->assertIsArray($key->getIndexes());
+        $this->assertSame($key->getIndexes(), self::INFO_KEY['indexes']);
+        $this->assertNull($key->getExpiresAt());
+        $this->assertNotNull($key->getCreatedAt());
+        $this->assertNotNull($key->getUpdatedAt());
 
-        $this->client->deleteKey($key['key']);
+        $this->client->deleteKey($key->getKey());
     }
 
     public function testCreateKeyWithOptions(): void
@@ -109,23 +120,18 @@ final class KeysAndPermissionsTest extends TestCase
         ];
         $response = $this->client->createKey($key);
 
-        $this->assertArrayHasKey('key', $response);
-        $this->assertArrayHasKey('description', $response);
-        $this->assertSame($response['description'], 'test create');
-        $this->assertArrayHasKey('actions', $response);
-        $this->assertIsArray($response['actions']);
-        $this->assertSame($response['actions'], ['search']);
-        $this->assertIsArray($response['indexes']);
-        $this->assertArrayHasKey('indexes', $response);
-        $this->assertSame($response['indexes'], ['index']);
-        $this->assertArrayHasKey('createdAt', $response);
-        $this->assertNotNull($response['createdAt']);
-        $this->assertArrayHasKey('expiresAt', $response);
-        $this->assertNotNull($response['expiresAt']);
-        $this->assertArrayHasKey('updatedAt', $response);
-        $this->assertNotNull($response['updatedAt']);
+        $this->assertNotNull($response->getKey());
+        $this->assertNotNull($response->getDescription());
+        $this->assertSame($response->getDescription(), 'test create');
+        $this->assertIsArray($response->getActions());
+        $this->assertSame($response->getActions(), ['search']);
+        $this->assertIsArray($response->getIndexes());
+        $this->assertSame($response->getIndexes(), ['index']);
+        $this->assertNotNull($response->getExpiresAt());
+        $this->assertNotNull($response->getCreatedAt());
+        $this->assertNotNull($response->getUpdatedAt());
 
-        $this->client->deleteKey($response['key']);
+        $this->client->deleteKey($response->getKey());
     }
 
     public function testCreateKeyWithoutActions(): void
@@ -141,37 +147,32 @@ final class KeysAndPermissionsTest extends TestCase
     public function testUpdateKey(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);
-        $response = $this->client->updateKey($key['key'], [
+        $response = $this->client->updateKey($key->getKey(), [
             'description' => 'test update',
             'indexes' => ['*'],
             'expiresAt' => date('Y-m-d', strtotime('+1 day')),
         ]);
 
-        $this->assertArrayHasKey('key', $response);
-        $this->assertArrayHasKey('description', $response);
-        $this->assertSame($response['description'], 'test update');
-        $this->assertArrayHasKey('actions', $response);
-        $this->assertIsArray($response['actions']);
-        $this->assertSame($response['actions'], self::INFO_KEY['actions']);
-        $this->assertIsArray($response['indexes']);
-        $this->assertArrayHasKey('indexes', $response);
-        $this->assertSame($response['indexes'], ['*']);
-        $this->assertArrayHasKey('createdAt', $response);
-        $this->assertNotNull($response['createdAt']);
-        $this->assertArrayHasKey('expiresAt', $response);
-        $this->assertNotNull($response['expiresAt']);
-        $this->assertArrayHasKey('updatedAt', $response);
-        $this->assertNotNull($response['updatedAt']);
+        $this->assertNotNull($response->getKey());
+        $this->assertNotNull($response->getDescription());
+        $this->assertSame($response->getDescription(), 'test update');
+        $this->assertIsArray($response->getActions());
+        $this->assertSame($response->getActions(), self::INFO_KEY['actions']);
+        $this->assertIsArray($response->getIndexes());
+        $this->assertSame($response->getIndexes(), ['*']);
+        $this->assertNotNull($response->getExpiresAt());
+        $this->assertNotNull($response->getCreatedAt());
+        $this->assertNotNull($response->getUpdatedAt());
 
-        $this->client->deleteKey($response['key']);
+        $this->client->deleteKey($response->getKey());
     }
 
     public function testDeleteKey(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);
-        $this->client->deleteKey($key['key']);
+        $this->client->deleteKey($key->getKey());
         $this->expectException(ApiException::class);
-        $this->client->getKey($key['key']);
+        $this->client->getKey($key->getKey());
     }
 
     public function testInextistingDeleteKey(): void


### PR DESCRIPTION
### Breaking Changes

The `class` `Keys` wasn't used as a proper class and did not return objects from the `Keys` but arrays. This has been changed. Setters and Getters have been added to the class.

- `client.getKey` return a Keys
- `client.createKey` return a Keys
- `client.updateKey` return a Keys