### PR TITLE
Keys changes v2

### DIFF
--- a/src/Contracts/KeysQuery.php
+++ b/src/Contracts/KeysQuery.php
@@ -25,9 +25,9 @@ class KeysQuery
 
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'offset' => $this->offset ?? null,
             'limit' => $this->limit ?? null,
-        ];
+        ], function ($item) { return null != $item; });
     }
 }

--- a/src/Contracts/KeysQuery.php
+++ b/src/Contracts/KeysQuery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+class KeysQuery
+{
+    private int $offset;
+    private int $limit;
+
+    public function setOffset(int $offset): KeysQuery
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function setLimit(int $limit): KeysQuery
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'offset' => $this->offset ?? null,
+            'limit' => $this->limit ?? null,
+        ];
+    }
+}

--- a/src/Contracts/KeysQuery.php
+++ b/src/Contracts/KeysQuery.php
@@ -28,6 +28,6 @@ class KeysQuery
         return array_filter([
             'offset' => $this->offset ?? null,
             'limit' => $this->limit ?? null,
-        ], function ($item) { return null != $item; });
+        ], function ($item) { return null != $item || is_numeric($item); });
     }
 }

--- a/src/Contracts/KeysResults.php
+++ b/src/Contracts/KeysResults.php
@@ -12,7 +12,8 @@ class KeysResults extends Data
 
     public function __construct(array $params)
     {
-        $this->data = $params['results'] ?? [];
+        parent::__construct($params['results'] ?? []);
+
         $this->offset = $params['offset'];
         $this->limit = $params['limit'];
         $this->total = $params['total'] ?? 0;
@@ -53,6 +54,6 @@ class KeysResults extends Data
 
     public function count(): int
     {
-        return count($this->data);
+        return \count($this->data);
     }
 }

--- a/src/Contracts/KeysResults.php
+++ b/src/Contracts/KeysResults.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+class KeysResults extends Data
+{
+    private int $offset;
+    private int $limit;
+    private int $total;
+
+    public function __construct(array $params)
+    {
+        $this->data = $params['results'] ?? [];
+        $this->offset = $params['offset'];
+        $this->limit = $params['limit'];
+        $this->total = $params['total'] ?? 0;
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    public function getResults(): array
+    {
+        return $this->data;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'results' => $this->data,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'total' => $this->total,
+        ];
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
+    }
+}

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -20,9 +20,9 @@ trait HandlesKeys
         return $this->keys->allRaw();
     }
 
-    public function getKey($key): Keys
+    public function getKey($keyOrUid): Keys
     {
-        return $this->keys->get($key);
+        return $this->keys->get($keyOrUid);
     }
 
     public function createKey(array $options = []): Keys
@@ -30,13 +30,13 @@ trait HandlesKeys
         return $this->keys->create($options);
     }
 
-    public function updateKey(string $key, array $options = []): Keys
+    public function updateKey(string $keyOrUid, array $options = []): Keys
     {
-        return $this->keys->update($key, $options);
+        return $this->keys->update($keyOrUid, $options);
     }
 
-    public function deleteKey(string $key): array
+    public function deleteKey(string $keyOrUid): array
     {
-        return $this->keys->delete($key);
+        return $this->keys->delete($keyOrUid);
     }
 }

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints\Delegates;
 
-use MeiliSearch\Endpoints\Keys;
-use MeiliSearch\Contracts\KeysResults;
 use MeiliSearch\Contracts\KeysQuery;
+use MeiliSearch\Contracts\KeysResults;
+use MeiliSearch\Endpoints\Keys;
 
 trait HandlesKeys
 {

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints\Delegates;
 
 use MeiliSearch\Endpoints\Keys;
+use MeiliSearch\Contracts\KeysResults;
+use MeiliSearch\Contracts\KeysQuery;
 
 trait HandlesKeys
 {
-    public function getKeys(): array
+    public function getKeys(KeysQuery $options = null): KeysResults
     {
-        return $this->keys->all();
+        return $this->keys->all($options);
     }
 
     public function getRawKeys(): array

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -148,9 +148,9 @@ class Keys extends Endpoint
         return $this->updatedAt;
     }
 
-    public function get($key): self
+    public function get($keyOrUid): self
     {
-        $response = $this->http->get(self::PATH.'/'.$key);
+        $response = $this->http->get(self::PATH.'/'.$keyOrUid);
 
         return $this->fill($response);
     }
@@ -186,16 +186,16 @@ class Keys extends Endpoint
         return $this->fill($response);
     }
 
