### PR TITLE
Implement methods for CSV and Ndjson batch adds

### DIFF
--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -10,7 +10,7 @@ interface Http
 
     public function post(string $path, $body = null, array $query = [], string $contentType = null);
 
-    public function put(string $path, $body = null, array $query = []);
+    public function put(string $path, $body = null, array $query = [], string $contentType = null);
 
     public function patch(string $path, $body = null, array $query = []);
 

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -92,6 +92,41 @@ trait HandlesDocuments
         return $promises;
     }
 
+    public function updateDocumentsJson(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/json');
+    }
+
+    public function updateDocumentsCsv(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
+    }
+
+    public function updateDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    {
+        $promises = [];
+        foreach (self::batchCsvString($documents, $batchSize) as $batch) {
+            $promises[] = $this->updateDocumentsCsv($batch, $primaryKey);
+        }
+
+        return $promises;
+    }
+
+    public function updateDocumentsNdjson(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/x-ndjson');
+    }
+
+    public function updateDocumentsNdjsonInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    {
+        $promises = [];
+        foreach (self::batchNdjsonString($documents, $batchSize) as $batch) {
+            $promises[] = $this->updateDocumentsNdjson($batch, $primaryKey);
+        }
+
+        return $promises;
+    }
+
     public function deleteAllDocuments(): array
     {
         return $this->http->delete(self::PATH.'/'.$this->uid.'/documents');

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -160,11 +160,12 @@ trait HandlesDocuments
         $documents = preg_split("/\r\n|\n|\r/", trim($documents));
         $csvHeader = $documents[0];
         array_shift($documents);
-
         $batches = array_chunk($documents, $batchSize);
+
         foreach ($batches as $batch) {
             array_unshift($batch, $csvHeader);
             $batch = implode("\n", $batch);
+
             yield $batch;
         }
     }
@@ -172,10 +173,11 @@ trait HandlesDocuments
     private static function batchNdjsonString(string $documents, int $batchSize): Generator
     {
         $documents = preg_split("/\r\n|\n|\r/", trim($documents));
-
         $batches = array_chunk($documents, $batchSize);
+
         foreach ($batches as $batch) {
             $batch = implode("\n", $batch);
+
             yield $batch;
         }
     }

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -32,6 +32,21 @@ trait HandlesDocuments
         return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey]);
     }
 
+    public function addDocumentsJson(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/json');
+    }
+
+    public function addDocumentsCsv(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
+    }
+
+    public function addDocumentsNdjson(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/x-ndjson');
+    }
+
     public function addDocumentsInBatches(array $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
     {
         $promises = [];
@@ -40,31 +55,6 @@ trait HandlesDocuments
         }
 
         return $promises;
-    }
-
-    public function addDocumentsJson(string $documents, ?string $primaryKey = null)
-    {
-        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/json');
-    }
-
-    public function addDocumentsNdjson(string $documents, ?string $primaryKey = null)
-    {
-        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/x-ndjson');
-    }
-
-    public function addDocumentsNdjsonInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
-    {
-        $promises = [];
-        foreach (self::batchNdjsonString($documents, $batchSize) as $batch) {
-            $promises[] = $this->addDocumentsNdjson($batch, $primaryKey);
-        }
-
-        return $promises;
-    }
-
-    public function addDocumentsCsv(string $documents, ?string $primaryKey = null)
-    {
-        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
     }
 
     public function addDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
@@ -77,19 +67,19 @@ trait HandlesDocuments
         return $promises;
     }
 
-    public function updateDocuments(array $documents, ?string $primaryKey = null)
-    {
-        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey]);
-    }
-
-    public function updateDocumentsInBatches(array $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    public function addDocumentsNdjsonInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
     {
         $promises = [];
-        foreach (self::batch($documents, $batchSize) as $batch) {
-            $promises[] = $this->updateDocuments($batch, $primaryKey);
+        foreach (self::batchNdjsonString($documents, $batchSize) as $batch) {
+            $promises[] = $this->addDocumentsNdjson($batch, $primaryKey);
         }
 
         return $promises;
+    }
+
+    public function updateDocuments(array $documents, ?string $primaryKey = null)
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey]);
     }
 
     public function updateDocumentsJson(string $documents, ?string $primaryKey = null)
@@ -102,6 +92,21 @@ trait HandlesDocuments
         return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
     }
 
+    public function updateDocumentsNdjson(string $documents, ?string $primaryKey = null)
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/x-ndjson');
+    }
+
+    public function updateDocumentsInBatches(array $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    {
+        $promises = [];
+        foreach (self::batch($documents, $batchSize) as $batch) {
+            $promises[] = $this->updateDocuments($batch, $primaryKey);
+        }
+
+        return $promises;
+    }
+
     public function updateDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
     {
         $promises = [];
@@ -110,11 +115,6 @@ trait HandlesDocuments
         }
 
         return $promises;
-    }
-
-    public function updateDocumentsNdjson(string $documents, ?string $primaryKey = null)
-    {
-        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/x-ndjson');
     }
 
     public function updateDocumentsNdjsonInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -100,13 +100,18 @@ class Client implements Http
         return $this->execute($request);
     }
 
-    public function put(string $path, $body = null, array $query = [])
+    public function put(string $path, $body = null, array $query = [], string $contentType = null)
     {
-        $this->headers['Content-type'] = 'application/json';
+        if (!\is_null($contentType)) {
+            $this->headers['Content-type'] = $contentType;
+        } else {
+            $this->headers['Content-type'] = 'application/json';
+            $body = $this->json->serialize($body);
+        }
         $request = $this->requestFactory->createRequest(
             'PUT',
             $this->baseUrl.$path.$this->buildQueryString($query)
-        )->withBody($this->streamFactory->createStream($this->json->serialize($body)));
+        )->withBody($this->streamFactory->createStream($body));
 
         return $this->execute($request);
     }

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -587,8 +587,8 @@ final class DocumentsTest extends TestCase
         $documentCsv = fread($fileCsv, filesize('./tests/datasets/songs.csv'));
         fclose($fileCsv);
 
-        $promise = $index->addDocumentsCsv($documentCsv);
-        $index->waitForTask($promise['taskUid']);
+        $addPromise = $index->addDocumentsCsv($documentCsv);
+        $index->waitForTask($addPromise['taskUid']);
 
         $replacement = 'id,title'.PHP_EOL;
         $replacement .= '888221515,Young folks'.PHP_EOL;
@@ -618,8 +618,8 @@ final class DocumentsTest extends TestCase
         $documentNdJson = fread($fileNdJson, filesize('./tests/datasets/songs.ndjson'));
         fclose($fileNdJson);
 
-        $promise = $index->addDocumentsNdjson($documentNdJson);
-        $index->waitForTask($promise['taskUid']);
+        $addPromise = $index->addDocumentsNdjson($documentNdJson);
+        $index->waitForTask($addPromise['taskUid']);
 
         $replacement = json_encode(['id' => 412559401, 'title' => 'WASPTHOVEN']).PHP_EOL;
         $replacement .= json_encode(['id' => 70764404, 'artist' => 'Ailitp']).PHP_EOL;


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #238

## What does this PR do?
- Implements methods for batch adding of documents in csv and ndjson format

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

## Notes
This is using `preg_split` and `implode` to chunk strings by newline. Let me know if there is a better way to do this.

If this is fine I can implement the rest of the methods from the issue.