### PR TITLE
Fix authorization header when no api key is provide

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -47,9 +47,11 @@ class Client implements Http
         $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([
-            'Authorization' => sprintf('Bearer %s', $this->apiKey),
             'User-Agent' => MeiliSearch::qualifiedVersion(),
         ]);
+        if ($this->apiKey) {
+            $this->headers['Authorization'] = sprintf('Bearer %s', $this->apiKey);
+        }
         $this->json = new Json();
     }
 

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -203,12 +203,12 @@ class ClientTest extends TestCase
             ->method('withAddedHeader')
             ->withConsecutive(
                 [
-                    $this->equalTo('Authorization'),
-                    $this->equalTo('Bearer masterKey'),
-                ],
-                [
                     $this->equalTo('User-Agent'),
                     $this->equalTo(MeiliSearch::qualifiedVersion()),
+                ],
+                [
+                    $this->equalTo('Authorization'),
+                    $this->equalTo('Bearer masterKey'),
                 ],
               )
             ->willReturnOnConsecutiveCalls($requestStub, $requestStub);


### PR DESCRIPTION
If no API key is provided for `Meilisearch` the Client added the header anyway.
fixes #304.
