### PR TITLE
Allow to inject the StreamFactoryInterface explicitly

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -19,6 +19,7 @@ use MeiliSearch\Endpoints\TenantToken;
 use MeiliSearch\Endpoints\Version;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 class Client
 {
@@ -43,9 +44,10 @@ class Client
         string $apiKey = null,
         ClientInterface $httpClient = null,
         RequestFactoryInterface $requestFactory = null,
-        array $clientAgents = []
+        array $clientAgents = [],
+        StreamFactoryInterface $streamFactory = null
     ) {
-        $this->http = new Http\Client($url, $apiKey, $httpClient, $requestFactory, $clientAgents);
+        $this->http = new Http\Client($url, $apiKey, $httpClient, $requestFactory, $clientAgents, $streamFactory);
         $this->index = new Indexes($this->http);
         $this->health = new Health($this->http);
         $this->version = new Version($this->http);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -40,13 +40,14 @@ class Client implements Http
         string $apiKey = null,
         ClientInterface $httpClient = null,
         RequestFactoryInterface $reqFactory = null,
-        array $clientAgents = []
+        array $clientAgents = [],
+        StreamFactoryInterface $streamFactory = null
     ) {
         $this->baseUrl = $url;
         $this->apiKey = $apiKey;
         $this->http = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
-        $this->streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([
             'User-Agent' => implode(';', array_merge($clientAgents, [MeiliSearch::qualifiedVersion()])),
         ]);

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 class ClientTest extends TestCase
@@ -35,6 +36,18 @@ class ClientTest extends TestCase
         $httpClient = $this->createHttpClientMock(200, '{}');
 
         $client = new Client('https://localhost', null, $httpClient);
+        $result = $client->post('/');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testPostExecutesRequestWithCustomStreamFactory(): void
+    {
+        $httpClient = $this->createHttpClientMock(200, '{}');
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->expects(self::atLeastOnce())->method('createStream');
+
+        $client = new Client('https://localhost', null, $httpClient, null, [], $streamFactory);
         $result = $client->post('/');
 
         $this->assertSame([], $result);


### PR DESCRIPTION
## What does this PR do?

This PR adds the possibility to inject `StreamFactoryInterface` to not rely on `php-http/discovery`.
The change is done in a way that does not break existing usages.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
