### PR TITLE
Fix phpdoc block of IndexesResults constructor

### DIFF
--- a/src/Contracts/IndexesResults.php
+++ b/src/Contracts/IndexesResults.php
@@ -12,9 +12,6 @@ class IndexesResults extends Data
     private int $limit;
     private int $total;
 
-    /**
-     * @param array{results: array<int, Indexes>, offset: int, limit: int, total: int|null} $params
-     */
     public function __construct(array $params)
     {
         parent::__construct($params['results']);


### PR DESCRIPTION
This class has a bad constructor. It's receiving an array instead of an object as a parameter, which is not a good practice, and PHPdoc does not have a good implementation for documenting nested arrays, so for now what we can do is remove the doc-block, and when a better implementation comes in, we updated doc-block as well.

## Related issue
Fixes #397

## What does this PR do?
- It removes the doc-block of the `IndexesResults` constructor fixing #397

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
