### PR TITLE
Update version for the next release (v0.23.2)

### DIFF
--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -6,7 +6,7 @@ namespace MeiliSearch;
 
 class MeiliSearch
 {
-    public const VERSION = '0.23.1';
+    public const VERSION = '0.23.2';
 
     public static function qualifiedVersion()
     {


### PR DESCRIPTION
This version makes this package compatible with MeiliSearch v0.27.0🎉 
Check out the changelog of [MeiliSearch v0.27.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.27.0) for more information about the changes.

## 🚀 Enhancements

- Add new methods for the new typo tolerance settings #316 @alallema
`index.getTypoTolerance()`
`index.updateTypoTolerance(params)`
`index.resetTypoTolerance()`
- Ensure nested field support #317 @alallema
- Add new search parameters highlightPreTag, highlightPostTag and cropMarker #318 @alallema

## 🐛 Bug Fixes

* Fix `getKeys` method (#323) @alallema