-    public function update(string $key, array $options = []): self
+    public function update(string $keyOrUid, array $options = []): self
     {
         $data = array_intersect_key($options, array_flip(['description', 'name']));
-        $response = $this->http->patch(self::PATH.'/'.$key, $data);
+        $response = $this->http->patch(self::PATH.'/'.$keyOrUid, $data);
 
         return $this->fill($response);
     }
 
-    public function delete(string $key): array
+    public function delete(string $keyOrUid): array
     {
-        return $this->http->delete(self::PATH.'/'.$key) ?? [];
+        return $this->http->delete(self::PATH.'/'.$keyOrUid) ?? [];
     }
 }

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -7,8 +7,8 @@ namespace MeiliSearch\Endpoints;
 use DateTime;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Contracts\Http;
-use MeiliSearch\Contracts\KeysResults;
 use MeiliSearch\Contracts\KeysQuery;
+use MeiliSearch\Contracts\KeysResults;
 
 class Keys extends Endpoint
 {

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -7,6 +7,8 @@ namespace MeiliSearch\Endpoints;
 use DateTime;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Contracts\Http;
+use MeiliSearch\Contracts\KeysResults;
+use MeiliSearch\Contracts\KeysQuery;
 
 class Keys extends Endpoint
 {
@@ -153,20 +155,25 @@ class Keys extends Endpoint
         return $this->fill($response);
     }
 
-    public function all(): array
+    public function all(KeysQuery $options = null): KeysResults
     {
-        $keys = [];
+        $query = isset($options) ? $options->toArray() : [];
 
-        foreach ($this->allRaw()['results'] as $key) {
+        $keys = [];
+        $response = $this->allRaw($query);
+
+        foreach ($response['results'] as $key) {
             $keys[] = $this->newInstance($key);
         }
 
-        return $keys;
+        $response['results'] = $keys;
+
+        return new KeysResults($response);
     }
 
-    public function allRaw(): array
+    public function allRaw(array $options = []): array
     {
-        return $this->http->get(self::PATH.'/');
+        return $this->http->get(self::PATH.'/', $options);
     }
 
     public function create(array $options = []): self

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -178,7 +178,7 @@ class Keys extends Endpoint
 
     public function create(array $options = []): self
     {
-        if ($options['expiresAt'] && $options['expiresAt'] instanceof DateTime) {
+        if (isset($options['expiresAt']) && $options['expiresAt'] instanceof DateTime) {
             $options['expiresAt'] = $options['expiresAt']->format('Y-m-d\TH:i:s.vu\Z');
         }
         $response = $this->http->post(self::PATH, $options);

--- a/tests/Contracts/KeysQueryTest.php
+++ b/tests/Contracts/KeysQueryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use MeiliSearch\Contracts\KeysQuery;
+use PHPUnit\Framework\TestCase;
+
+class KeysQueryTest extends TestCase
+{
+    public function testToArrayWithSetOffsetAndSetLimit(): void
+    {
+        $data = (new KeysQuery())->setLimit(10)->setOffset(18);
+
+        $this->assertEquals($data->toArray(), ['limit' => 10, 'offset' => 18]);
+    }
+
+    public function testToArrayWithSetOffset(): void
+    {
+        $data = (new KeysQuery())->setOffset(5);
+
+        $this->assertEquals($data->toArray(), ['offset' => 5]);
+    }
+
+    public function testToArrayWithoutSet(): void
+    {
+        $data = new KeysQuery();
+
+        $this->assertEquals($data->toArray(), []);
+    }
+}

--- a/tests/Contracts/KeysQueryTest.php
+++ b/tests/Contracts/KeysQueryTest.php
@@ -29,4 +29,11 @@ class KeysQueryTest extends TestCase
 
         $this->assertEquals($data->toArray(), []);
     }
+
+    public function testToArrayWithZeros(): void
+    {
+        $data = (new KeysQuery())->setLimit(0)->setOffset(0);
+
+        $this->assertEquals($data->toArray(), ['limit' => 0, 'offset' => 0]);
+    }
 }

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -81,6 +81,14 @@ final class KeysAndPermissionsTest extends TestCase
         $this->assertCount(1, $response);
     }
 
+    public function testGetKeysWithOffset(): void
+    {
+        $response = $this->client->getKeys((new KeysQuery())->setOffset(100));
+
+        $this->assertCount(0, $response);
+    }
+
+
     public function testGetKey(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Endpoints;
 use MeiliSearch\Client;
 use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
+use MeiliSearch\Contracts\KeysQuery;
 
 final class KeysAndPermissionsTest extends TestCase
 {
@@ -19,14 +20,14 @@ final class KeysAndPermissionsTest extends TestCase
     public function testGetKeysAlwaysReturnsArray(): void
     {
         /* @phpstan-ignore-next-line */
-        $this->assertIsArray($this->client->getKeys());
+        $this->assertIsIterable($this->client->getKeys());
     }
 
     public function testGetKeysDefault(): void
     {
         $response = $this->client->getKeys();
 
-        $this->assertGreaterThan(2, $response);
+        $this->assertGreaterThan(0, $response->count());
         $this->assertIsArray($response[0]->getActions());
         $this->assertIsArray($response[0]->getIndexes());
         $this->assertNull($response[0]->getExpiresAt());
@@ -71,6 +72,13 @@ final class KeysAndPermissionsTest extends TestCase
         $this->expectException(ApiException::class);
         $client = new Client($this->host, 'bad-key');
         $client->getKeys();
+    }
+
+    public function testGetKeysWithLimit(): void
+    {
+        $response = $this->client->getKeys((new KeysQuery())->setLimit(1));
+
+        $this->assertCount(1, $response);
     }
 
     public function testGetKey(): void
@@ -266,8 +274,11 @@ final class KeysAndPermissionsTest extends TestCase
                   "createdAt": "2022-06-14T10:34:03.627606639Z",
                   "updatedAt": "2022-06-14T10:34:03.627606639Z"
                 }
-              ]
-            }
+              ],
+              "limit": 10,
+              "offset": 0,
+              "total": 3
+          }
         ');
 
         $newClient = new \MeiliSearch\Client('https://localhost:7700', null, $httpClient);

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -199,6 +199,21 @@ final class KeysAndPermissionsTest extends TestCase
         $this->client->deleteKey($response->getKey());
     }
 
