### PR TITLE
Tasks refactor v1

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -151,12 +151,12 @@ class Indexes extends Endpoint
 
     public function getTask($uid): array
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/tasks'.'/'.$uid);
+        return $this->http->get('/tasks/'.$uid, ['indexUid' => $this->uid]);
     }
 
     public function getTasks(): array
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/tasks');
+        return $this->http->get('/tasks', ['indexUid' => $this->uid]);
     }
 
     // Search

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -132,7 +132,7 @@ final class ClientTest extends TestCase
         $this->createEmptyIndex('indexA');
 
         $response = $this->client->updateIndex('indexA', ['primaryKey' => 'id']);
-        $this->client->waitForTask($response['uid']);
+        $this->client->waitForTask($response['taskUid']);
         $index = $this->client->getIndex($response['indexUid']);
 
         $this->assertSame($index->getPrimaryKey(), 'id');
@@ -147,7 +147,7 @@ final class ClientTest extends TestCase
         $this->assertCount(1, $response);
 
         $response = $this->client->deleteIndex('index');
-        $this->client->waitForTask($response['uid']);
+        $this->client->waitForTask($response['taskUid']);
 
         $this->expectException(ApiException::class);
         $index = $this->client->getIndex('index');
@@ -170,7 +170,7 @@ final class ClientTest extends TestCase
         $res = $this->client->deleteAllIndexes();
 
         $taskUids = array_map(function ($task) {
-            return $task['uid'];
+            return $task['uid'] ?? $task['taskUid'];
         }, $res);
         $res = $this->client->waitForTasks($taskUids);
 
@@ -186,7 +186,7 @@ final class ClientTest extends TestCase
 
         $res = $this->client->deleteAllIndexes();
         $taskUids = array_map(function ($task) {
-            return $task['uid'];
+            return $task['uid'] ?? $task['taskUid'];
         }, $res);
         $this->client->waitForTasks($taskUids);
 

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -18,7 +18,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $response = $index->getDocuments();
         $this->assertCount(\count(self::DOCUMENTS), $response);
@@ -33,7 +33,7 @@ final class DocumentsTest extends TestCase
 
         foreach ($promises as $promise) {
             $this->assertIsValidPromise($promise);
-            $index->waitForTask($promise['uid']);
+            $index->waitForTask($promise['taskUid']);
         }
 
         $response = $index->getDocuments();
@@ -52,7 +52,7 @@ final class DocumentsTest extends TestCase
         $promise = $index->addDocuments($documents);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $response = $index->getDocuments();
         $this->assertCount(\count($documents), $response);
@@ -75,7 +75,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $update = $index->waitForTask($promise['uid']);
+        $update = $index->waitForTask($promise['taskUid']);
 
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
@@ -96,7 +96,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $update = $index->waitForTask($promise['uid']);
+        $update = $index->waitForTask($promise['taskUid']);
 
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
@@ -117,7 +117,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $update = $index->waitForTask($promise['uid']);
+        $update = $index->waitForTask($promise['taskUid']);
 
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
@@ -141,7 +141,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $doc = $this->findDocumentWithId(self::DOCUMENTS, 4);
         $response = $index->getDocument($doc['id']);
 
@@ -155,7 +155,7 @@ final class DocumentsTest extends TestCase
         $stringDocumentId = 'myUniqueId';
         $index = $this->createEmptyIndex('documents');
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
-        $index->waitForTask($addDocumentResponse['uid']);
+        $index->waitForTask($addDocumentResponse['taskUid']);
         $response = $index->getDocument($stringDocumentId);
 
         $this->assertIsArray($response);
