### PR TITLE
Add typo tolerance settings

### DIFF
--- a/src/Contracts/Index/Settings.php
+++ b/src/Contracts/Index/Settings.php
@@ -11,6 +11,7 @@ class Settings extends Data implements \JsonSerializable
     public function __construct(array $data = [])
     {
         $data['synonyms'] = new Synonyms($data['synonyms'] ?? []);
+        $data['typoTolerance'] = new TypoTolerance($data['typoTolerance'] ?? []);
         parent::__construct($data);
     }
 

--- a/src/Contracts/Index/TypoTolerance.php
+++ b/src/Contracts/Index/TypoTolerance.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts\Index;
+
+use MeiliSearch\Contracts\Data;
+
+class TypoTolerance extends Data implements \JsonSerializable
+{
+    public function jsonSerialize(): object
+    {
+        return (object) $this->getIterator()->getArrayCopy();
+    }
+}

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints\Delegates;
 
 use MeiliSearch\Contracts\Index\Synonyms;
+use MeiliSearch\Contracts\Index\TypoTolerance;
 
 trait HandlesSettings
 {
@@ -143,5 +144,23 @@ trait HandlesSettings
     public function resetSortableAttributes(): array
     {
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/sortable-attributes');
+    }
+
+    // Settings - Typo Tolerance
+
+    public function getTypoTolerance(): array
+    {
+        return (new TypoTolerance($this->http->get(self::PATH.'/'.$this->uid.'/settings/typo-tolerance')))
+            ->getIterator()->getArrayCopy();
+    }
+
+    public function updateTypoTolerance(array $typoTolerance): array
+    {
+        return $this->http->post(self::PATH.'/'.$this->uid.'/settings/typo-tolerance', new TypoTolerance($typoTolerance));
+    }
+
+    public function resetTypoTolerance(): array
+    {
+        return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/typo-tolerance');
     }
 }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -35,6 +35,8 @@ final class IndexTest extends TestCase
         $this->assertIsArray($this->index->getFilterableAttributes());
         /* @phpstan-ignore-next-line */
         $this->assertIsArray($this->index->getDisplayedAttributes());
+        /* @phpstan-ignore-next-line */
+        $this->assertIsArray($this->index->getTypoTolerance());
     }
 
     public function testGetPrimaryKey(): void

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -205,7 +205,7 @@ final class SearchResultTest extends TestCase
         $this->assertCount(1, $response);
     }
 
-    public function testTransformFacetsDritributionMethod(): void
+    public function testTransformFacetsDistributionMethod(): void
     {
         $facetsToUpperFunc = function (array $facets): array {
             $changeOneFacet = function (array $facet): array {

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -17,6 +17,16 @@ final class SettingsTest extends TestCase
         'exactness',
     ];
 
+    public const DEFAULT_TYPO_TOLERANCE = [
+        'enabled' => True,
+        'minWordLengthForTypo' => [
+            'oneTypo' => 5,
+            'twoTypos' => 9,
+        ],
+        'disableOnWords' => [],
+        'disableOnAttributes' => [],
+    ];
+
     public const DEFAULT_SEARCHABLE_ATTRIBUTES = ['*'];
     public const DEFAULT_DISPLAYED_ATTRIBUTES = ['*'];
 
@@ -46,6 +56,8 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settingA['filterableAttributes']);
         $this->assertIsArray($settingA['sortableAttributes']);
         $this->assertEmpty($settingA['sortableAttributes']);
+        $this->assertIsIterable($settingA['typoTolerance']);
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, iterator_to_array($settingA['typoTolerance']));
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $settingB['rankingRules']);
         $this->assertNull($settingB['distinctAttribute']);
@@ -59,6 +71,8 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settingB['filterableAttributes']);
         $this->assertIsArray($settingB['sortableAttributes']);
         $this->assertEmpty($settingB['sortableAttributes']);
+        $this->assertIsIterable($settingB['typoTolerance']);
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, iterator_to_array($settingB['typoTolerance']));
     }
 
     public function testUpdateSettings(): void
@@ -87,15 +101,27 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settings['filterableAttributes']);
         $this->assertIsArray($settings['sortableAttributes']);
         $this->assertEmpty($settings['sortableAttributes']);
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, iterator_to_array($settings['typoTolerance']));
     }
 
     public function testUpdateSettingsWithoutOverwritingThem(): void
     {
+        $new_typo_tolerance = [
+            'enabled' => True,
+            'minWordLengthForTypo' => [
+                'oneTypo' => 5,
+                'twoTypos' => 9,
+            ],
+            'disableOnWords' => [],
+            'disableOnAttributes' => [],
+        ];
+
         $index = $this->createEmptyIndex('index');
         $promise = $index->updateSettings([
             'distinctAttribute' => 'title',
             'rankingRules' => ['title:asc', 'typo'],
             'stopWords' => ['the'],
+            'typoTolerance' => $new_typo_tolerance,
         ]);
 
         $this->assertIsValidPromise($promise);
@@ -122,6 +148,7 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settings['filterableAttributes']);
         $this->assertIsArray($settings['sortableAttributes']);
         $this->assertEmpty($settings['sortableAttributes']);
+        $this->assertEquals($new_typo_tolerance, iterator_to_array($settings['typoTolerance']));
     }
 
     public function testResetSettings(): void
