### PR TITLE
Make possible for static analysis tools to detect return type of `Indexes::search`

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -181,6 +181,8 @@ class Indexes extends Endpoint
 
     /**
      * @return SearchResult|array
+     *
+     * @phpstan-return ($options is array{raw: true|non-falsy-string|positive-int} ? array : SearchResult)
      */
     public function search(?string $query, array $searchParams = [], array $options = [])
     {

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -616,7 +616,7 @@ final class SearchTest extends TestCase
         $this->assertSame('Le Petit Prince', $response->getHit(0)['title']);
         $this->assertSame(2, $response->getEstimatedTotalHits());
         $this->assertSame(1, $response->getHitsCount());
-        $this->assertSame(1, $response->count());
+        $this->assertCount(1, $response);
     }
 
     public function testBasicSearchWithTransformHitsOptionToMap(): void


### PR DESCRIPTION
# Pull Request

## What does this PR do?

This change allow static analysis tools such as PHPStan or Psalm to detect the return type according to the `$options` array.
For downstream consumers also using a static analysis tool it avoids an unnecessary check/assertion to determine the type of the returned value.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
