### PR TITLE
Remove conditionals between steps in pre-release-tests.yml

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -36,9 +36,6 @@ jobs:
         sh scripts/tests.sh
         composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
     - name: Run test suite - php-http/guzzle6-adapter
-      # Don't run on PHP 8
-      # Guzzle 6 is not compatible with PHP 8.0
-      if: ${{ !startsWith(matrix.php-versions, '8.') }}
       run: |
         composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
         sh scripts/tests.sh
@@ -49,18 +46,12 @@ jobs:
         sh scripts/tests.sh
         composer remove --dev symfony/http-client nyholm/psr7
     - name: Run test suite - php-http/curl-client
-      # Don't run on PHP 8
-      # php-http/curl-client is currently not compatible with PHP 8.0
-      if: ${{ !startsWith(matrix.php-versions, '8.') }}
       run: |
         composer require --dev php-http/curl-client nyholm/psr7
         sh scripts/tests.sh
         composer remove --dev php-http/curl-client nyholm/psr7
     - name: Run test suite - kriswallsmith/buzz
-      # Don't run on PHP 8
-      # kriswallsmith/buzz is currently not compatible with PHP 8.0
-      if: ${{ !startsWith(matrix.php-versions, '8.') }}
       run: |
-        composer require --dev kriswallsmith/buzz nyholm/psr7
+        composer require --dev kriswallsmith/buzz nyholm/psr7 --with-all-dependencies
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7


### PR DESCRIPTION
I noticed we have only in the pre-release tests (GitHub action config file) some conditionals.

We do not need to add those since we already run without them in the ordinary tests action.