@@ -156,6 +183,7 @@ final class SettingsTest extends TestCase
         $this->assertEmpty($settings['filterableAttributes']);
         $this->assertIsArray($settings['sortableAttributes']);
         $this->assertEmpty($settings['sortableAttributes']);
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, iterator_to_array($settings['typoTolerance']));
     }
 
     // Here the test to prevent https://github.com/meilisearch/meilisearch-php/issues/204.

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -18,7 +18,7 @@ final class SettingsTest extends TestCase
     ];
 
     public const DEFAULT_TYPO_TOLERANCE = [
-        'enabled' => True,
+        'enabled' => true,
         'minWordSizeForTypos' => [
             'oneTypo' => 5,
             'twoTypos' => 9,
@@ -107,7 +107,7 @@ final class SettingsTest extends TestCase
     public function testUpdateSettingsWithoutOverwritingThem(): void
     {
         $new_typo_tolerance = [
-            'enabled' => True,
+            'enabled' => true,
             'minWordSizeForTypos' => [
                 'oneTypo' => 5,
                 'twoTypos' => 9,

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -19,7 +19,7 @@ final class SettingsTest extends TestCase
 
     public const DEFAULT_TYPO_TOLERANCE = [
         'enabled' => True,
-        'minWordLengthForTypo' => [
+        'minWordSizeForTypos' => [
             'oneTypo' => 5,
             'twoTypos' => 9,
         ],
@@ -108,7 +108,7 @@ final class SettingsTest extends TestCase
     {
         $new_typo_tolerance = [
             'enabled' => True,
-            'minWordLengthForTypo' => [
+            'minWordSizeForTypos' => [
                 'oneTypo' => 5,
                 'twoTypos' => 9,
             ],

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use MeiliSearch\Endpoints\Indexes;
+use Tests\TestCase;
+
+final class TypoToleranceTest extends TestCase
+{
+    private Indexes $index;
+
+    public const DEFAULT_TYPO_TOLERANCE = [
+        'enabled' => True,
+        'minWordLengthForTypo' => [
+            'oneTypo' => 5,
+            'twoTypos' => 9,
+        ],
+        'disableOnWords' => [],
+        'disableOnAttributes' => [],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->index = $this->createEmptyIndex('index');
+    }
+
+    public function testGetDefaultTypoTolerance(): void
+    {
+        $response = $this->index->getTypoTolerance();
+
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, $response);
+    }
+
+    public function testUpdateTypoTolerance(): void
+    {
+        $newTypoTolerance = [
+            'enabled' => True,
+            'minWordLengthForTypo' => [
+                'oneTypo' => 6,
+                'twoTypos' => 10,
+            ],
+            'disableOnWords' => [],
+            'disableOnAttributes' => ['title'],
+        ];
+        $promise = $this->index->updateTypoTolerance($newTypoTolerance);
+
+        $this->assertIsValidPromise($promise);
+
+        $this->index->waitForTask($promise['uid']);
+        $typoTolerance = $this->index->getTypoTolerance();
+
+        $this->assertEquals($newTypoTolerance, $typoTolerance);
+    }
+
+    public function testResetTypoTolerance(): void
+    {
+        $promise = $this->index->resetTypoTolerance();
+
+        $this->assertIsValidPromise($promise);
+
+        $this->index->waitForTask($promise['uid']);
+        $typoTolerance = $this->index->getTypoTolerance();
+
+        $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, $typoTolerance);
+    }
+}

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -46,12 +46,10 @@ final class TypoToleranceTest extends TestCase
             'disableOnAttributes' => ['title'],
         ];
         $promise = $this->index->updateTypoTolerance($newTypoTolerance);
-
-        $this->assertIsValidPromise($promise);
-
         $this->index->waitForTask($promise['uid']);
         $typoTolerance = $this->index->getTypoTolerance();
 
+        $this->assertIsValidPromise($promise);
         $this->assertEquals($newTypoTolerance, $typoTolerance);
     }
 

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -12,7 +12,7 @@ final class TypoToleranceTest extends TestCase
     private Indexes $index;
 
     public const DEFAULT_TYPO_TOLERANCE = [
-        'enabled' => True,
+        'enabled' => true,
         'minWordSizeForTypos' => [
             'oneTypo' => 5,
             'twoTypos' => 9,
@@ -37,7 +37,7 @@ final class TypoToleranceTest extends TestCase
     public function testUpdateTypoTolerance(): void
     {
         $newTypoTolerance = [
-            'enabled' => True,
+            'enabled' => true,
             'minWordSizeForTypos' => [
                 'oneTypo' => 6,
                 'twoTypos' => 10,

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -13,7 +13,7 @@ final class TypoToleranceTest extends TestCase
 
     public const DEFAULT_TYPO_TOLERANCE = [
         'enabled' => True,
-        'minWordLengthForTypo' => [
+        'minWordSizeForTypos' => [
             'oneTypo' => 5,
             'twoTypos' => 9,
         ],
@@ -38,7 +38,7 @@ final class TypoToleranceTest extends TestCase
     {
         $newTypoTolerance = [
             'enabled' => True,
-            'minWordLengthForTypo' => [
+            'minWordSizeForTypos' => [
                 'oneTypo' => 6,
                 'twoTypos' => 10,
             ],

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -56,12 +56,10 @@ final class TypoToleranceTest extends TestCase
     public function testResetTypoTolerance(): void
     {
         $promise = $this->index->resetTypoTolerance();
-
-        $this->assertIsValidPromise($promise);
-
         $this->index->waitForTask($promise['uid']);
         $typoTolerance = $this->index->getTypoTolerance();
 
+        $this->assertIsValidPromise($promise);
         $this->assertEquals(self::DEFAULT_TYPO_TOLERANCE, $typoTolerance);
     }
 }


### PR DESCRIPTION
This PR introduces the new setting: [typoTolerance](https://github.com/meilisearch/specifications/pull/117)

new methods: 
`index.getTypoTolerance()`
`index.updateTypoTolerance(params)`
`index.resetTypoTolerance()`