### PR TITLE
Fix tests due to cropping and facet distribution

### DIFF
--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -160,7 +160,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('_formatted', $response->getHit(0));
         $this->assertArrayNotHasKey('comment', $response->getHit(0));
         $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
-        $this->assertSame('Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
+        $this->assertSame('Le Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
 
         $response = $this->index->search('prince', [
             'limit' => 5,
@@ -180,7 +180,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
         $this->assertArrayNotHasKey('comment', $response['hits'][0]);
         $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesInfo']);
-        $this->assertSame('Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
+        $this->assertSame('Le Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
     }
 
     public function testParametersCanBeAStar(): void
@@ -204,7 +204,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('_formatted', $response->getHit(0));
         $this->assertArrayHasKey('comment', $response->getHit(0));
         $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
-        $this->assertSame('Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
+        $this->assertSame('Le Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
 
         $response = $this->index->search('prince', [
             'limit' => 5,
@@ -224,7 +224,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
         $this->assertArrayHasKey('comment', $response['hits'][0]);
         $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesInfo']);
-        $this->assertSame('Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
+        $this->assertSame('Le Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
     }
 
     public function testSearchWithFilterCanBeInt(): void
@@ -613,16 +613,16 @@ final class SearchTest extends TestCase
         $this->index->waitForTask($response['uid']);
 
         $response = $this->index->search(
-            'prince',
+            'witch',
             ['facetsDistribution' => ['genre', 'adaptation']]
         );
 
-        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
+        $this->assertCount(1, $response->getFacetsDistribution()['genre']);
         $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['fantasy']);
-        $this->assertEquals([], $response->getFacetsDistribution()['adaptation']);
-        $this->assertCount(0, $response->getRaw()['facetsDistribution']['adaptation']);
-        $this->assertCount(2, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertCount(1, $response->getFacetsDistribution()['adaptation']);
+        $this->assertEquals(1, $response->getFacetsDistribution()['adaptation']['video game']);
+        $this->assertCount(1, $response->getRaw()['facetsDistribution']['adaptation']);
+        $this->assertCount(1, $response->getRaw()['facetsDistribution']['genre']);
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
         $this->assertEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
     }


### PR DESCRIPTION
As per the changes made in the cropping behavior (now per words see [this spec](https://github.com/meilisearch/specifications/blob/f5c6a8e183e22cc3b80d9a0251c411250f31674f/text/0118-search-api.md#3111-attributestocrop) tests needed to be fixed.