### PR TITLE
Modify Client test to check ApiException code rather than ApiException message

### DIFF
--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -72,7 +72,7 @@ class ClientTest extends TestCase
         $client = new Client('https://localhost', null, $httpClient);
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('internal error');
+        $this->expectExceptionCode(300);
 
         $client->post('/', '');
     }
@@ -119,7 +119,7 @@ class ClientTest extends TestCase
         $client = new Client('https://localhost', null, $httpClient);
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('internal error');
+        $this->expectExceptionCode(300);
 
         $client->put('/', '');
     }
@@ -166,7 +166,7 @@ class ClientTest extends TestCase
         $client = new Client('https://localhost', null, $httpClient);
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('internal error');
+        $this->expectExceptionCode(300);
 
         $client->post('/', '');
     }

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -67,14 +67,14 @@ class ClientTest extends TestCase
 
     public function testPostThrowsApiException(): void
     {
-        $httpClient = $this->createHttpClientMock(300, '{"message":"internal error"}');
-
-        $client = new Client('https://localhost', null, $httpClient);
-
-        $this->expectException(ApiException::class);
-        $this->expectExceptionCode(300);
-
-        $client->post('/', '');
+        try {
+            $httpClient = $this->createHttpClientMock(300, '{"message":"internal error","code":"internal"}');
+            $client = new Client('https://localhost', null, $httpClient);
+            $client->post('/', '');
+            $this->fail('ApiException not raised.');
+        } catch (ApiException $e) {
+            $this->assertEquals('internal', $e->errorCode);
+        }
     }
 
     public function testPutExecutesRequest(): void
@@ -114,14 +114,14 @@ class ClientTest extends TestCase
 
     public function testPutThrowsApiException(): void
     {
-        $httpClient = $this->createHttpClientMock(300, '{"message":"internal error"}');
-
-        $client = new Client('https://localhost', null, $httpClient);
-
-        $this->expectException(ApiException::class);
-        $this->expectExceptionCode(300);
-
-        $client->put('/', '');
+        try {
+            $httpClient = $this->createHttpClientMock(300, '{"message":"internal error","code":"internal"}');
+            $client = new Client('https://localhost', null, $httpClient);
+            $client->put('/', '');
+            $this->fail('ApiException not raised.');
+        } catch (ApiException $e) {
+            $this->assertEquals('internal', $e->errorCode);
+        }
     }
 
     public function testPatchExecutesRequest(): void
@@ -161,14 +161,14 @@ class ClientTest extends TestCase
 
     public function testPatchThrowsApiException(): void
     {
-        $httpClient = $this->createHttpClientMock(300, '{"message":"internal error"}');
-
-        $client = new Client('https://localhost', null, $httpClient);
-
-        $this->expectException(ApiException::class);
-        $this->expectExceptionCode(300);
-
-        $client->post('/', '');
+        try {
+            $httpClient = $this->createHttpClientMock(300, '{"message":"internal error","code":"internal"}');
+            $client = new Client('https://localhost', null, $httpClient);
+            $client->patch('/', '');
+            $this->fail('ApiException not raised.');
+        } catch (ApiException $e) {
+            $this->assertEquals('internal', $e->errorCode);
+        }
     }
 
     public function testDeleteExecutesRequest(): void


### PR DESCRIPTION
Check ApiException error code rather than error message to avoid tests break due to Meilisearch API evolving.

# Pull Request

## What does this PR do?
Fixes #252 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