@@ -166,7 +166,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $replacement = [
             'id' => 2,
             'title' => 'The Red And The Black',
@@ -175,7 +175,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($response);
 
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $response = $index->getDocument($replacement['id']);
 
         $this->assertSame($replacement['id'], $response['id']);
@@ -189,7 +189,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $promise = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $replacement = [
             'id' => 456,
             'title' => 'The Little Prince',
@@ -198,7 +198,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocument($replacement['id']);
 
         $this->assertSame($replacement['id'], $response['id']);
@@ -214,7 +214,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $documentPromise = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($documentPromise['uid']);
+        $index->waitForTask($documentPromise['taskUid']);
 
         $replacements = [
             ['id' => 1, 'title' => 'Alice Outside Wonderland'],
@@ -229,7 +229,7 @@ final class DocumentsTest extends TestCase
 
         foreach ($promises as $promise) {
             $this->assertIsValidPromise($promise);
-            $index->waitForTask($promise['uid']);
+            $index->waitForTask($promise['taskUid']);
         }
 
         foreach ($replacements as $replacement) {
@@ -247,7 +247,7 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $document = [
             'id' => 9,
             'title' => '1984',
@@ -256,7 +256,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocument($document['id']);
 
         $this->assertSame($document['id'], $response['id']);
@@ -272,14 +272,14 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
 
         $documentId = 9;
         $promise = $index->deleteDocument($documentId);
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS), $response);
@@ -290,14 +290,14 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
 
         $documentId = 123;
         $promise = $index->deleteDocument($documentId);
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS) - 1, $response);
@@ -309,10 +309,10 @@ final class DocumentsTest extends TestCase
         $stringDocumentId = 'myUniqueId';
         $index = $this->createEmptyIndex('documents');
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
-        $index->waitForTask($addDocumentResponse['uid']);
+        $index->waitForTask($addDocumentResponse['taskUid']);
 
         $promise = $index->deleteDocument($stringDocumentId);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $response = $index->getDocuments();
 
@@ -323,13 +323,13 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $documentIds = [1, 2];
         $promise = $index->deleteDocuments($documentIds);
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS) - 2, $response);
@@ -346,10 +346,10 @@ final class DocumentsTest extends TestCase
         ];
         $index = $this->createEmptyIndex('documents');
         $addDocumentResponse = $index->addDocuments($documents);
-        $index->waitForTask($addDocumentResponse['uid']);
+        $index->waitForTask($addDocumentResponse['taskUid']);
 
         $promise = $index->deleteDocuments(['myUniqueId1', 'myUniqueId3']);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $response = $index->getDocuments();
         $this->assertCount(1, $response);
