### PR TITLE
Fix errors assigning bool to `DateTime` properties in `Keys`

### DIFF
--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -43,13 +43,13 @@ class Keys extends Endpoint
             $attributes['indexes'],
         );
         if ($attributes['expiresAt']) {
-            $key->expiresAt = date_create_from_format('Y-m-d\TH:i:s\Z', $attributes['expiresAt']);
+            $key->expiresAt = $this->createDate($attributes['expiresAt']);
         }
         if ($attributes['createdAt']) {
-            $key->createdAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['createdAt']);
+            $key->createdAt = $this->createDate($attributes['createdAt']);
         }
         if ($attributes['updatedAt']) {
-            $key->updatedAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['updatedAt']);
+            $key->updatedAt = $this->createDate($attributes['updatedAt']);
         }
 
         return $key;
@@ -65,16 +65,27 @@ class Keys extends Endpoint
         $this->actions = $attributes['actions'];
         $this->indexes = $attributes['indexes'];
         if ($attributes['expiresAt']) {
-            $this->expiresAt = date_create_from_format('Y-m-d\TH:i:s\Z', $attributes['expiresAt']);
+            $this->expiresAt = $this->createDate($attributes['expiresAt']);
         }
         if ($attributes['createdAt']) {
-            $this->createdAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['createdAt']);
+            $this->createdAt = $this->createDate($attributes['createdAt']);
         }
         if ($attributes['updatedAt']) {
-            $this->updatedAt = date_create_from_format('Y-m-d\TH:i:s.vu\Z', $attributes['updatedAt']);
+            $this->updatedAt = $this->createDate($attributes['updatedAt']);
         }
 
         return $this;
+    }
+
+    protected function createDate($attribute): DateTime|null
+    {
+        if (!is_string($attribute)) {
+            return null;
+        }
+
+        return date_create_from_format(DateTime::ATOM, $attribute)
+            ?: date_create_from_format('Y-m-d\TH:i:s.uP', $attribute)
+            ?: null;
     }
 
     public function getKey(): ?string


### PR DESCRIPTION
## What does this PR do?
Fixes #321

### Comments on the format choices:
MeiliSearch outputs various slight variations of timestamp formats depending on the precise moment represented by it (see #321). This SDK can neither assume that `expiresAt` never contains milli- or microseconds, nor that `createdAt` or `updatedAt` always contains microseconds. I don't think PHP provides a way to handle this in a single `date_create_from_format` call, so this change makes it always try both.

In my opinion `.vu` as a format term for microseconds is unnecessarily restrictive, forcing the milli-/microsecond part to always contain four or more digits, while using just `u` covers all possibilities. The same goes for forcing the timezone to appear as `Z`. While MeiliSearch seems to adhere to this, I don't think it is necessary to disallow generic time zone notations.

If an invalid timestamp is provided, so either a non-string is passed or the string has an invalid format, it defaults to returning `null`. This reliably prevents the assignment error, but might not be desired behavior as it eats formatting errors.

Please do not hesitate to make style or implementation changes. I would consider this a high priority issue, so please do not wait for me to get back to you. The SDK is virtually unusable in practice if you need to interact with API keys.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
