### PR TITLE
Add uuids to index names for randomization

### DIFF
--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -14,7 +14,7 @@ final class ClientTest extends TestCase
 {
     public function testClientIndexMethodsAlwaysReturnArray(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         /* @phpstan-ignore-next-line */
         $this->assertIsIterable($this->client->getAllIndexes());
         /* @phpstan-ignore-next-line */
@@ -25,7 +25,7 @@ final class ClientTest extends TestCase
 
     public function testClientIndexMethodsAlwaysReturnsIndexesInstance(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         /* @phpstan-ignore-next-line */
         $this->assertInstanceOf(Indexes::class, $this->client->getIndex($index->getUid()));
         /* @phpstan-ignore-next-line */
@@ -63,41 +63,44 @@ final class ClientTest extends TestCase
 
     public function testCreateIndexWithOnlyUid(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $indexName = $this->safeIndexName();
+        $index = $this->createEmptyIndex($indexName);
 
-        $this->assertSame('index', $index->getUid());
+        $this->assertSame($indexName, $index->getUid());
         $this->assertNull($index->getPrimaryKey());
     }
 
     public function testCreateIndexWithUidAndPrimaryKey(): void
     {
+        $indexName = $this->safeIndexName();
         $index = $this->createEmptyIndex(
-            'index',
+            $indexName,
             ['primaryKey' => 'ObjectId']
         );
 
-        $this->assertSame('index', $index->getUid());
+        $this->assertSame($indexName, $index->getUid());
         $this->assertSame('ObjectId', $index->getPrimaryKey());
     }
 
     public function testCreateIndexWithUidInOptions(): void
     {
+        $indexName = $this->safeIndexName();
         $index = $this->createEmptyIndex(
-            'index',
+            $indexName,
             [
                 'uid' => 'wrong',
                 'primaryKey' => 'ObjectId',
             ]
         );
 
-        $this->assertSame('index', $index->getUid());
+        $this->assertSame($indexName, $index->getUid());
         $this->assertSame('ObjectId', $index->getPrimaryKey());
     }
 
     public function testGetAllIndexes(): void
     {
-        $indexA = 'indexA';
-        $indexB = 'indexB';
+        $indexA = $this->safeIndexName('indexA');
+        $indexB = $this->safeIndexName('indexB');
         $response = $this->client->createIndex($indexA);
         $this->client->waitForTask($response['taskUid']);
         $response = $this->client->createIndex($indexB);
@@ -110,8 +113,8 @@ final class ClientTest extends TestCase
 
     public function testGetAllRawIndexes(): void
     {
-        $indexA = 'indexA';
-        $indexB = 'indexB';
+        $indexA = $this->safeIndexName('indexA');
+        $indexB = $this->safeIndexName('indexB');
         $response = $this->client->createIndex($indexA);
         $this->client->waitForTask($response['taskUid']);
         $response = $this->client->createIndex($indexB);
@@ -134,19 +137,20 @@ final class ClientTest extends TestCase
 
     public function testUpdateIndex(): void
     {
-        $this->createEmptyIndex('indexA');
+        $indexName = $this->safeIndexName('indexA');
+        $this->createEmptyIndex($indexName);
 
-        $response = $this->client->updateIndex('indexA', ['primaryKey' => 'id']);
+        $response = $this->client->updateIndex($indexName, ['primaryKey' => 'id']);
         $this->client->waitForTask($response['taskUid']);
         $index = $this->client->getIndex($response['indexUid']);
 
         $this->assertSame($index->getPrimaryKey(), 'id');
-        $this->assertSame($index->getUid(), 'indexA');
+        $this->assertSame($index->getUid(), $indexName);
     }
 
     public function testDeleteIndex(): void
     {
-        $this->createEmptyIndex('index');
+        $this->createEmptyIndex($this->safeIndexName());
 
         $response = $this->client->getAllIndexes();
         $this->assertCount(1, $response);
@@ -165,8 +169,8 @@ final class ClientTest extends TestCase
 
     public function testDeleteAllIndexes(): void
     {
-        $this->createEmptyIndex('index-1');
-        $this->createEmptyIndex('index-2');
+        $this->createEmptyIndex($this->safeIndexName('index-1'));
+        $this->createEmptyIndex($this->safeIndexName('index-2'));
 
         $response = $this->client->getAllIndexes();
 
@@ -200,16 +204,17 @@ final class ClientTest extends TestCase
 
     public function testGetIndex(): void
     {
-        $this->createEmptyIndex('index');
+        $indexName = $this->safeIndexName();
+        $this->createEmptyIndex($indexName);
 
-        $index = $this->client->getIndex('index');
-        $this->assertSame('index', $index->getUid());
+        $index = $this->client->getIndex($indexName);
+        $this->assertSame($indexName, $index->getUid());
         $this->assertNull($index->getPrimaryKey());
     }
 
     public function testIndex(): void
     {
-        $this->createEmptyIndex('index');
+        $this->createEmptyIndex($this->safeIndexName());
 
         $index = $this->client->index('index');
         $this->assertSame('index', $index->getUid());

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -99,11 +99,11 @@ final class ClientTest extends TestCase
 
     public function testGetAllIndexes(): void
     {
-        $indexA = $this->safeIndexName('indexA');
-        $indexB = $this->safeIndexName('indexB');
-        $response = $this->client->createIndex($indexA);
+        $booksIndex1 = $this->safeIndexName('books-1');
+        $booksIndex2 = $this->safeIndexName('books-2');
+        $response = $this->client->createIndex($booksIndex1);
         $this->client->waitForTask($response['taskUid']);
-        $response = $this->client->createIndex($indexB);
+        $response = $this->client->createIndex($booksIndex2);
         $this->client->waitForTask($response['taskUid']);
 
         $indexes = $this->client->getAllIndexes();
@@ -113,11 +113,11 @@ final class ClientTest extends TestCase
 
     public function testGetAllRawIndexes(): void
     {
-        $indexA = $this->safeIndexName('indexA');
-        $indexB = $this->safeIndexName('indexB');
-        $response = $this->client->createIndex($indexA);
+        $booksIndex1 = $this->safeIndexName('books-1');
+        $booksIndex2 = $this->safeIndexName('books-2');
+        $response = $this->client->createIndex($booksIndex1);
         $this->client->waitForTask($response['taskUid']);
-        $response = $this->client->createIndex($indexB);
+        $response = $this->client->createIndex($booksIndex2);
         $this->client->waitForTask($response['taskUid']);
 
         $res = $this->client->getAllRawIndexes()['results'];
@@ -127,17 +127,16 @@ final class ClientTest extends TestCase
 
     public function testGetRawIndex(): void
     {
-        $indexA = 'indexA';
-        $this->createEmptyIndex($indexA);
+        $this->createEmptyIndex('books-1');
 
-        $res = $this->client->getRawIndex('indexA');
+        $res = $this->client->getRawIndex('books-1');
 
         $this->assertArrayHasKey('uid', $res);
     }
 
     public function testUpdateIndex(): void
     {
-        $indexName = $this->safeIndexName('indexA');
+        $indexName = $this->safeIndexName('books-1');
         $this->createEmptyIndex($indexName);
 
         $response = $this->client->updateIndex($indexName, ['primaryKey' => 'id']);
@@ -169,8 +168,8 @@ final class ClientTest extends TestCase
 
     public function testDeleteAllIndexes(): void
     {
-        $this->createEmptyIndex($this->safeIndexName('index-1'));
-        $this->createEmptyIndex($this->safeIndexName('index-2'));
+        $this->createEmptyIndex($this->safeIndexName('books-1'));
+        $this->createEmptyIndex($this->safeIndexName('books-2'));
 
         $response = $this->client->getAllIndexes();
 

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -14,7 +14,7 @@ final class DocumentsTest extends TestCase
 {
     public function testAddDocuments(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $promise = $index->addDocuments(self::DOCUMENTS);
 
         $this->assertIsValidPromise($promise);
@@ -26,7 +26,7 @@ final class DocumentsTest extends TestCase
 
     public function testAddDocumentsInBatches(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $promises = $index->addDocumentsInBatches(self::DOCUMENTS, 2);
 
         $this->assertCount(4, $promises);
@@ -48,7 +48,7 @@ final class DocumentsTest extends TestCase
             ['id' => 62, 'title' => 'Очень красивый!', 'comment' => ''], // Russian
         ];
 
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $promise = $index->addDocuments($documents);
 
         $this->assertIsValidPromise($promise);
@@ -133,13 +133,13 @@ final class DocumentsTest extends TestCase
 
         $documents = ["\xB1\x31"];
 
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $index->addDocuments($documents);
     }
 
     public function testGetSingleDocumentWithIntegerDocumentId(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $doc = $this->findDocumentWithId(self::DOCUMENTS, 4);
@@ -152,7 +152,7 @@ final class DocumentsTest extends TestCase
 
     public function testGetSingleDocumentWithFields(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $doc = $this->findDocumentWithId(self::DOCUMENTS, 4);
@@ -166,7 +166,7 @@ final class DocumentsTest extends TestCase
     public function testGetSingleDocumentWithStringDocumentId(): void
     {
         $stringDocumentId = 'myUniqueId';
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
         $index->waitForTask($addDocumentResponse['taskUid']);
         $response = $index->getDocument($stringDocumentId);
@@ -177,7 +177,7 @@ final class DocumentsTest extends TestCase
 
     public function testReplaceDocuments(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $replacement = [
@@ -200,7 +200,7 @@ final class DocumentsTest extends TestCase
 
     public function testUpdateDocuments(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $promise = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($promise['taskUid']);
         $replacement = [
@@ -225,7 +225,7 @@ final class DocumentsTest extends TestCase
 
     public function testUpdateDocumentsInBatches(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $documentPromise = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($documentPromise['taskUid']);
 
@@ -258,7 +258,7 @@ final class DocumentsTest extends TestCase
 
     public function testAddWithUpdateDocuments(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $document = [
@@ -283,7 +283,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteNonExistingDocument(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
 
@@ -301,7 +301,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteSingleExistingDocumentWithDocumentIdAsInteger(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
 
@@ -320,7 +320,7 @@ final class DocumentsTest extends TestCase
     public function testDeleteSingleExistingDocumentWithDocumentIdAsString(): void
     {
         $stringDocumentId = 'myUniqueId';
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
         $index->waitForTask($addDocumentResponse['taskUid']);
 
@@ -334,7 +334,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteMultipleDocumentsWithDocumentIdAsInteger(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $documentIds = [1, 2];
@@ -357,7 +357,7 @@ final class DocumentsTest extends TestCase
             ['id' => 'myUniqueId2'],
             ['id' => 'myUniqueId3'],
         ];
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $addDocumentResponse = $index->addDocuments($documents);
         $index->waitForTask($addDocumentResponse['taskUid']);
 
@@ -371,7 +371,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteAllDocuments(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $promise = $index->deleteAllDocuments();
@@ -386,7 +386,7 @@ final class DocumentsTest extends TestCase
 
     public function testExceptionIfNoDocumentIdWhenGetting(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('new-index'));
+        $index = $this->createEmptyIndex($this->safeIndexName('books-1'));
 
         $this->expectException(ApiException::class);
 
@@ -402,7 +402,7 @@ final class DocumentsTest extends TestCase
                 'title' => 'Le Rouge et le Noir',
             ],
         ];
-        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies-1'));
         $response = $index->addDocuments($documents, 'unique');
 
         $this->assertArrayHasKey('taskUid', $response);
@@ -434,7 +434,7 @@ final class DocumentsTest extends TestCase
 
     public function testGetDocumentsWithPagination(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
         $promise = $index->addDocuments(self::DOCUMENTS);
         $this->assertIsValidPromise($promise);
         $index->waitForTask($promise['taskUid']);
@@ -449,7 +449,7 @@ final class DocumentsTest extends TestCase
      */
     public function testFetchingDocumentWithInvalidId($documentId): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies-1'));
 
         $this->expectException(InvalidArgumentException::class);
         $index->getDocument($documentId);
@@ -460,7 +460,7 @@ final class DocumentsTest extends TestCase
      */
     public function testDeletingDocumentWithInvalidId($documentId): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movies-1'));
 
         $this->expectException(InvalidArgumentException::class);
         $index->deleteDocument($documentId);

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -14,7 +14,7 @@ final class DocumentsTest extends TestCase
 {
     public function testAddDocuments(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $promise = $index->addDocuments(self::DOCUMENTS);
 
         $this->assertIsValidPromise($promise);
@@ -26,7 +26,7 @@ final class DocumentsTest extends TestCase
 
     public function testAddDocumentsInBatches(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $promises = $index->addDocumentsInBatches(self::DOCUMENTS, 2);
 
         $this->assertCount(4, $promises);
@@ -48,7 +48,7 @@ final class DocumentsTest extends TestCase
             ['id' => 62, 'title' => 'Очень красивый!', 'comment' => ''], // Russian
         ];
 
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $promise = $index->addDocuments($documents);
 
         $this->assertIsValidPromise($promise);
@@ -133,13 +133,13 @@ final class DocumentsTest extends TestCase
 
         $documents = ["\xB1\x31"];
 
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $index->addDocuments($documents);
     }
 
     public function testGetSingleDocumentWithIntegerDocumentId(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $doc = $this->findDocumentWithId(self::DOCUMENTS, 4);
@@ -152,7 +152,7 @@ final class DocumentsTest extends TestCase
 
     public function testGetSingleDocumentWithFields(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $doc = $this->findDocumentWithId(self::DOCUMENTS, 4);
@@ -166,7 +166,7 @@ final class DocumentsTest extends TestCase
     public function testGetSingleDocumentWithStringDocumentId(): void
     {
         $stringDocumentId = 'myUniqueId';
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
         $index->waitForTask($addDocumentResponse['taskUid']);
         $response = $index->getDocument($stringDocumentId);
@@ -177,7 +177,7 @@ final class DocumentsTest extends TestCase
 
     public function testReplaceDocuments(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $replacement = [
@@ -200,7 +200,7 @@ final class DocumentsTest extends TestCase
 
     public function testUpdateDocuments(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $promise = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($promise['taskUid']);
         $replacement = [
@@ -225,7 +225,7 @@ final class DocumentsTest extends TestCase
 
     public function testUpdateDocumentsInBatches(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $documentPromise = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($documentPromise['taskUid']);
 
@@ -258,7 +258,7 @@ final class DocumentsTest extends TestCase
 
     public function testAddWithUpdateDocuments(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $document = [
@@ -283,7 +283,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteNonExistingDocument(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
 
@@ -301,7 +301,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteSingleExistingDocumentWithDocumentIdAsInteger(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
 
@@ -320,7 +320,7 @@ final class DocumentsTest extends TestCase
     public function testDeleteSingleExistingDocumentWithDocumentIdAsString(): void
     {
         $stringDocumentId = 'myUniqueId';
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $addDocumentResponse = $index->addDocuments([['id' => $stringDocumentId]]);
         $index->waitForTask($addDocumentResponse['taskUid']);
 
@@ -334,7 +334,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteMultipleDocumentsWithDocumentIdAsInteger(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $documentIds = [1, 2];
@@ -357,7 +357,7 @@ final class DocumentsTest extends TestCase
             ['id' => 'myUniqueId2'],
             ['id' => 'myUniqueId3'],
         ];
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $addDocumentResponse = $index->addDocuments($documents);
         $index->waitForTask($addDocumentResponse['taskUid']);
 
@@ -371,7 +371,7 @@ final class DocumentsTest extends TestCase
 
     public function testDeleteAllDocuments(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $response = $index->addDocuments(self::DOCUMENTS);
         $index->waitForTask($response['taskUid']);
         $promise = $index->deleteAllDocuments();
@@ -386,7 +386,7 @@ final class DocumentsTest extends TestCase
 
     public function testExceptionIfNoDocumentIdWhenGetting(): void
     {
-        $index = $this->createEmptyIndex('new-index');
+        $index = $this->createEmptyIndex($this->safeIndexName('new-index'));
 
         $this->expectException(ApiException::class);
 
@@ -402,7 +402,7 @@ final class DocumentsTest extends TestCase
                 'title' => 'Le Rouge et le Noir',
             ],
         ];
-        $index = $this->createEmptyIndex('an-index');
+        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
         $response = $index->addDocuments($documents, 'unique');
 
         $this->assertArrayHasKey('taskUid', $response);
@@ -421,7 +421,7 @@ final class DocumentsTest extends TestCase
                 'title' => 'Le Rouge et le Noir',
             ],
         ];
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $promise = $index->updateDocuments($documents, 'unique');
 
         $this->assertIsValidPromise($promise);
@@ -434,7 +434,7 @@ final class DocumentsTest extends TestCase
 
     public function testGetDocumentsWithPagination(): void
     {
-        $index = $this->createEmptyIndex('documents');
+        $index = $this->createEmptyIndex($this->safeIndexName('documents'));
         $promise = $index->addDocuments(self::DOCUMENTS);
         $this->assertIsValidPromise($promise);
         $index->waitForTask($promise['taskUid']);
@@ -449,7 +449,7 @@ final class DocumentsTest extends TestCase
      */
     public function testFetchingDocumentWithInvalidId($documentId): void
     {
-        $index = $this->createEmptyIndex('an-index');
+        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
 
         $this->expectException(InvalidArgumentException::class);
         $index->getDocument($documentId);
@@ -460,7 +460,7 @@ final class DocumentsTest extends TestCase
      */
     public function testDeletingDocumentWithInvalidId($documentId): void
     {
-        $index = $this->createEmptyIndex('an-index');
+        $index = $this->createEmptyIndex($this->safeIndexName('an-index'));
 
         $this->expectException(InvalidArgumentException::class);
         $index->deleteDocument($documentId);

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -49,24 +49,24 @@ final class IndexTest extends TestCase
 
     public function testGetPrimaryKey(): void
     {
-        $indexB = $this->createEmptyIndex(
-            $this->safeIndexName('indexB'),
+        $index = $this->createEmptyIndex(
+            $this->safeIndexName('books-2'),
             ['primaryKey' => 'objectId']
         );
 
         $this->assertNull($this->index->getPrimaryKey());
-        $this->assertSame('objectId', $indexB->getPrimaryKey());
+        $this->assertSame('objectId', $index->getPrimaryKey());
     }
 
     public function testGetUid(): void
     {
-        $indexName = $this->safeIndexName('indexB');
-        $indexB = $this->createEmptyIndex(
+        $indexName = $this->safeIndexName('books-2');
+        $index = $this->createEmptyIndex(
             $indexName,
             ['primaryKey' => 'objectId']
         );
         $this->assertSame($this->indexName, $this->index->getUid());
-        $this->assertSame($indexName, $indexB->getUid());
+        $this->assertSame($indexName, $index->getUid());
     }
 
     public function testGetCreatedAt(): void
@@ -105,7 +105,7 @@ final class IndexTest extends TestCase
 
     public function testFetchRawInfo(): void
     {
-        $indexName = $this->safeIndexName('indexB');
+        $indexName = $this->safeIndexName('books-2');
         $index = $this->createEmptyIndex(
             $indexName,
             ['primaryKey' => 'objectId']
@@ -147,31 +147,31 @@ final class IndexTest extends TestCase
 
     public function testFetchInfo(): void
     {
-        $uid = $this->safeIndexName('indexA');
+        $indexName = $this->safeIndexName('books-1');
         $this->createEmptyIndex(
-            $uid,
+            $indexName,
             ['primaryKey' => 'objectID']
         );
 
-        $index = $this->client->index($uid);
+        $index = $this->client->index($indexName);
         $this->assertNull($index->getPrimaryKey());
 
         $index = $index->fetchInfo();
         $this->assertSame('objectID', $index->getPrimaryKey());
-        $this->assertSame($uid, $index->getUid());
+        $this->assertSame($indexName, $index->getUid());
         $this->assertInstanceOf(DateTimeInterface::class, $index->getCreatedAt());
         $this->assertInstanceOf(DateTimeInterface::class, $index->getUpdatedAt());
     }
 
     public function testGetAndFetchPrimaryKey(): void
     {
-        $uid = $this->safeIndexName('indexA');
+        $indexName = $this->safeIndexName('books-1');
         $this->createEmptyIndex(
-            $uid,
+            $indexName,
             ['primaryKey' => 'objectID']
         );
 
-        $index = $this->client->index($uid);
+        $index = $this->client->index($indexName);
         $this->assertNull($index->getPrimaryKey());
         $this->assertSame('objectID', $index->fetchPrimaryKey());
         $this->assertSame('objectID', $index->getPrimaryKey());
@@ -251,19 +251,19 @@ final class IndexTest extends TestCase
 
     public function testDeleteIndexes(): void
     {
-        $indexAName = $this->safeIndexName('indexA');
-        $this->index = $this->createEmptyIndex($indexAName);
-        $indexBName = $this->safeIndexName('indexB');
-        $indexB = $this->createEmptyIndex($indexBName);
+        $indexName1 = $this->safeIndexName('books-1');
+        $this->index = $this->createEmptyIndex($indexName1);
+        $indexName2 = $this->safeIndexName('books-2');
+        $index = $this->createEmptyIndex($indexName2);
 
         $res = $this->index->delete();
-        $this->assertSame($res['indexUid'], $indexAName);
+        $this->assertSame($res['indexUid'], $indexName1);
         $this->assertArrayHasKey('type', $res);
         $this->assertSame($res['type'], 'indexDeletion');
         $this->assertArrayHasKey('enqueuedAt', $res);
 
-        $res = $indexB->delete();
-        $this->assertSame($res['indexUid'], $indexBName);
+        $res = $index->delete();
+        $this->assertSame($res['indexUid'], $indexName2);
         $this->assertArrayHasKey('type', $res);
         $this->assertSame($res['type'], 'indexDeletion');
         $this->assertArrayHasKey('enqueuedAt', $res);

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -13,11 +13,13 @@ use Tests\TestCase;
 final class IndexTest extends TestCase
 {
     private Indexes $index;
+    private string $indexName;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->indexName = $this->safeIndexName();
+        $this->index = $this->createEmptyIndex($this->indexName);
     }
 
     public function testIndexGetSettings(): void
@@ -48,7 +50,7 @@ final class IndexTest extends TestCase
     public function testGetPrimaryKey(): void
     {
         $indexB = $this->createEmptyIndex(
-            'indexB',
+            $this->safeIndexName('indexB'),
             ['primaryKey' => 'objectId']
         );
 
@@ -58,12 +60,13 @@ final class IndexTest extends TestCase
 
     public function testGetUid(): void
     {
+        $indexName = $this->safeIndexName('indexB');
         $indexB = $this->createEmptyIndex(
-            'indexB',
+            $indexName,
             ['primaryKey' => 'objectId']
         );
-        $this->assertSame('index', $this->index->getUid());
-        $this->assertSame('indexB', $indexB->getUid());
+        $this->assertSame($this->indexName, $this->index->getUid());
+        $this->assertSame($indexName, $indexB->getUid());
     }
 
     public function testGetCreatedAt(): void
@@ -102,8 +105,9 @@ final class IndexTest extends TestCase
 
     public function testFetchRawInfo(): void
     {
+        $indexName = $this->safeIndexName('indexB');
         $index = $this->createEmptyIndex(
-            'indexB',
+            $indexName,
             ['primaryKey' => 'objectId']
         );
 
@@ -114,7 +118,7 @@ final class IndexTest extends TestCase
         $this->assertArrayHasKey('createdAt', $response);
         $this->assertArrayHasKey('updatedAt', $response);
         $this->assertSame($response['primaryKey'], 'objectId');
-        $this->assertSame($response['uid'], 'indexB');
+        $this->assertSame($response['uid'], $indexName);
     }
 
     public function testPrimaryKeyUpdate(): void
@@ -126,9 +130,9 @@ final class IndexTest extends TestCase
         $index = $this->client->getIndex($response['indexUid']);
 
         $this->assertSame($index->getPrimaryKey(), $primaryKey);
-        $this->assertSame($index->getUid(), 'index');
+        $this->assertSame($index->getUid(), $this->indexName);
         $this->assertSame($index->getPrimaryKey(), $primaryKey);
-        $this->assertSame($this->index->getUid(), 'index');
+        $this->assertSame($this->index->getUid(), $this->indexName);
     }
 
     public function testIndexStats(): void
@@ -143,7 +147,7 @@ final class IndexTest extends TestCase
 
     public function testFetchInfo(): void
     {
-        $uid = 'indexA';
+        $uid = $this->safeIndexName('indexA');
         $this->createEmptyIndex(
             $uid,
             ['primaryKey' => 'objectID']
@@ -161,7 +165,7 @@ final class IndexTest extends TestCase
 
     public function testGetAndFetchPrimaryKey(): void
     {
-        $uid = 'indexA';
+        $uid = $this->safeIndexName('indexA');
         $this->createEmptyIndex(
             $uid,
             ['primaryKey' => 'objectID']
@@ -247,17 +251,19 @@ final class IndexTest extends TestCase
 
     public function testDeleteIndexes(): void
     {
-        $this->index = $this->createEmptyIndex('indexA');
-        $indexB = $this->createEmptyIndex('indexB');
+        $indexAName = $this->safeIndexName('indexA');
+        $this->index = $this->createEmptyIndex($indexAName);
+        $indexBName = $this->safeIndexName('indexB');
+        $indexB = $this->createEmptyIndex($indexBName);
 
         $res = $this->index->delete();
-        $this->assertSame($res['indexUid'], 'indexA');
+        $this->assertSame($res['indexUid'], $indexAName);
         $this->assertArrayHasKey('type', $res);
         $this->assertSame($res['type'], 'indexDeletion');
         $this->assertArrayHasKey('enqueuedAt', $res);
 
         $res = $indexB->delete();
-        $this->assertSame($res['indexUid'], 'indexB');
+        $this->assertSame($res['indexUid'], $indexBName);
         $this->assertArrayHasKey('type', $res);
         $this->assertSame($res['type'], 'indexDeletion');
         $this->assertArrayHasKey('enqueuedAt', $res);

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -57,14 +57,15 @@ final class KeysAndPermissionsTest extends TestCase
 
     public function testExceptionIfBadKeyProvidedToGetSettings(): void
     {
-        $this->createEmptyIndex('index');
-        $response = $this->client->index('index')->getSettings();
+        $index = $this->safeIndexName();
+        $this->createEmptyIndex($index);
+        $response = $this->client->index($index)->getSettings();
         $this->assertEquals(['*'], $response['searchableAttributes']);
 
         $newClient = new Client($this->host, 'bad-key');
 
         $this->expectException(ApiException::class);
-        $newClient->index('index')->getSettings();
+        $newClient->index($index)->getSettings();
     }
 
     public function testExceptionIfBadKeyProvidedToGetKeys(): void

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -130,7 +130,7 @@ final class SearchTest extends TestCase
 
     public function testExceptionIfNoIndexWhenSearching(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('another-index'));
+        $index = $this->createEmptyIndex($this->safeIndexName('movie-1'));
         $res = $index->delete();
         $index->waitForTask($res['taskUid']);
 

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -15,7 +15,7 @@ final class SearchTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
         $promise = $this->index->updateDocuments(self::DOCUMENTS);
         $this->index->waitForTask($promise['taskUid']);
     }
@@ -105,7 +105,7 @@ final class SearchTest extends TestCase
 
     public function testBasicSearchIfNoPrimaryKeyAndDocumentProvided(): void
     {
-        $emptyIndex = $this->createEmptyIndex('empty');
+        $emptyIndex = $this->createEmptyIndex($this->safeIndexName('empty'));
 
         $res = $emptyIndex->search('prince');
 
@@ -130,7 +130,7 @@ final class SearchTest extends TestCase
 
     public function testExceptionIfNoIndexWhenSearching(): void
     {
-        $index = $this->createEmptyIndex('another-index');
+        $index = $this->createEmptyIndex($this->safeIndexName('another-index'));
         $res = $index->delete();
         $index->waitForTask($res['taskUid']);
 

--- a/tests/Endpoints/SearchTestNestedFields.php
+++ b/tests/Endpoints/SearchTestNestedFields.php
@@ -14,7 +14,7 @@ final class SearchTestNestedFields extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('nestedIndex');
+        $this->index = $this->createEmptyIndex($this->safeIndexName('nestedIndex'));
         $promise = $this->index->updateDocuments(self::NESTED_DOCUMENTS);
         $this->index->waitForTask($promise['uid']);
     }

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -98,7 +98,7 @@ final class TasksTest extends TestCase
         $response = $this->index->getTasks();
         $firstIndex = $response->getResults()[0]['uid'];
 
-        $newIndex = $this->createEmptyIndex($this->safeIndexName('a_new_index'));
+        $newIndex = $this->createEmptyIndex($this->safeIndexName('movie-1'));
         $newIndex->updateDocuments(self::DOCUMENTS);
 
         $response = $this->index->getTasks();
@@ -114,7 +114,7 @@ final class TasksTest extends TestCase
         $firstIndex = $response->getResults()[0]['uid'];
         $this->assertEquals($response->getResults()[0]['status'], 'succeeded');
 
-        $newIndex = $this->createEmptyIndex($this->safeIndexName('a_new_index'));
+        $newIndex = $this->createEmptyIndex($this->safeIndexName('movie-1'));
         $newIndex->updateDocuments(self::DOCUMENTS);
 
         $response = $this->index->getTasks();

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -12,11 +12,13 @@ use Tests\TestCase;
 final class TasksTest extends TestCase
 {
     private Indexes $index;
+    private string $indexName;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->indexName = $this->safeIndexName();
+        $this->index = $this->createEmptyIndex($this->indexName);
     }
 
     public function testGetOneTaskFromWaitTask(): void
@@ -29,7 +31,7 @@ final class TasksTest extends TestCase
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAdditionOrUpdate');
         $this->assertArrayHasKey('indexUid', $response);
-        $this->assertSame($response['indexUid'], 'index');
+        $this->assertSame($response['indexUid'], $this->indexName);
         $this->assertArrayHasKey('enqueuedAt', $response);
         $this->assertArrayHasKey('startedAt', $response);
         $this->assertArrayHasKey('finishedAt', $response);
@@ -47,7 +49,7 @@ final class TasksTest extends TestCase
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAdditionOrUpdate');
         $this->assertArrayHasKey('indexUid', $response);
-        $this->assertSame($response['indexUid'], 'index');
+        $this->assertSame($response['indexUid'], $this->indexName);
         $this->assertArrayHasKey('enqueuedAt', $response);
         $this->assertArrayHasKey('startedAt', $response);
         $this->assertArrayHasKey('finishedAt', $response);
@@ -84,7 +86,7 @@ final class TasksTest extends TestCase
         $this->assertArrayHasKey('type', $response);
         $this->assertSame($response['type'], 'documentAdditionOrUpdate');
         $this->assertArrayHasKey('indexUid', $response);
-        $this->assertSame($response['indexUid'], 'index');
+        $this->assertSame($response['indexUid'], $this->indexName);
         $this->assertArrayHasKey('enqueuedAt', $response);
         $this->assertArrayHasKey('startedAt', $response);
         $this->assertArrayHasKey('finishedAt', $response);
@@ -96,7 +98,7 @@ final class TasksTest extends TestCase
         $response = $this->index->getTasks();
         $firstIndex = $response->getResults()[0]['uid'];
 
-        $newIndex = $this->createEmptyIndex('a_new_index');
+        $newIndex = $this->createEmptyIndex($this->safeIndexName('a_new_index'));
         $newIndex->updateDocuments(self::DOCUMENTS);
 
         $response = $this->index->getTasks();
@@ -112,7 +114,7 @@ final class TasksTest extends TestCase
         $firstIndex = $response->getResults()[0]['uid'];
         $this->assertEquals($response->getResults()[0]['status'], 'succeeded');
 
-        $newIndex = $this->createEmptyIndex('a_new_index');
+        $newIndex = $this->createEmptyIndex($this->safeIndexName('a_new_index'));
         $newIndex->updateDocuments(self::DOCUMENTS);
 
         $response = $this->index->getTasks();

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -10,8 +10,8 @@ final class DisplayedAttributesTest extends TestCase
 {
     public function testGetDefaultDisplayedAttributes(): void
     {
-        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
-        $indexB = $this->createEmptyIndex($this->safeIndexName('indexB'), ['primaryKey' => 'objectID']);
+        $indexA = $this->createEmptyIndex($this->safeIndexName('books-1'));
+        $indexB = $this->createEmptyIndex($this->safeIndexName('books-2'), ['primaryKey' => 'objectID']);
 
         $attributesA = $indexA->getDisplayedAttributes();
         $attributesB = $indexB->getDisplayedAttributes();

--- a/tests/Settings/DisplayedAttributesTest.php
+++ b/tests/Settings/DisplayedAttributesTest.php
@@ -10,8 +10,8 @@ final class DisplayedAttributesTest extends TestCase
 {
     public function testGetDefaultDisplayedAttributes(): void
     {
-        $indexA = $this->createEmptyIndex('indexA');
-        $indexB = $this->createEmptyIndex('indexB', ['primaryKey' => 'objectID']);
+        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
+        $indexB = $this->createEmptyIndex($this->safeIndexName('indexB'), ['primaryKey' => 'objectID']);
 
         $attributesA = $indexA->getDisplayedAttributes();
         $attributesB = $indexB->getDisplayedAttributes();
@@ -23,7 +23,7 @@ final class DisplayedAttributesTest extends TestCase
     public function testUpdateDisplayedAttributes(): void
     {
         $newAttributes = ['title'];
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $promise = $index->updateDisplayedAttributes($newAttributes);
 
@@ -37,7 +37,7 @@ final class DisplayedAttributesTest extends TestCase
 
     public function testResetDisplayedAttributes(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $newAttributes = ['title'];
 
         $promise = $index->updateDisplayedAttributes($newAttributes);

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -14,7 +14,7 @@ final class DistinctAttributeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 
     public function testGetDefaultDistinctAttribute(): void

--- a/tests/Settings/FilterableAttributesTest.php
+++ b/tests/Settings/FilterableAttributesTest.php
@@ -10,7 +10,7 @@ final class FilterableAttributesTest extends TestCase
 {
     public function testGetDefaultFilterableAttributes(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $attributes = $index->getFilterableAttributes();
 
@@ -20,7 +20,7 @@ final class FilterableAttributesTest extends TestCase
     public function testUpdateFilterableAttributes(): void
     {
         $newAttributes = ['title'];
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $promise = $index->updateFilterableAttributes($newAttributes);
 
@@ -34,7 +34,7 @@ final class FilterableAttributesTest extends TestCase
 
     public function testResetFilterableAttributes(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $newAttributes = ['title'];
 
         $promise = $index->updateFilterableAttributes($newAttributes);

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -23,7 +23,7 @@ final class RankingRulesTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 
     public function testGetDefaultRankingRules(): void

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -10,8 +10,8 @@ final class SearchableAttributesTest extends TestCase
 {
     public function testGetDefaultSearchableAttributes(): void
     {
-        $indexA = $this->createEmptyIndex('indexA');
-        $indexB = $this->createEmptyIndex('indexB', ['primaryKey' => 'objectID']);
+        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
+        $indexB = $this->createEmptyIndex($this->safeIndexName('indexB'), ['primaryKey' => 'objectID']);
 
         $searchableAttributesA = $indexA->getSearchableAttributes();
         $searchableAttributesB = $indexB->getSearchableAttributes();
@@ -22,7 +22,7 @@ final class SearchableAttributesTest extends TestCase
 
     public function testUpdateSearchableAttributes(): void
     {
-        $indexA = $this->createEmptyIndex('indexA');
+        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
         $searchableAttributes = [
             'title',
             'description',
@@ -40,7 +40,7 @@ final class SearchableAttributesTest extends TestCase
 
     public function testResetSearchableAttributes(): void
     {
-        $index = $this->createEmptyIndex('indexA');
+        $index = $this->createEmptyIndex($this->safeIndexName('indexA'));
         $promise = $index->resetSearchableAttributes();
 
         $this->assertIsValidPromise($promise);

--- a/tests/Settings/SearchableAttributesTest.php
+++ b/tests/Settings/SearchableAttributesTest.php
@@ -10,8 +10,8 @@ final class SearchableAttributesTest extends TestCase
 {
     public function testGetDefaultSearchableAttributes(): void
     {
-        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
-        $indexB = $this->createEmptyIndex($this->safeIndexName('indexB'), ['primaryKey' => 'objectID']);
+        $indexA = $this->createEmptyIndex($this->safeIndexName('books-1'));
+        $indexB = $this->createEmptyIndex($this->safeIndexName('books-2'), ['primaryKey' => 'objectID']);
 
         $searchableAttributesA = $indexA->getSearchableAttributes();
         $searchableAttributesB = $indexB->getSearchableAttributes();
@@ -22,7 +22,7 @@ final class SearchableAttributesTest extends TestCase
 
     public function testUpdateSearchableAttributes(): void
     {
-        $indexA = $this->createEmptyIndex($this->safeIndexName('indexA'));
+        $indexA = $this->createEmptyIndex($this->safeIndexName('books-1'));
         $searchableAttributes = [
             'title',
             'description',
@@ -40,7 +40,7 @@ final class SearchableAttributesTest extends TestCase
 
     public function testResetSearchableAttributes(): void
     {
-        $index = $this->createEmptyIndex($this->safeIndexName('indexA'));
+        $index = $this->createEmptyIndex($this->safeIndexName('books-1'));
         $promise = $index->resetSearchableAttributes();
 
         $this->assertIsValidPromise($promise);

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -77,7 +77,7 @@ final class SettingsTest extends TestCase
 
     public function testUpdateSettings(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $promise = $index->updateSettings([
             'distinctAttribute' => 'title',
             'rankingRules' => ['title:asc', 'typo'],
@@ -116,7 +116,7 @@ final class SettingsTest extends TestCase
             'disableOnAttributes' => [],
         ];
 
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $promise = $index->updateSettings([
             'distinctAttribute' => 'title',
             'rankingRules' => ['title:asc', 'typo'],
@@ -153,7 +153,7 @@ final class SettingsTest extends TestCase
 
     public function testResetSettings(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $promise = $index->updateSettings([
             'distinctAttribute' => 'title',
             'rankingRules' => ['title:asc', 'typo'],
@@ -189,7 +189,7 @@ final class SettingsTest extends TestCase
     // Here the test to prevent https://github.com/meilisearch/meilisearch-php/issues/204.
     public function testGetThenUpdateSettings(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $resetPromise = $index->resetSettings();
         $this->assertIsValidPromise($resetPromise);

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -34,11 +34,11 @@ final class SettingsTest extends TestCase
     {
         $primaryKey = 'ObjectID';
         $settingA = $this
-            ->createEmptyIndex('indexA')
+            ->createEmptyIndex($this->safeIndexName('books-1'))
             ->getSettings();
         $settingB = $this
             ->createEmptyIndex(
-                'indexB',
+                $this->safeIndexName('books-1'),
                 ['primaryKey' => $primaryKey]
             )->getSettings();
 

--- a/tests/Settings/SortableAttributesTest.php
+++ b/tests/Settings/SortableAttributesTest.php
@@ -10,7 +10,7 @@ final class SortableAttributesTest extends TestCase
 {
     public function testGetDefaultSortableAttributes(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $attributes = $index->getSortableAttributes();
 
@@ -20,7 +20,7 @@ final class SortableAttributesTest extends TestCase
     public function testUpdateSortableAttributes(): void
     {
         $newAttributes = ['title'];
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
 
         $promise = $index->updateSortableAttributes($newAttributes);
 
@@ -34,7 +34,7 @@ final class SortableAttributesTest extends TestCase
 
     public function testResetSortableAttributes(): void
     {
-        $index = $this->createEmptyIndex('index');
+        $index = $this->createEmptyIndex($this->safeIndexName());
         $newAttributes = ['title'];
 
         $promise = $index->updateSortableAttributes($newAttributes);

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -14,7 +14,7 @@ final class StopWordsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 
     public function testGetDefaultStopWords(): void

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -14,7 +14,7 @@ final class SynonymsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 
     public function testGetDefaultSynonyms(): void

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -24,7 +24,7 @@ final class TypoToleranceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->index = $this->createEmptyIndex('index');
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 
     public function testGetDefaultTypoTolerance(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,6 +73,16 @@ abstract class TestCase extends BaseTestCase
         return $this->client->getIndex($response['indexUid']);
     }
 
+    public function safeIndexName(string $indexName = 'index'): string
+    {
+        $uidData = random_bytes(16);
+        $uidData[6] = \chr(\ord($uidData[6]) & 0x0F | 0x40);
+        $uidData[8] = \chr(\ord($uidData[8]) & 0x3F | 0x80);
+        $uid = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($uidData), 4));
+
+        return $indexName.'_'.$uid;
+    }
+
     protected function createHttpClientMock(int $status = 200, string $content = '{', string $contentType = 'application/json')
     {
         $stream = $this->createMock(StreamInterface::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -75,12 +75,7 @@ abstract class TestCase extends BaseTestCase
 
     public function safeIndexName(string $indexName = 'index'): string
     {
-        $uidData = random_bytes(16);
-        $uidData[6] = \chr(\ord($uidData[6]) & 0x0F | 0x40);
-        $uidData[8] = \chr(\ord($uidData[8]) & 0x3F | 0x80);
-        $uid = vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($uidData), 4));
-
-        return $indexName.'_'.$uid;
+        return $indexName.'_'.bin2hex(random_bytes(16));
     }
 
     protected function createHttpClientMock(int $status = 200, string $content = '{', string $contentType = 'application/json')


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #334 

## What does this PR do?
- Add function to create randomized index names
- The function adds a UUID behind the given index name, if no index name is given it defaults to `index`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
