### PR TITLE
Apply search changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -272,7 +272,7 @@ search_parameter_guide_highlight_tag_1: |-
     'highlightPostTag' => '</span>'
   ]);
 search_parameter_guide_matches_1: |-
-  $client->index('movies')->search('winter feast', ['attributesToHighlight' => ['overview'], 'matches' => true]);
+  $client->index('movies')->search('winter feast', ['attributesToHighlight' => ['overview'], 'showMatchesPosition' => true]);
 settings_guide_synonyms_1: |-
   $client->index('tops')->updateSettings([
     'synonyms' => [
@@ -468,7 +468,7 @@ faceted_search_update_settings_1: |-
 faceted_search_filter_1: |-
   $client->index('movies')->search('thriller', ['filter' => [['genres = Horror', 'genres = Mystery'], 'director = "Jordan Peele"']]);
 faceted_search_facets_distribution_1: |-
-  $client->index('movies')->search('Batman', ['facetsDistribution' => ['genres']]);
+  $client->index('movies')->search('Batman', ['facets' => ['genres']]);
 faceted_search_walkthrough_filter_1: |-
   $client->index('movies')->search('thriller', ['filter' => [['genres = Horror', 'genres = Mystery'], 'director = "Jordan Peele"']]);
 post_dump_1: |-

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $index->search(
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 1,
+  "estimatedTotalHits": 1,
   "processingTimeMs": 0,
   "query": "wonder"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch:latest
+    image: getmeili/meilisearch:v0.28.0rc0
     ports:
       - "7700"
     environment:

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -185,7 +185,12 @@ class Indexes extends Endpoint
             $searchParams
         );
 
-        return $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
+        $result = $this->http->post(self::PATH.'/'.$this->uid.'/search', $parameters);
+
+        // patch to prevent breaking in laravel/scout getTotalCount method.
+        $result['nbHits'] = $result['estimativeNbHits'];
+
+        return $result;
     }
 
     // Stats

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -16,25 +16,23 @@ class SearchResult implements Countable, IteratorAggregate
     private array $hits;
 
     /**
-     * `nbHits` is the attributes returned by the Meilisearch server
+     * `estimatedTotalHits` is the attributes returned by the Meilisearch server
      * and its value will not be modified by the methods in this class.
      * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
      */
-    private int $nbHits;
+    private int $estimatedTotalHits;
 
     private int $hitsCount;
-    private bool $exhaustiveNbHits;
     private int $offset;
     private int $limit;
     private int $processingTimeMs;
 
     private string $query;
-    private ?bool $exhaustiveFacetsCount;
 
     /**
      * @var array<string, mixed>
      */
-    private array $facetsDistribution;
+    private array $facetDistribution;
 
     /**
      * @var array<string, mixed>
@@ -46,13 +44,11 @@ class SearchResult implements Countable, IteratorAggregate
         $this->hits = $body['hits'] ?? [];
         $this->offset = $body['offset'];
         $this->limit = $body['limit'];
-        $this->nbHits = $body['nbHits'];
+        $this->estimatedTotalHits = $body['estimatedTotalHits'];
         $this->hitsCount = \count($body['hits']);
-        $this->exhaustiveNbHits = $body['exhaustiveNbHits'] ?? false;
         $this->processingTimeMs = $body['processingTimeMs'];
         $this->query = $body['query'];
-        $this->exhaustiveFacetsCount = $body['exhaustiveFacetsCount'] ?? null;
-        $this->facetsDistribution = $body['facetsDistribution'] ?? [];
+        $this->facetDistribution = $body['facetDistribution'] ?? [];
         $this->raw = $body;
     }
 
@@ -60,7 +56,7 @@ class SearchResult implements Countable, IteratorAggregate
      * Return a new {@see SearchResult} instance.
      *
      * The $options parameter is an array, and the following keys are accepted:
-     * - transformFacetsDistribution (callable)
+     * - transformFacetDistribution (callable)
      * - transformHits (callable)
      *
      * The method does NOT trigger a new search.
@@ -72,8 +68,8 @@ class SearchResult implements Countable, IteratorAggregate
         if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
             $this->transformHits($options['transformHits']);
         }
-        if (\array_key_exists('transformFacetsDistribution', $options) && \is_callable($options['transformFacetsDistribution'])) {
-            $this->transformFacetsDistribution($options['transformFacetsDistribution']);
+        if (\array_key_exists('transformFacetDistribution', $options) && \is_callable($options['transformFacetDistribution'])) {
+            $this->transformFacetDistribution($options['transformFacetDistribution']);
         }
 
         return $this;
@@ -87,9 +83,9 @@ class SearchResult implements Countable, IteratorAggregate
         return $this;
     }
 
-    public function transformFacetsDistribution(callable $callback): self
+    public function transformFacetDistribution(callable $callback): self
     {
-        $this->facetsDistribution = $callback($this->facetsDistribution);
+        $this->facetDistribution = $callback($this->facetDistribution);
 
         return $this;
     }
@@ -127,14 +123,9 @@ class SearchResult implements Countable, IteratorAggregate
         return $this->hitsCount;
     }
 
-    public function getNbHits(): int
+    public function getEstimatedTotalHits(): int
     {
-        return $this->nbHits;
-    }
-
-    public function getExhaustiveNbHits(): bool
-    {
-        return $this->exhaustiveNbHits;
+        return $this->estimatedTotalHits;
     }
 
     public function getProcessingTimeMs(): int
@@ -147,17 +138,12 @@ class SearchResult implements Countable, IteratorAggregate
         return $this->query;
     }
 
-    public function getExhaustiveFacetsCount(): ?bool
-    {
-        return $this->exhaustiveFacetsCount;
-    }
-
     /**
      * @return array<string, mixed>
      */
-    public function getFacetsDistribution(): array
+    public function getFacetDistribution(): array
     {
-        return $this->facetsDistribution;
+        return $this->facetDistribution;
     }
 
     /**
@@ -176,13 +162,11 @@ class SearchResult implements Countable, IteratorAggregate
             'hits' => $this->hits,
             'offset' => $this->offset,
             'limit' => $this->limit,
-            'nbHits' => $this->nbHits,
+            'estimatedTotalHits' => $this->estimatedTotalHits,
             'hitsCount' => $this->hitsCount,
-            'exhaustiveNbHits' => $this->exhaustiveNbHits,
             'processingTimeMs' => $this->processingTimeMs,
             'query' => $this->query,
-            'exhaustiveFacetsCount' => $this->exhaustiveFacetsCount,
-            'facetsDistribution' => $this->facetsDistribution,
+            'facetDistribution' => $this->facetDistribution,
         ];
     }
 

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -29,7 +29,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(2, $response->getEstimatedTotalHits());
         $this->assertCount(2, $response->getHits());
 
         $response = $this->index->search('prince', [], [
@@ -41,7 +41,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(2, $response['nbHits']);
+        $this->assertSame(2, $response['estimatedTotalHits']);
     }
 
     public function testBasicEmptySearch(): void
@@ -64,7 +64,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(7, $response['nbHits']);
+        $this->assertSame(7, $response['estimatedTotalHits']);
     }
 
     public function testBasicPlaceholderSearch(): void
@@ -87,7 +87,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(\count(self::DOCUMENTS), $response['nbHits']);
+        $this->assertSame(\count(self::DOCUMENTS), $response['estimatedTotalHits']);
     }
 
     public function testSearchWithOptions(): void
@@ -125,7 +125,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $res);
         $this->assertArrayHasKey('processingTimeMs', $res);
         $this->assertArrayHasKey('query', $res);
-        $this->assertSame(0, $res['nbHits']);
+        $this->assertSame(0, $res['estimatedTotalHits']);
     }
 
     public function testExceptionIfNoIndexWhenSearching(): void
@@ -246,14 +246,14 @@ final class SearchTest extends TestCase
             'cropLength' => 6,
             'attributesToHighlight' => ['title'],
             'filter' => 'title = "Le Petit Prince"',
-            'matches' => true,
+            'showMatchesPosition' => true,
         ]);
 
-        $this->assertArrayHasKey('_matchesInfo', $response->getHit(0));
-        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayHasKey('_matchesPosition', $response->getHit(0));
+        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesPosition']);
         $this->assertArrayHasKey('_formatted', $response->getHit(0));
         $this->assertArrayNotHasKey('comment', $response->getHit(0));
-        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesPosition']);
         $this->assertSame('Le Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
 
         $response = $this->index->search('prince', [
@@ -264,16 +264,16 @@ final class SearchTest extends TestCase
             'cropLength' => 6,
             'attributesToHighlight' => ['title'],
             'filter' => 'title = "Le Petit Prince"',
-            'matches' => true,
+            'showMatchesPosition' => true,
         ], [
             'raw' => true,
         ]);
 
-        $this->assertArrayHasKey('_matchesInfo', $response['hits'][0]);
-        $this->assertArrayHasKey('title', $response['hits'][0]['_matchesInfo']);
+        $this->assertArrayHasKey('_matchesPosition', $response['hits'][0]);
+        $this->assertArrayHasKey('title', $response['hits'][0]['_matchesPosition']);
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
         $this->assertArrayNotHasKey('comment', $response['hits'][0]);
-        $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesInfo']);
+        $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesPosition']);
         $this->assertSame('Le Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
     }
 
@@ -290,14 +290,14 @@ final class SearchTest extends TestCase
             'cropLength' => 6,
             'attributesToHighlight' => ['*'],
             'filter' => 'title = "Le Petit Prince"',
-            'matches' => true,
+            'showMatchesPosition' => true,
         ]);
 
-        $this->assertArrayHasKey('_matchesInfo', $response->getHit(0));
-        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayHasKey('_matchesPosition', $response->getHit(0));
+        $this->assertArrayHasKey('title', $response->getHit(0)['_matchesPosition']);
         $this->assertArrayHasKey('_formatted', $response->getHit(0));
         $this->assertArrayHasKey('comment', $response->getHit(0));
-        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesInfo']);
+        $this->assertArrayNotHasKey('comment', $response->getHit(0)['_matchesPosition']);
         $this->assertSame('Le Petit <em>Prince</em>', $response->getHit(0)['_formatted']['title']);
 
         $response = $this->index->search('prince', [
@@ -308,16 +308,16 @@ final class SearchTest extends TestCase
             'cropLength' => 6,
             'attributesToHighlight' => ['*'],
             'filter' => 'title = "Le Petit Prince"',
-            'matches' => true,
+            'showMatchesPosition' => true,
         ], [
             'raw' => true,
         ]);
 
-        $this->assertArrayHasKey('_matchesInfo', $response['hits'][0]);
-        $this->assertArrayHasKey('title', $response['hits'][0]['_matchesInfo']);
+        $this->assertArrayHasKey('_matchesPosition', $response['hits'][0]);
+        $this->assertArrayHasKey('title', $response['hits'][0]['_matchesPosition']);
         $this->assertArrayHasKey('_formatted', $response['hits'][0]);
         $this->assertArrayHasKey('comment', $response['hits'][0]);
-        $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesInfo']);
+        $this->assertArrayNotHasKey('comment', $response['hits'][0]['_matchesPosition']);
         $this->assertSame('Le Petit <em>Prince</em>', $response['hits'][0]['_formatted']['title']);
     }
 
@@ -330,7 +330,7 @@ final class SearchTest extends TestCase
             'filter' => 'id < 12',
         ]);
 
-        $this->assertSame(1, $response->getNbHits());
+        $this->assertSame(1, $response->getEstimatedTotalHits());
         $this->assertCount(1, $response->getHits());
         $this->assertSame(4, $response->getHit(0)['id']);
 
@@ -338,40 +338,36 @@ final class SearchTest extends TestCase
             'filter' => 'genre = fantasy AND id < 12',
         ]);
 
-        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(2, $response->getEstimatedTotalHits());
         $this->assertCount(2, $response->getHits());
         $this->assertSame(1, $response->getHit(0)['id']);
         $this->assertSame(4, $response->getHit(1)['id']);
     }
 
-    public function testBasicSearchWithFacetsDistribution(): void
+    public function testBasicSearchWithFacetDistribution(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
         $this->index->waitForTask($response['uid']);
 
         $response = $this->index->search('prince', [
-            'facetsDistribution' => ['genre'],
+            'facets' => ['genre'],
         ]);
         $this->assertSame(2, $response->getHitsCount());
-        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
-        $this->assertArrayHasKey('exhaustiveFacetsCount', $response->toArray());
-        $this->assertArrayHasKey('genre', $response->getFacetsDistribution());
-        $this->assertFalse($response->getExhaustiveFacetsCount());
-        $this->assertSame($response->getFacetsDistribution()['genre']['fantasy'], 1);
-        $this->assertSame($response->getFacetsDistribution()['genre']['adventure'], 1);
+        $this->assertArrayHasKey('facetDistribution', $response->toArray());
+        $this->assertArrayHasKey('genre', $response->getFacetDistribution());
+        $this->assertSame($response->getFacetDistribution()['genre']['fantasy'], 1);
+        $this->assertSame($response->getFacetDistribution()['genre']['adventure'], 1);
 
         $response = $this->index->search('prince', [
-            'facetsDistribution' => ['genre'],
+            'facets' => ['genre'],
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(2, $response['nbHits']);
-        $this->assertArrayHasKey('facetsDistribution', $response);
-        $this->assertArrayHasKey('exhaustiveFacetsCount', $response);
-        $this->assertArrayHasKey('genre', $response['facetsDistribution']);
-        $this->assertFalse($response['exhaustiveFacetsCount']);
-        $this->assertSame($response['facetsDistribution']['genre']['fantasy'], 1);
-        $this->assertSame($response['facetsDistribution']['genre']['adventure'], 1);
+        $this->assertSame(2, $response['estimatedTotalHits']);
+        $this->assertArrayHasKey('facetDistribution', $response);
+        $this->assertArrayHasKey('genre', $response['facetDistribution']);
+        $this->assertSame($response['facetDistribution']['genre']['fantasy'], 1);
+        $this->assertSame($response['facetDistribution']['genre']['adventure'], 1);
     }
 
     public function testBasicSearchWithFilters(): void
@@ -383,8 +379,7 @@ final class SearchTest extends TestCase
             'filter' => [['genre = fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -392,9 +387,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(1, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(1, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(4, $response['hits'][0]['id']);
     }
 
@@ -407,8 +401,7 @@ final class SearchTest extends TestCase
             'filter' => ['genre = fantasy', ['genre = fantasy', 'genre = fantasy']],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -416,9 +409,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(1, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(1, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(4, $response['hits'][0]['id']);
     }
 
@@ -432,8 +424,7 @@ final class SearchTest extends TestCase
             'attributesToRetrieve' => ['id', 'title'],
         ]);
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
         $this->assertArrayHasKey('id', $response->getHit(0));
         $this->assertArrayHasKey('title', $response->getHit(0));
@@ -445,9 +436,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(1, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(1, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(4, $response['hits'][0]['id']);
         $this->assertArrayHasKey('id', $response['hits'][0]);
         $this->assertArrayHasKey('title', $response['hits'][0]);
@@ -472,8 +462,7 @@ final class SearchTest extends TestCase
             'sort' => ['genre:asc'],
         ]);
         $this->assertSame(2, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(456, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -481,9 +470,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(2, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(2, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(456, $response['hits'][0]['id']);
     }
 
@@ -505,8 +493,7 @@ final class SearchTest extends TestCase
             'sort' => ['id:asc'],
         ]);
         $this->assertSame(2, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -514,9 +501,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(2, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(2, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(4, $response['hits'][0]['id']);
     }
 
@@ -538,8 +524,7 @@ final class SearchTest extends TestCase
             'sort' => ['id:asc', 'title:asc'],
         ]);
         $this->assertSame(2, $response->getHitsCount());
-        $this->assertArrayNotHasKey('facetsDistribution', $response->getRaw());
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response->getRaw());
+        $this->assertArrayNotHasKey('facetDistribution', $response->getRaw());
         $this->assertSame(4, $response->getHit(0)['id']);
 
         $response = $this->index->search('prince', [
@@ -547,9 +532,8 @@ final class SearchTest extends TestCase
         ], [
             'raw' => true,
         ]);
-        $this->assertSame(2, $response['nbHits']);
-        $this->assertArrayNotHasKey('facetsDistribution', $response);
-        $this->assertArrayNotHasKey('exhaustiveFacetsCount', $response);
+        $this->assertSame(2, $response['estimatedTotalHits']);
+        $this->assertArrayNotHasKey('facetDistribution', $response);
         $this->assertSame(4, $response['hits'][0]['id']);
     }
 
@@ -571,7 +555,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(2, $response['nbHits']);
+        $this->assertSame(2, $response['estimatedTotalHits']);
         $this->assertCount(2, $response['hits']);
         $this->assertEquals('Le Petit Prince', $response['hits'][0]['title']);
     }
@@ -585,7 +569,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(2, $response['nbHits']);
+        $this->assertSame(2, $response['estimatedTotalHits']);
         $this->assertCount(2, $response['hits']);
     }
 
@@ -606,7 +590,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertSame('Le Petit Prince', $response->getHit(0)['title']);
-        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(2, $response->getEstimatedTotalHits());
         $this->assertSame(1, $response->getHitsCount());
         $this->assertSame(1, $response->count());
     }
@@ -631,7 +615,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
-        $this->assertSame(2, $response->getNbHits());
+        $this->assertSame(2, $response->getEstimatedTotalHits());
         $this->assertSame(2, $response->getHitsCount());
         $this->assertCount(2, $response->getHits());
         $this->assertSame('LE PETIT PRINCE', $response->getHits()[0]['title']);
@@ -656,7 +640,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(2, $response['nbHits']);
+        $this->assertSame(2, $response['estimatedTotalHits']);
         $this->assertCount(2, $response['hits']);
     }
 
@@ -676,7 +660,7 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('limit', $response);
         $this->assertArrayHasKey('processingTimeMs', $response);
         $this->assertArrayHasKey('query', $response);
-        $this->assertSame(2, $response['nbHits']);
+        $this->assertSame(2, $response['estimatedTotalHits']);
         $this->assertCount(1, $response['hits']);
         $this->assertEquals('Le Petit Prince', $response['hits'][0]['title']);
     }
@@ -688,15 +672,15 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search(
             'prince',
-            ['facetsDistribution' => ['genre']]
+            ['facets' => ['genre']]
         );
 
-        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['fantasy']);
-        $this->assertCount(2, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertCount(2, $response->getFacetDistribution()['genre']);
+        $this->assertEquals(1, $response->getFacetDistribution()['genre']['adventure']);
+        $this->assertEquals(1, $response->getFacetDistribution()['genre']['fantasy']);
+        $this->assertCount(2, $response->getRaw()['facetDistribution']['genre']);
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertEquals($response->getRaw()['facetDistribution'], $response->getFacetDistribution());
     }
 
     public function testBasicSearchWithFacetsOptionAndMultipleFacets(): void
@@ -708,17 +692,17 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search(
             'witch',
-            ['facetsDistribution' => ['genre', 'adaptation']]
+            ['facets' => ['genre', 'adaptation']]
         );
 
-        $this->assertCount(1, $response->getFacetsDistribution()['genre']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
-        $this->assertCount(1, $response->getFacetsDistribution()['adaptation']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['adaptation']['video game']);
-        $this->assertCount(1, $response->getRaw()['facetsDistribution']['adaptation']);
-        $this->assertCount(1, $response->getRaw()['facetsDistribution']['genre']);
+        $this->assertCount(1, $response->getFacetDistribution()['genre']);
+        $this->assertEquals(1, $response->getFacetDistribution()['genre']['adventure']);
+        $this->assertCount(1, $response->getFacetDistribution()['adaptation']);
+        $this->assertEquals(1, $response->getFacetDistribution()['adaptation']['video game']);
+        $this->assertCount(1, $response->getRaw()['facetDistribution']['adaptation']);
+        $this->assertCount(1, $response->getRaw()['facetDistribution']['genre']);
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertEquals($response->getRaw()['facetDistribution'], $response->getFacetDistribution());
     }
 
     public function testBasicSearchWithTransformFacetsDritributionOptionToFilter(): void
@@ -740,22 +724,22 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search(
             null,
-            ['facetsDistribution' => ['genre']],
-            ['transformFacetsDistribution' => $filterAllFacets]
+            ['facets' => ['genre']],
+            ['transformFacetDistribution' => $filterAllFacets]
         );
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('facetDistribution', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
-        $this->assertCount(3, $response->getRaw()['facetsDistribution']['genre']);
-        $this->assertCount(2, $response->getFacetsDistribution()['genre']);
-        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['romance']);
-        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['fantasy']);
+        $this->assertNotEquals($response->getRaw()['facetDistribution'], $response->getFacetDistribution());
+        $this->assertCount(3, $response->getRaw()['facetDistribution']['genre']);
+        $this->assertCount(2, $response->getFacetDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetDistribution()['genre']['romance']);
+        $this->assertEquals(2, $response->getFacetDistribution()['genre']['fantasy']);
     }
 
     public function testBasicSearchWithTransformFacetsDritributionOptionToMap(): void
@@ -778,22 +762,22 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search(
             null,
-            ['facetsDistribution' => ['genre']],
-            ['transformFacetsDistribution' => $facetsToUpperFunc]
+            ['facets' => ['genre']],
+            ['transformFacetDistribution' => $facetsToUpperFunc]
         );
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('facetDistribution', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
-        $this->assertCount(3, $response->getFacetsDistribution()['genre']);
-        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['ROMANCE']);
-        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['FANTASY']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['ADVENTURE']);
+        $this->assertNotEquals($response->getRaw()['facetDistribution'], $response->getFacetDistribution());
+        $this->assertCount(3, $response->getFacetDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetDistribution()['genre']['ROMANCE']);
+        $this->assertEquals(2, $response->getFacetDistribution()['genre']['FANTASY']);
+        $this->assertEquals(1, $response->getFacetDistribution()['genre']['ADVENTURE']);
     }
 
     public function testBasicSearchWithTransformFacetsDritributionOptionToOder(): void
@@ -813,22 +797,22 @@ final class SearchTest extends TestCase
 
         $response = $this->index->search(
             null,
-            ['facetsDistribution' => ['genre']],
-            ['transformFacetsDistribution' => $facetsToUpperFunc]
+            ['facets' => ['genre']],
+            ['transformFacetDistribution' => $facetsToUpperFunc]
         );
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('facetDistribution', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertEquals('adventure', array_key_first($response->getFacetsDistribution()['genre']));
-        $this->assertEquals('romance', array_key_last($response->getFacetsDistribution()['genre']));
-        $this->assertCount(3, $response->getFacetsDistribution()['genre']);
-        $this->assertEquals(3, $response->getFacetsDistribution()['genre']['romance']);
-        $this->assertEquals(2, $response->getFacetsDistribution()['genre']['fantasy']);
-        $this->assertEquals(1, $response->getFacetsDistribution()['genre']['adventure']);
+        $this->assertEquals('adventure', array_key_first($response->getFacetDistribution()['genre']));
+        $this->assertEquals('romance', array_key_last($response->getFacetDistribution()['genre']));
+        $this->assertCount(3, $response->getFacetDistribution()['genre']);
+        $this->assertEquals(3, $response->getFacetDistribution()['genre']['romance']);
+        $this->assertEquals(2, $response->getFacetDistribution()['genre']['fantasy']);
+        $this->assertEquals(1, $response->getFacetDistribution()['genre']['adventure']);
     }
 }

--- a/tests/Endpoints/SearchTestNestedFields.php
+++ b/tests/Endpoints/SearchTestNestedFields.php
@@ -31,7 +31,7 @@ final class SearchTestNestedFields extends TestCase
         ]);
 
         $this->assertArrayHasKey('hits', $response);
-        $this->assertSame(1, $response['nbHits']);
+        $this->assertSame(1, $response['estimatedTotalHits']);
         $this->assertSame(5, $response['hits'][0]['id']);
     }
 
@@ -47,7 +47,7 @@ final class SearchTestNestedFields extends TestCase
         ]);
 
         $this->assertArrayHasKey('hits', $response);
-        $this->assertSame(6, $response['nbHits']);
+        $this->assertSame(6, $response['estimatedTotalHits']);
         $this->assertSame(4, $response['hits'][0]['id']);
     }
 
@@ -80,7 +80,7 @@ final class SearchTestNestedFields extends TestCase
         ]);
 
         $this->assertArrayHasKey('hits', $response);
-        $this->assertSame(1, $response['nbHits']);
+        $this->assertSame(1, $response['estimatedTotalHits']);
         $this->assertSame(5, $response['hits'][0]['id']);
     }
 
@@ -102,7 +102,7 @@ final class SearchTestNestedFields extends TestCase
         ]);
 
         $this->assertArrayHasKey('hits', $response);
-        $this->assertSame(1, $response['nbHits']);
+        $this->assertSame(1, $response['estimatedTotalHits']);
         $this->assertSame(5, $response['hits'][0]['id']);
     }
 
@@ -127,7 +127,7 @@ final class SearchTestNestedFields extends TestCase
         ]);
 
         $this->assertArrayHasKey('hits', $response);
-        $this->assertSame(1, $response['nbHits']);
+        $this->assertSame(1, $response['estimatedTotalHits']);
         $this->assertSame(5, $response['hits'][0]['id']);
     }
 }

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -36,8 +36,7 @@ final class SearchResultTest extends TestCase
             ],
             'offset' => 0,
             'limit' => 20,
-            'nbHits' => 976,
-            'exhaustiveNbHits' => false,
+            'estimatedTotalHits' => 976,
             'processingTimeMs' => 35,
             'query' => 'american',
         ];
@@ -59,18 +58,16 @@ final class SearchResultTest extends TestCase
             ],
             'offset' => 0,
             'limit' => 20,
-            'nbHits' => 2,
-            'exhaustiveNbHits' => false,
+            'estimatedTotalHits' => 2,
             'processingTimeMs' => 1,
             'query' => 'prinec',
-            'facetsDistribution' => [
+            'facetDistribution' => [
                 'genre' => [
                     'fantasy' => 1,
                     'romance' => 0,
                     'adventure' => 1,
                 ],
             ],
-            'exhaustiveFacetsCount' => true,
         ];
         $this->resultWithFacets = new SearchResult($serverResponseWithFacets);
     }
@@ -98,24 +95,20 @@ final class SearchResultTest extends TestCase
         $this->assertSame(0, $this->basicResult->getOffset());
         $this->assertSame(20, $this->basicResult->getLimit());
         $this->assertSame(2, $this->basicResult->getHitsCount());
-        $this->assertSame(976, $this->basicResult->getNbHits());
-        $this->assertFalse($this->basicResult->getExhaustiveNbHits());
+        $this->assertSame(976, $this->basicResult->getEstimatedTotalHits());
         $this->assertSame(35, $this->basicResult->getProcessingTimeMs());
         $this->assertSame('american', $this->basicResult->getQuery());
-        $this->assertNull($this->basicResult->getExhaustiveFacetsCount());
         $this->assertEmpty($this->basicResult->getFacetsDistribution());
         $this->assertCount(2, $this->basicResult);
 
         $this->assertArrayHasKey('hits', $this->basicResult->toArray());
         $this->assertArrayHasKey('offset', $this->basicResult->toArray());
         $this->assertArrayHasKey('limit', $this->basicResult->toArray());
-        $this->assertArrayHasKey('nbHits', $this->basicResult->toArray());
+        $this->assertArrayHasKey('estimatedTotalHits', $this->basicResult->toArray());
         $this->assertArrayHasKey('hitsCount', $this->basicResult->toArray());
-        $this->assertArrayHasKey('exhaustiveNbHits', $this->basicResult->toArray());
         $this->assertArrayHasKey('processingTimeMs', $this->basicResult->toArray());
         $this->assertArrayHasKey('query', $this->basicResult->toArray());
-        $this->assertArrayHasKey('exhaustiveFacetsCount', $this->basicResult->toArray());
-        $this->assertArrayHasKey('facetsDistribution', $this->basicResult->toArray());
+        $this->assertArrayHasKey('facetDistribution', $this->basicResult->toArray());
     }
 
     public function testSearchResultCanBeFiltered(): void
@@ -133,7 +126,7 @@ final class SearchResultTest extends TestCase
 
         $this->assertCount(1, $filteredResults);
         $this->assertSame(1, $filteredResults->getHitsCount());
-        $this->assertSame(976, $filteredResults->getNbHits());
+        $this->assertSame(976, $filteredResults->getEstimatedTotalHits());
         $this->assertEquals([
             'id' => '190859',
             'title' => 'American Sniper',
@@ -146,7 +139,6 @@ final class SearchResultTest extends TestCase
     public function testResultCanBeReturnedAsJson(): void
     {
         $this->assertJsonStringEqualsJsonString(
-            '{"hits":[{"id":"1","title":"American Pie 2","poster":"https:\/\/image.tmdb.org\/t\/p\/w1280\/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg","overview":"The whole gang are back and as close as ever. They decide to get even closer by spending the summer together at a beach house. They decide to hold the biggest...","release_date":997405200},{"id":"190859","title":"American Sniper","poster":"https:\/\/image.tmdb.org\/t\/p\/w1280\/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg","overview":"U.S. Navy SEAL Chris Kyle takes his sole mission\u2014protect his comrades\u2014to heart and becomes one of the most lethal snipers in American history. His pinpoint accuracy not only saves countless lives but also makes him a prime...","release_date":1418256000}],"offset":0,"limit":20,"nbHits":976,"hitsCount":2,"exhaustiveNbHits":false,"processingTimeMs":35,"query":"american","exhaustiveFacetsCount":null,"facetsDistribution":[]}',
             $this->basicResult->toJSON()
         );
     }
@@ -200,7 +192,7 @@ final class SearchResultTest extends TestCase
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertSame('American Sniper', $response->getHit(1)['title']); // Not getHits(0) because array_filter() does not reorder the indexes after filtering.
-        $this->assertSame(976, $response->getNbHits());
+        $this->assertSame(976, $response->getEstimatedTotalHits());
         $this->assertSame(1, $response->getHitsCount());
         $this->assertCount(1, $response);
     }
@@ -223,13 +215,13 @@ final class SearchResultTest extends TestCase
         $response = $this->resultWithFacets->transformFacetsDistribution($facetsToUpperFunc);
 
         $this->assertArrayHasKey('hits', $response->toArray());
-        $this->assertArrayHasKey('facetsDistribution', $response->toArray());
+        $this->assertArrayHasKey('facetDistribution', $response->toArray());
         $this->assertArrayHasKey('offset', $response->toArray());
         $this->assertArrayHasKey('limit', $response->toArray());
         $this->assertArrayHasKey('processingTimeMs', $response->toArray());
         $this->assertArrayHasKey('query', $response->toArray());
         $this->assertEquals($response->getRaw()['hits'], $response->getHits());
-        $this->assertNotEquals($response->getRaw()['facetsDistribution'], $response->getFacetsDistribution());
+        $this->assertNotEquals($response->getRaw()['facetDistribution'], $response->getFacetsDistribution());
         $this->assertCount(3, $response->getFacetsDistribution()['genre']);
         $this->assertEquals(0, $response->getFacetsDistribution()['genre']['ROMANCE']);
         $this->assertEquals(1, $response->getFacetsDistribution()['genre']['FANTASY']);


### PR DESCRIPTION
- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `_matchesInfo` response parameter is renamed `_matchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.
- Rename `transformFacetsDistribution` into `transformFacetDistribution`
- Add a patch to "copy the value" from `estimatedTotalHits` to `nbHits`.