+    public function testCreateKeyWithUid(): void
+    {
+        $key = $this->client->createKey([
+            'uid' => 'acab6d06-5385-47a2-a534-1ed4fd7f6402',
+            'actions' => ['*'],
+            'indexes' => ['*'],
+            'expiresAt' => null,
+        ]);
+
+        $this->assertNotNull($key->getKey());
+        $this->assertEquals('acab6d06-5385-47a2-a534-1ed4fd7f6402', $key->getUid());
+
+        $this->client->deleteKey($key->getKey());
+    }
+
     public function testUpdateKeyWithExpInDate(): void
     {
         $key = $this->client->createKey(self::INFO_KEY);

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use MeiliSearch\Client;
+use MeiliSearch\Contracts\KeysQuery;
 use MeiliSearch\Exceptions\ApiException;
 use Tests\TestCase;
-use MeiliSearch\Contracts\KeysQuery;
 
 final class KeysAndPermissionsTest extends TestCase
 {
@@ -87,7 +87,6 @@ final class KeysAndPermissionsTest extends TestCase
 
         $this->assertCount(0, $response);
     }
-
 
     public function testGetKey(): void
     {


### PR DESCRIPTION
- Create `KeysQuery` and `KeysResults` to handle pagination in keys endpoint.
- Apply the `KeysQuery` to `getKeys` function
- Rename `$key` to `$keyOrUid` in `getKeys`