### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropM…

### DIFF
--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -139,6 +139,112 @@ final class SearchTest extends TestCase
         $index->search('prince');
     }
 
+    public function testParametersCropMarker(): void
+    {
+        $response = $this->index->updateFilterableAttributes(['title']);
+        $this->index->waitForTask($response['uid']);
+
+        $response = $this->index->search('blood', [
+            'limit' => 1,
+            'attributesToCrop' => ['title'],
+            'cropLength' => 2,
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertSame('…Half-Blood…', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('blood', [
+            'limit' => 1,
+            'attributesToCrop' => ['title'],
+            'cropLength' => 2,
+        ], [
+            'raw' => true,
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response['hits'][0]);
+        $this->assertSame('…Half-Blood…', $response['hits'][0]['_formatted']['title']);
+    }
+
+    public function testParametersWithCustomizedCropMarker(): void
+    {
+        $response = $this->index->updateFilterableAttributes(['title']);
+        $this->index->waitForTask($response['uid']);
+
+        $response = $this->index->search('blood', [
+            'limit' => 1,
+            'attributesToCrop' => ['title'],
+            'cropLength' => 3,
+            'cropMarker' => '(ꈍᴗꈍ)',
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertSame('(ꈍᴗꈍ)Half-Blood Prince', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('blood', [
+            'limit' => 1,
+            'attributesToCrop' => ['title'],
+            'cropLength' => 3,
+            'cropMarker' => '(ꈍᴗꈍ)',
+        ], [
+            'raw' => true,
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response['hits'][0]);
+        $this->assertSame('(ꈍᴗꈍ)Half-Blood Prince', $response['hits'][0]['_formatted']['title']);
+    }
+
+    public function testParametersWithHighlightTag(): void
+    {
+        $response = $this->index->updateFilterableAttributes(['title']);
+        $this->index->waitForTask($response['uid']);
+
+        $response = $this->index->search('and', [
+            'limit' => 1,
+            'attributesToHighlight' => ['*'],
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertSame('Pride <em>and</em> Prejudice', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('and', [
+            'limit' => 1,
+            'attributesToHighlight' => ['*'],
+        ], [
+            'raw' => true,
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response['hits'][0]);
+        $this->assertSame('Pride <em>and</em> Prejudice', $response['hits'][0]['_formatted']['title']);
+    }
+
+    public function testParametersWithCustomizedHighlightTag(): void
+    {
+        $response = $this->index->updateFilterableAttributes(['title']);
+        $this->index->waitForTask($response['uid']);
+
+        $response = $this->index->search('and', [
+            'limit' => 1,
+            'attributesToHighlight' => ['*'],
+            'highlightPreTag' => '(⊃｡•́‿•̀｡)⊃ ',
+            'highlightPostTag' => ' ⊂(´• ω •`⊂)',
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response->getHit(0));
+        $this->assertSame('Pride (⊃｡•́‿•̀｡)⊃ and ⊂(´• ω •`⊂) Prejudice', $response->getHit(0)['_formatted']['title']);
+
+        $response = $this->index->search('and', [
+            'limit' => 1,
+            'attributesToHighlight' => ['*'],
+            'highlightPreTag' => '(⊃｡•́‿•̀｡)⊃ ',
+            'highlightPostTag' => ' ⊂(´• ω •`⊂)',
+        ], [
+            'raw' => true,
+        ]);
+
+        $this->assertArrayHasKey('_formatted', $response['hits'][0]);
+        $this->assertSame('Pride (⊃｡•́‿•̀｡)⊃ and ⊂(´• ω •`⊂) Prejudice', $response['hits'][0]['_formatted']['title']);
+    }
+
     public function testParametersArray(): void
     {
         $response = $this->index->updateFilterableAttributes(['title']);

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -141,9 +141,6 @@ final class SearchTest extends TestCase
 
     public function testParametersCropMarker(): void
     {
-        $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
-
         $response = $this->index->search('blood', [
             'limit' => 1,
             'attributesToCrop' => ['title'],
@@ -167,9 +164,6 @@ final class SearchTest extends TestCase
 
     public function testParametersWithCustomizedCropMarker(): void
     {
-        $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
-
         $response = $this->index->search('blood', [
             'limit' => 1,
             'attributesToCrop' => ['title'],
@@ -195,9 +189,6 @@ final class SearchTest extends TestCase
 
     public function testParametersWithHighlightTag(): void
     {
-        $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
-
         $response = $this->index->search('and', [
             'limit' => 1,
             'attributesToHighlight' => ['*'],
@@ -219,9 +210,6 @@ final class SearchTest extends TestCase
 
     public function testParametersWithCustomizedHighlightTag(): void
     {
-        $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
-
         $response = $this->index->search('and', [
             'limit' => 1,
             'attributesToHighlight' => ['*'],


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced: 

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`
