### PR TITLE
Update version for the next release (v0.24.0)

### DIFF
--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -6,7 +6,7 @@ namespace MeiliSearch;
 
 class MeiliSearch
 {
-    public const VERSION = '0.23.3';
+    public const VERSION = '0.24.0';
 
     public static function qualifiedVersion()
     {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥  Breaking changes

:warning: Small disclaimer: The `rawSearch` (and other `raw*` functions) are a direct connection between your PHP application and Meilisearch, you may find changes that are not present in this section.

- `MeiliSearch\Client->getDumpStatus` method was removed. (#336) @brunoocasali
- `MeiliSearch\Client->getIndexes` method now return a object type `IndexesResults`. (#341), (#345) @brunoocasali
- `MeiliSearch\Client->generateTenantToken` now require a `String apiKeyUid` which is the `uid` of the `Key` instance used to sign the token.  (#343) @brunoocasali
- `MeiliSearch\Client->createDump` now responds with `Task` object. (#336, #337) @brunoocasali
- `MeiliSearch\Client->getKeys` method now return a object type `KeysResults`. (#343), (#338) @brunoocasali
- `MeiliSearch\Client->updateKey` now can just update a `description` and/or `name`, if there are other key/value will be silently ignored. (#343), (#338) @brunoocasali
- `MeiliSearch\Client->getTasks` method now return a object type `TasksResults`. (#337), (#346) @brunoocasali
- `MeiliSearch\Index->getTasks` method now return a object type `TasksResults`. (#337), (#346) @brunoocasali
- `MeiliSearch\Index->search` `facetsDistribution` is now `facets` (#332) @curquiza
- `MeiliSearch\Index->search` `matches` is now `showMatchesPosition` (#332) @curquiza
- `MeiliSearch\Index->getDocuments` method now return a object type `DocumentsResults`.
- `MeiliSearch\Index->getDocuments` method now accepts a object as a parameter and `offset`, `limit`, `attributesToRetrieve` were not longer accepted.
- `exhaustiveNbHits`, `facetsDistribution`, `exhaustiveFacetsCount` were removed from `SearchResult`. (#332) @curquiza


## 🚀  Enhancements
- `MeiliSearch\Client->getIndexes` accepts a object `IndexesQuery` to filter and paginate the results.
- `MeiliSearch\Client->getKeys` accepts a object `KeysQuery` to filter and paginate the results. (#343), (#338) @brunoocasali
- `MeiliSearch\Client->getKey` accepts both a `Key#uid` or `Key#key` value. (#343), (#338) @brunoocasali
- `MeiliSearch\Client->getTasks` accepts a object `TasksQuery` to filter and paginate the results. (#337), (#346) @brunoocasali
- `MeiliSearch\Index->getTasks` accepts a object `TasksQuery` to filter and paginate the results. (#337), (#346) @brunoocasali
- `MeiliSearch\Client->createKey` can specify a `uid` (optionally) to create a new `Key`. (#343), (#338) @brunoocasali
- `MeiliSearch\Index->getDocument` accepts a `fields` list to compact the remap the response. (#340), (#344) @brunoocasali
- `MeiliSearch\Index->getDocuments` accepts a object `DocumentsQuery` to filter and paginate the results. (#340), (#344) @brunoocasali
- `Key` has now a `name` and `uid` string fields. (#343), (#338) @brunoocasali
- `estimatedTotalHits`, `facetDistribution` were added to `SearchResult` (#332) @curquiza
  - `nbHits` is still defined and will contain the same value as `estimatedTotalHits`.
- Sending a invalid `uid` or `apiKey` will raise `InvalidApiKeyException`. (#343) @brunoocasali

Thanks again to @brunoocasali, @curquiza! 🎉