### PR TITLE
Add missing docker command + supress warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM php:8.1
 
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/src/Contracts/Data.php
+++ b/src/Contracts/Data.php
@@ -40,6 +40,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->data[$offset])) {


### PR DESCRIPTION
During the v0.28 implementation, I noticed that I had an annoying warning in the tests, and during the attempts of fixing this warning, I had to move to PHP 7.4 to test, doing that I noticed the Docker config didn't have the `zip` and `git` libraries that are required to composer work.

I probably miss that because the PHP repo saves the vendor stuff locally not in a volume as I was used to, this PR fixes both things!