### PR TITLE
Documents changes v2

### DIFF
--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -37,6 +37,6 @@ class DocumentsQuery
             'offset' => $this->offset ?? null,
             'limit' => $this->limit ?? null,
             'fields' => isset($this->fields) ? implode(',', $this->fields) : null,
-        ], function($item) { return $item != null; });
+        ], function ($item) { return null != $item; });
     }
 }

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+class DocumentsQuery
+{
+    private int $offset;
+    private int $limit;
+    private array $fields;
+
+    public function setOffset(int $offset): DocumentsQuery
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function setLimit(int $limit): DocumentsQuery
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function setFields(array $fields): DocumentsQuery
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'offset' => $this->offset ?? null,
+            'limit' => $this->limit ?? null,
+            'fields' => isset($this->fields) ? implode(',', $this->fields) : null,
+        ], function($item) { return $item != null; });
+    }
+}

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -37,6 +37,6 @@ class DocumentsQuery
             'offset' => $this->offset ?? null,
             'limit' => $this->limit ?? null,
             'fields' => isset($this->fields) ? implode(',', $this->fields) : null,
-        ], function ($item) { return null != $item; });
+        ], function ($item) { return null != $item || is_numeric($item); });
     }
 }

--- a/src/Contracts/DocumentsResults.php
+++ b/src/Contracts/DocumentsResults.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+class DocumentsResults extends Data
+{
+    private int $offset;
+    private int $limit;
+    private int $total;
+
+    public function __construct(array $params)
+    {
+        $this->data = $params['results'] ?? [];
+        $this->offset = $params['offset'];
+        $this->limit = $params['limit'];
+        $this->total = $params['total'] ?? 0;
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    public function getResults(): array
+    {
+        return $this->data;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'results' => $this->data,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'total' => $this->total,
+        ];
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
+    }
+}

--- a/src/Contracts/DocumentsResults.php
+++ b/src/Contracts/DocumentsResults.php
@@ -12,7 +12,8 @@ class DocumentsResults extends Data
 
     public function __construct(array $params)
     {
-        $this->data = $params['results'] ?? [];
+        parent::__construct($params['results'] ?? []);
+
         $this->offset = $params['offset'];
         $this->limit = $params['limit'];
         $this->total = $params['total'] ?? 0;
@@ -53,6 +54,6 @@ class DocumentsResults extends Data
 
     public function count(): int
     {
-        return count($this->data);
+        return \count($this->data);
     }
 }

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints\Delegates;
 
 use Generator;
-use MeiliSearch\Exceptions\InvalidArgumentException;
-use MeiliSearch\Contracts\DocumentsResults;
 use MeiliSearch\Contracts\DocumentsQuery;
+use MeiliSearch\Contracts\DocumentsResults;
+use MeiliSearch\Exceptions\InvalidArgumentException;
 
 trait HandlesDocuments
 {

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -6,6 +6,8 @@ namespace MeiliSearch\Endpoints\Delegates;
 
 use Generator;
 use MeiliSearch\Exceptions\InvalidArgumentException;
+use MeiliSearch\Contracts\DocumentsResults;
+use MeiliSearch\Contracts\DocumentsQuery;
 
 trait HandlesDocuments
 {
@@ -16,9 +18,12 @@ trait HandlesDocuments
         return $this->http->get(self::PATH.'/'.$this->uid.'/documents/'.$documentId);
     }
 
-    public function getDocuments(array $query = [])
+    public function getDocuments(DocumentsQuery $options = null): DocumentsResults
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/documents', $query);
+        $query = isset($options) ? $options->toArray() : [];
+        $response = $this->http->get(self::PATH.'/'.$this->uid.'/documents', $query);
+
+        return new DocumentsResults($response);
     }
 
     public function addDocuments(array $documents, ?string $primaryKey = null)

--- a/tests/Contracts/DocumentsQueryTest.php
+++ b/tests/Contracts/DocumentsQueryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use PHPUnit\Framework\TestCase;
+use MeiliSearch\Contracts\DocumentsQuery;
+
+class DocumentsQueryTest extends TestCase
+{
+    public function testSetFields(): void
+    {
+        $data = (new DocumentsQuery())->setLimit(10)->setFields(['abc', 'xyz']);
+
+        $this->assertEquals($data->toArray(), ['limit' => 10, 'fields' => 'abc,xyz']);
+    }
+
+    public function testToArrayWithoutSetFields(): void
+    {
+        $data = (new DocumentsQuery())->setLimit(10);
+
+        $this->assertEquals($data->toArray(), ['limit' => 10]);
+    }
+
+    public function testToArrayWithoutSetOffset(): void
+    {
+        $data = (new DocumentsQuery())->setOffset(10);
+
+        $this->assertEquals($data->toArray(), ['offset' => 10]);
+    }
+}

--- a/tests/Contracts/DocumentsQueryTest.php
+++ b/tests/Contracts/DocumentsQueryTest.php
@@ -29,4 +29,11 @@ class DocumentsQueryTest extends TestCase
 
         $this->assertEquals($data->toArray(), ['offset' => 10]);
     }
+
+    public function testToArrayWithZeros(): void
+    {
+        $data = (new DocumentsQuery())->setLimit(0)->setOffset(0);
+
+        $this->assertEquals($data->toArray(), ['limit' => 0, 'offset' => 0]);
+    }
 }

--- a/tests/Contracts/DocumentsQueryTest.php
+++ b/tests/Contracts/DocumentsQueryTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use PHPUnit\Framework\TestCase;
 use MeiliSearch\Contracts\DocumentsQuery;