@@ -360,12 +360,12 @@ final class DocumentsTest extends TestCase
     {
         $index = $this->createEmptyIndex('documents');
         $response = $index->addDocuments(self::DOCUMENTS);
-        $index->waitForTask($response['uid']);
+        $index->waitForTask($response['taskUid']);
         $promise = $index->deleteAllDocuments();
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $response = $index->getDocuments();
 
         $this->assertCount(0, $response);
@@ -392,8 +392,8 @@ final class DocumentsTest extends TestCase
         $index = $this->createEmptyIndex('an-index');
         $response = $index->addDocuments($documents, 'unique');
 
-        $this->assertArrayHasKey('uid', $response);
-        $index->waitForTask($response['uid']);
+        $this->assertArrayHasKey('taskUid', $response);
+        $index->waitForTask($response['taskUid']);
 
         $this->assertSame('unique', $index->fetchPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
@@ -413,7 +413,7 @@ final class DocumentsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $this->assertSame('unique', $index->fetchPrimaryKey());
         $this->assertCount(1, $index->getDocuments());

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -116,7 +116,7 @@ final class IndexTest extends TestCase
         $primaryKey = 'id';
 
         $response = $this->index->update(['primaryKey' => $primaryKey]);
-        $this->client->waitForTask($response['uid']);
+        $this->client->waitForTask($response['taskUid']);
         $index = $this->client->getIndex($response['indexUid']);
 
         $this->assertSame($index->getPrimaryKey(), $primaryKey);
@@ -171,12 +171,12 @@ final class IndexTest extends TestCase
     {
         $promise = $this->index->addDocuments([['id' => 1, 'title' => 'Pride and Prejudice']]);
 
-        $response = $this->index->waitForTask($promise['uid']);
+        $response = $this->index->waitForTask($promise['taskUid']);
 
         /* @phpstan-ignore-next-line */
         $this->assertIsArray($response);
         $this->assertSame($response['status'], 'succeeded');
-        $this->assertSame($response['uid'], $promise['uid']);
+        $this->assertSame($response['uid'], $promise['taskUid']);
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAddition');
         $this->assertArrayHasKey('duration', $response);
@@ -187,10 +187,10 @@ final class IndexTest extends TestCase
     public function testWaitForTaskWithTimeoutAndInterval(): void
     {
         $promise = $this->index->addDocuments([['id' => 1, 'title' => 'Pride and Prejudice']]);
-        $response = $this->index->waitForTask($promise['uid'], 100, 20);
+        $response = $this->index->waitForTask($promise['taskUid'], 100, 20);
 
         $this->assertSame($response['status'], 'succeeded');
-        $this->assertSame($response['uid'], $promise['uid']);
+        $this->assertSame($response['uid'], $promise['taskUid']);
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAddition');
         $this->assertArrayHasKey('duration', $response);
@@ -202,10 +202,10 @@ final class IndexTest extends TestCase
     public function testWaitForTaskWithTimeout(): void
     {
         $promise = $this->index->addDocuments([['id' => 1, 'title' => 'Pride and Prejudice']]);
-        $response = $this->index->waitForTask($promise['uid'], 100);
+        $response = $this->index->waitForTask($promise['taskUid'], 100);
 
         $this->assertSame($response['status'], 'succeeded');
-        $this->assertSame($response['uid'], $promise['uid']);
+        $this->assertSame($response['uid'], $promise['taskUid']);
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAddition');
         $this->assertArrayHasKey('duration', $response);

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -17,7 +17,7 @@ final class SearchTest extends TestCase
         parent::setUp();
         $this->index = $this->createEmptyIndex('index');
         $promise = $this->index->updateDocuments(self::DOCUMENTS);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
     }
 
     public function testBasicSearch(): void
@@ -132,7 +132,7 @@ final class SearchTest extends TestCase
     {
         $index = $this->createEmptyIndex('another-index');
         $res = $index->delete();
-        $index->waitForTask($res['uid']);
+        $index->waitForTask($res['taskUid']);
 
         $this->expectException(ApiException::class);
 
@@ -236,7 +236,7 @@ final class SearchTest extends TestCase
     public function testParametersArray(): void
     {
         $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'limit' => 5,
@@ -280,7 +280,7 @@ final class SearchTest extends TestCase
     public function testParametersCanBeAStar(): void
     {
         $response = $this->index->updateFilterableAttributes(['title']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'limit' => 5,
@@ -324,7 +324,7 @@ final class SearchTest extends TestCase
     public function testSearchWithFilterCanBeInt(): void
     {
         $response = $this->index->updateFilterableAttributes(['id', 'genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'filter' => 'id < 12',
@@ -347,7 +347,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithFacetDistribution(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'facets' => ['genre'],
@@ -373,7 +373,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithFilters(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'filter' => [['genre = fantasy']],
@@ -395,7 +395,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithMultipleFilter(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'filter' => ['genre = fantasy', ['genre = fantasy', 'genre = fantasy']],
@@ -417,7 +417,7 @@ final class SearchTest extends TestCase
     public function testCustomSearchWithFilterAndAttributesToRetrieve(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'filter' => [['genre = fantasy']],
@@ -454,9 +454,9 @@ final class SearchTest extends TestCase
             'attribute',
             'exactness',
         ]);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
         $response = $this->index->updateSortableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'sort' => ['genre:asc'],
@@ -485,9 +485,9 @@ final class SearchTest extends TestCase
             'attribute',
             'exactness',
         ]);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
         $response = $this->index->updateSortableAttributes(['id']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'sort' => ['id:asc'],
@@ -516,9 +516,9 @@ final class SearchTest extends TestCase
             'attribute',
             'exactness',
         ]);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
         $response = $this->index->updateSortableAttributes(['id', 'title']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search('prince', [
             'sort' => ['id:asc', 'title:asc'],
@@ -668,7 +668,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithFacetsOption(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search(
             'prince',
@@ -686,9 +686,9 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithFacetsOptionAndMultipleFacets(): void
     {
         $response = $this->index->addDocuments([['id' => 32, 'title' => 'The Witcher', 'genre' => 'adventure', 'adaptation' => 'video game']]);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
         $response = $this->index->updateFilterableAttributes(['genre', 'adaptation']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $response = $this->index->search(
             'witch',
@@ -708,7 +708,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithTransformFacetsDritributionOptionToFilter(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $filterAllFacets = function (array $facets): array {
             $filterOneFacet = function (array $facet): array {
@@ -745,7 +745,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithTransformFacetsDritributionOptionToMap(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $facetsToUpperFunc = function (array $facets): array {
             $changeOneFacet = function (array $facet): array {
@@ -783,7 +783,7 @@ final class SearchTest extends TestCase
     public function testBasicSearchWithTransformFacetsDritributionOptionToOder(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);
-        $this->index->waitForTask($response['uid']);
+        $this->index->waitForTask($response['taskUid']);
 
         $facetsToUpperFunc = function (array $facets): array {
             $sortOneFacet = function (array $facet): array {

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -33,7 +33,7 @@ final class TenantTokenTest extends TestCase
     public function testGenerateTenantTokenWithSearchRulesOnly(): void
     {
         $promise = $this->client->index('tenantToken')->addDocuments(self::DOCUMENTS);
-        $this->client->waitForTask($promise['uid']);
+        $this->client->waitForTask($promise['taskUid']);
 
         $token = $this->privateClient->generateTenantToken(['*']);
         $tokenClient = new Client($this->host, $token);
@@ -46,7 +46,7 @@ final class TenantTokenTest extends TestCase
     public function testGenerateTenantTokenWithSearchRulesAsObject(): void
     {
         $promise = $this->client->index('tenantToken')->addDocuments(self::DOCUMENTS);
-        $this->client->waitForTask($promise['uid']);
+        $this->client->waitForTask($promise['taskUid']);
 
         $token = $this->privateClient->generateTenantToken((object) ['*' => (object) []]);
         $tokenClient = new Client($this->host, $token);
@@ -59,11 +59,11 @@ final class TenantTokenTest extends TestCase
     public function testGenerateTenantTokenWithFilter(): void
     {
         $promise = $this->client->index('tenantToken')->addDocuments(self::DOCUMENTS);
-        $this->client->waitForTask($promise['uid']);
+        $this->client->waitForTask($promise['taskUid']);
         $promiseFromFilter = $this->client->index('tenantToken')->updateFilterableAttributes([
             'id',
         ]);
-        $this->client->waitForTask($promiseFromFilter['uid']);
+        $this->client->waitForTask($promiseFromFilter['taskUid']);
 
         $token = $this->privateClient->generateTenantToken((object) ['tenantToken' => (object) ['filter' => 'id > 10']]);
         $tokenClient = new Client($this->host, $token);

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -28,7 +28,7 @@ final class DisplayedAttributesTest extends TestCase
         $promise = $index->updateDisplayedAttributes($newAttributes);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $displayedAttributes = $index->getDisplayedAttributes();
 
@@ -41,13 +41,13 @@ final class DisplayedAttributesTest extends TestCase
         $newAttributes = ['title'];
 
         $promise = $index->updateDisplayedAttributes($newAttributes);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $promise = $index->resetDisplayedAttributes();
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $displayedAttributes = $index->getDisplayedAttributes();
         $this->assertEquals(['*'], $displayedAttributes);

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -29,7 +29,7 @@ final class DistinctAttributeTest extends TestCase
         $promise = $this->index->updateDistinctAttribute($distinctAttribute);
 
         $this->assertIsValidPromise($promise);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
 
         $this->assertEquals($distinctAttribute, $this->index->getDistinctAttribute());
     }
@@ -38,12 +38,12 @@ final class DistinctAttributeTest extends TestCase
     {
         $distinctAttribute = 'description';
         $promise = $this->index->updateDistinctAttribute($distinctAttribute);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
 
         $promise = $this->index->resetDistinctAttribute();
 
         $this->assertIsValidPromise($promise);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $this->assertNull($this->index->getDistinctAttribute());
     }
 }

--- a/tests/Settings/FilterableAttributesTest.php
+++ b/tests/Settings/FilterableAttributesTest.php
@@ -25,7 +25,7 @@ final class FilterableAttributesTest extends TestCase
         $promise = $index->updateFilterableAttributes($newAttributes);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $filterableAttributes = $index->getFilterableAttributes();
 
@@ -38,13 +38,13 @@ final class FilterableAttributesTest extends TestCase
         $newAttributes = ['title'];
 
         $promise = $index->updateFilterableAttributes($newAttributes);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $promise = $index->resetFilterableAttributes();
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $filterableAttributes = $index->getFilterableAttributes();
         $this->assertEmpty($filterableAttributes);

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -44,7 +44,7 @@ final class RankingRulesTest extends TestCase
         $promise = $this->index->updateRankingRules($newRankingRules);
 
         $this->assertIsValidPromise($promise);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
 
         $rankingRules = $this->index->getRankingRules();
 
@@ -57,7 +57,7 @@ final class RankingRulesTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $rankingRules = $this->index->getRankingRules();
 
         $this->assertEquals(self::DEFAULT_RANKING_RULES, $rankingRules);

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -32,7 +32,7 @@ final class SearchableAttributesTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $indexA->waitForTask($promise['uid']);
+        $indexA->waitForTask($promise['taskUid']);
         $updatedAttributes = $indexA->getSearchableAttributes();
 
         $this->assertEquals($searchableAttributes, $updatedAttributes);
@@ -45,7 +45,7 @@ final class SearchableAttributesTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
         $searchableAttributes = $index->getSearchableAttributes();
 
         $this->assertEquals(['*'], $searchableAttributes);

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -84,7 +84,7 @@ final class SettingsTest extends TestCase
             'stopWords' => ['the'],
         ]);
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $settings = $index->getSettings();
 
@@ -125,14 +125,14 @@ final class SettingsTest extends TestCase
         ]);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $promise = $index->updateSettings([
             'searchableAttributes' => ['title'],
         ]);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $settings = $index->getSettings();
 
@@ -160,12 +160,12 @@ final class SettingsTest extends TestCase
             'stopWords' => ['the'],
         ]);
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $promise = $index->resetSettings();
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $settings = $index->getSettings();
 
@@ -193,11 +193,11 @@ final class SettingsTest extends TestCase
 
         $resetPromise = $index->resetSettings();
         $this->assertIsValidPromise($resetPromise);
-        $index->waitForTask($resetPromise['uid']);
+        $index->waitForTask($resetPromise['taskUid']);
 
         $settings = $index->getSettings();
         $promise = $index->updateSettings($settings);
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
     }
 }

--- a/tests/Settings/SortableAttributesTest.php
+++ b/tests/Settings/SortableAttributesTest.php
@@ -25,7 +25,7 @@ final class SortableAttributesTest extends TestCase
         $promise = $index->updateSortableAttributes($newAttributes);
 
         $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $sortableAttributes = $index->getSortableAttributes();
 
@@ -38,13 +38,13 @@ final class SortableAttributesTest extends TestCase
         $newAttributes = ['title'];
 
         $promise = $index->updateSortableAttributes($newAttributes);
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $promise = $index->resetSortableAttributes();
 
         $this->assertIsValidPromise($promise);
 
-        $index->waitForTask($promise['uid']);
+        $index->waitForTask($promise['taskUid']);
 
         $sortableAttributes = $index->getSortableAttributes();
         $this->assertEmpty($sortableAttributes);

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -31,7 +31,7 @@ final class StopWordsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $stopWords = $this->index->getStopWords();
 
         $this->assertEquals($newStopWords, $stopWords);
@@ -40,12 +40,12 @@ final class StopWordsTest extends TestCase
     public function testResetStopWords(): void
     {
         $promise = $this->index->updateStopWords(['the']);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
 
         $promise = $this->index->resetStopWords();
 
         $this->assertIsValidPromise($promise);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
 
         $stopWords = $this->index->getStopWords();
 

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -34,7 +34,7 @@ final class SynonymsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $synonyms = $this->index->getSynonyms();
 
         $this->assertEquals($newSynonyms, $synonyms);
@@ -47,7 +47,7 @@ final class SynonymsTest extends TestCase
 
         $this->assertIsValidPromise($promise);
 
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $synonyms = $this->index->getSynonyms();
 
         $this->assertEquals($newSynonyms, $synonyms);
@@ -58,12 +58,12 @@ final class SynonymsTest extends TestCase
         $promise = $this->index->updateSynonyms([
             'hp' => ['harry potter'],
         ]);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $promise = $this->index->resetSynonyms();
 
         $this->assertIsValidPromise($promise);
 
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $synonyms = $this->index->getSynonyms();
 
         $this->assertEmpty($synonyms);

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -46,7 +46,7 @@ final class TypoToleranceTest extends TestCase
             'disableOnAttributes' => ['title'],
         ];
         $promise = $this->index->updateTypoTolerance($newTypoTolerance);
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $typoTolerance = $this->index->getTypoTolerance();
 
         $this->assertIsValidPromise($promise);
@@ -56,7 +56,7 @@ final class TypoToleranceTest extends TestCase
     public function testResetTypoTolerance(): void
     {
         $promise = $this->index->resetTypoTolerance();
-        $this->index->waitForTask($promise['uid']);
+        $this->index->waitForTask($promise['taskUid']);
         $typoTolerance = $this->index->getTypoTolerance();
 
         $this->assertIsValidPromise($promise);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,20 +55,20 @@ abstract class TestCase extends BaseTestCase
     {
         $res = $this->client->deleteAllIndexes();
         $uids = array_map(function ($task) {
-            return $task['uid'];
+            return $task['uid'] ?? $task['taskUid'];
         }, $res);
         $this->client->waitForTasks($uids);
     }
 
     public function assertIsValidPromise(array $promise): void
     {
-        $this->assertArrayHasKey('uid', $promise);
+        $this->assertArrayHasKey('taskUid', $promise);
     }
 
     public function createEmptyIndex($indexName, $options = []): Indexes
     {
         $response = $this->client->createIndex($indexName, $options);
-        $this->client->waitForTask($response['uid']);
+        $this->client->waitForTask($response['taskUid']);
 
         return $this->client->getIndex($response['indexUid']);
     }


### PR DESCRIPTION
This PR changes all the places that currently are handling the summarized task version from `uid` to `taskUid`. And replace the tasks route index namespace with the global one + add the ability to infer the index from it.

disclaimer: The work in the tasks is not done yet, this is the first step.