+use PHPUnit\Framework\TestCase;
 
 class DocumentsQueryTest extends TestCase
 {

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use MeiliSearch\Contracts\DocumentsQuery;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\InvalidArgumentException;
 use MeiliSearch\Exceptions\JsonEncodingException;
-use MeiliSearch\Contracts\DocumentsQuery;
 use Tests\TestCase;
 
 final class DocumentsTest extends TestCase

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -19,7 +19,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
 
         $index->waitForTask($promise['taskUid']);
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
@@ -35,7 +35,7 @@ final class DocumentsTest extends TestCase
             $index->waitForTask($promise['taskUid']);
         }
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
@@ -53,7 +53,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
         $index->waitForTask($promise['taskUid']);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(\count($documents), $response);
 
         foreach ($documents as $k => $document) {
@@ -79,7 +79,7 @@ final class DocumentsTest extends TestCase
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(20, $response);
     }
 
@@ -100,7 +100,7 @@ final class DocumentsTest extends TestCase
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(20, $response);
     }
 
@@ -121,7 +121,7 @@ final class DocumentsTest extends TestCase
         $this->assertEquals($update['status'], 'succeeded');
         $this->assertNotEquals($update['details']['receivedDocuments'], 0);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(20, $response);
     }
 
@@ -180,7 +180,7 @@ final class DocumentsTest extends TestCase
         $this->assertSame($replacement['id'], $response['id']);
         $this->assertSame($replacement['title'], $response['title']);
         $this->assertFalse(array_search('comment', $response, true));
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
@@ -204,7 +204,7 @@ final class DocumentsTest extends TestCase
         $this->assertSame($replacement['title'], $response['title']);
         $this->assertArrayHasKey('comment', $response);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS), $response);
     }
@@ -238,7 +238,7 @@ final class DocumentsTest extends TestCase
             $this->assertArrayHasKey('comment', $response);
         }
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(\count(self::DOCUMENTS), $response);
     }
 
@@ -262,7 +262,7 @@ final class DocumentsTest extends TestCase
         $this->assertSame($document['title'], $response['title']);
         $this->assertFalse(array_search('comment', $response, true));
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS) + 1, $response);
     }
@@ -279,7 +279,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
 
         $index->waitForTask($promise['taskUid']);
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS), $response);
         $this->assertNull($this->findDocumentWithId($response, $documentId));
@@ -297,7 +297,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
 
         $index->waitForTask($promise['taskUid']);
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS) - 1, $response);
         $this->assertNull($this->findDocumentWithId($response, $documentId));
@@ -313,7 +313,7 @@ final class DocumentsTest extends TestCase
         $promise = $index->deleteDocument($stringDocumentId);
         $index->waitForTask($promise['taskUid']);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertEmpty($response);
     }
@@ -329,7 +329,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
 
         $index->waitForTask($promise['taskUid']);
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(\count(self::DOCUMENTS) - 2, $response);
         $this->assertNull($this->findDocumentWithId($response, $documentIds[0]));
@@ -350,9 +350,9 @@ final class DocumentsTest extends TestCase
         $promise = $index->deleteDocuments(['myUniqueId1', 'myUniqueId3']);
         $index->waitForTask($promise['taskUid']);
 
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
         $this->assertCount(1, $response);
-        $this->assertSame([['id' => 'myUniqueId2']], $response);
+        $this->assertSame([['id' => 'myUniqueId2']], $response->getResults());
     }
 
     public function testDeleteAllDocuments(): void
@@ -365,7 +365,7 @@ final class DocumentsTest extends TestCase
         $this->assertIsValidPromise($promise);
 
         $index->waitForTask($promise['taskUid']);
-        $response = $index->getDocuments()['results'];
+        $response = $index->getDocuments();
 
         $this->assertCount(0, $response);
     }
@@ -395,7 +395,7 @@ final class DocumentsTest extends TestCase
         $index->waitForTask($response['taskUid']);
 
         $this->assertSame('unique', $index->fetchPrimaryKey());
-        $this->assertCount(1, $index->getDocuments()['results']);
+        $this->assertCount(1, $index->getDocuments());
     }
 
     public function testUpdateDocumentWithPrimaryKey(): void
@@ -415,7 +415,7 @@ final class DocumentsTest extends TestCase
         $index->waitForTask($promise['taskUid']);
 
         $this->assertSame('unique', $index->fetchPrimaryKey());
-        $this->assertCount(1, $index->getDocuments()['results']);
+        $this->assertCount(1, $index->getDocuments());
     }
 
     /**

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Endpoints;
 use MeiliSearch\Exceptions\ApiException;
 use MeiliSearch\Exceptions\InvalidArgumentException;
 use MeiliSearch\Exceptions\JsonEncodingException;
+use MeiliSearch\Contracts\DocumentsQuery;
 use Tests\TestCase;
 
 final class DocumentsTest extends TestCase
@@ -416,6 +417,18 @@ final class DocumentsTest extends TestCase
 
         $this->assertSame('unique', $index->fetchPrimaryKey());
         $this->assertCount(1, $index->getDocuments());
+    }
+
+    public function testGetDocumentsWithPagination(): void
+    {
+        $index = $this->createEmptyIndex('documents');
+        $promise = $index->addDocuments(self::DOCUMENTS);
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $response = $index->getDocuments((new DocumentsQuery())->setLimit(3));
+
+        $this->assertCount(3, $response);
     }
 
     /**


### PR DESCRIPTION
- Create `DocumentsQuery` to handle pagination in documents endpoint.
- Introduce `DocumentsResults` & make the `getDocuments` return a object
- Add `DocumentsQuery/Results` to `getDocuments` handler