### PR TITLE
Fix tasks specs with v0.30rc2

### DIFF
--- a/src/Contracts/TasksQuery.php
+++ b/src/Contracts/TasksQuery.php
@@ -9,9 +9,9 @@ class TasksQuery
     private int $from;
     private int $limit;
     private int $next;
-    private array $type;
-    private array $status;
-    private array $indexUid;
+    private array $types;
+    private array $statuses;
+    private array $indexUids;
 
     public function setFrom(int $from): TasksQuery
     {
@@ -36,28 +36,28 @@ class TasksQuery
 
     public function setTypes(array $types): TasksQuery
     {
-        $this->type = $types;
+        $this->types = $types;
 
         return $this;
     }
 
-    public function setStatus(array $status): TasksQuery
+    public function setStatuses(array $statuses): TasksQuery
     {
-        $this->status = $status;
+        $this->statuses = $statuses;
 
         return $this;
     }
 
-    public function setUid(array $indexUid): TasksQuery
+    public function setIndexUids(array $indexUids): TasksQuery
     {
-        $this->indexUid = $indexUid;
+        $this->indexUids = $indexUids;
 
         return $this;
     }
 
-    public function getUid(): array
+    public function getIndexUids(): array
     {
-        return $this->indexUid ?? [];
+        return $this->indexUids ?? [];
     }
 
     public function toArray(): array
@@ -66,9 +66,9 @@ class TasksQuery
             'from' => $this->from ?? null,
             'limit' => $this->limit ?? null,
             'next' => $this->next ?? null,
-            'status' => isset($this->status) ? implode(',', $this->status) : null,
-            'type' => isset($this->type) ? implode(',', $this->type) : null,
-            'indexUid' => isset($this->indexUid) ? implode(',', $this->indexUid) : null,
+            'statuses' => isset($this->statuses) ? implode(',', $this->statuses) : null,
+            'types' => isset($this->types) ? implode(',', $this->types) : null,
+            'indexUids' => isset($this->indexUids) ? implode(',', $this->indexUids) : null,
         ], function ($item) { return null != $item || is_numeric($item); });
     }
 }

--- a/src/Contracts/TasksQuery.php
+++ b/src/Contracts/TasksQuery.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Contracts;
 
+use MeiliSearch\Delegates\TasksQueryTrait;
+
 class TasksQuery
 {
+    use TasksQueryTrait;
+
     private int $from;
     private int $limit;
-    private int $next;
-    private array $types;
-    private array $statuses;
-    private array $indexUids;
 
     public function setFrom(int $from): TasksQuery
     {
@@ -27,48 +27,23 @@ class TasksQuery
         return $this;
     }
 
-    public function setNext(int $next): TasksQuery
-    {
-        $this->next = $next;
-
-        return $this;
-    }
-
-    public function setTypes(array $types): TasksQuery
-    {
-        $this->types = $types;
-
-        return $this;
-    }
-
-    public function setStatuses(array $statuses): TasksQuery
-    {
-        $this->statuses = $statuses;
-
-        return $this;
-    }
-
-    public function setIndexUids(array $indexUids): TasksQuery
-    {
-        $this->indexUids = $indexUids;
-
-        return $this;
-    }
-
-    public function getIndexUids(): array
-    {
-        return $this->indexUids ?? [];
-    }
-
     public function toArray(): array
     {
         return array_filter([
             'from' => $this->from ?? null,
             'limit' => $this->limit ?? null,
             'next' => $this->next ?? null,
-            'statuses' => isset($this->statuses) ? implode(',', $this->statuses) : null,
-            'types' => isset($this->types) ? implode(',', $this->types) : null,
-            'indexUids' => isset($this->indexUids) ? implode(',', $this->indexUids) : null,
+            'beforeEnqueuedAt' => $this->formatDate($this->beforeEnqueuedAt ?? null),
+            'afterEnqueuedAt' => $this->formatDate($this->afterEnqueuedAt ?? null),
+            'beforeStartedAt' => $this->formatDate($this->beforeStartedAt ?? null),
+            'afterStartedAt' => $this->formatDate($this->afterStartedAt ?? null),
+            'beforeFinishedAt' => $this->formatDate($this->beforeFinishedAt ?? null),
+            'afterFinishedAt' => $this->formatDate($this->afterFinishedAt ?? null),
+            'statuses' => $this->formatArray($this->statuses ?? null),
+            'uids' => $this->formatArray($this->uids ?? null),
+            'canceledBy' => $this->formatArray($this->canceledBy ?? null),
+            'types' => $this->formatArray($this->types ?? null),
+            'indexUids' => $this->formatArray($this->indexUids ?? null),
         ], function ($item) { return null != $item || is_numeric($item); });
     }
 }

--- a/src/Delegates/TasksQueryTrait.php
+++ b/src/Delegates/TasksQueryTrait.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Delegates;
+
+trait TasksQueryTrait
+{
+    private int $next;
+    private array $types;
+    private array $statuses;
+    private array $indexUids;
+    private array $uids;
+    private array $canceledBy;
+    private \DateTime $beforeEnqueuedAt;
+    private \DateTime $afterEnqueuedAt;
+    private \DateTime $beforeStartedAt;
+    private \DateTime $afterStartedAt;
+    private \DateTime $beforeFinishedAt;
+    private \DateTime $afterFinishedAt;
+
+    public function setNext(int $next)
+    {
+        $this->next = $next;
+
+        return $this;
+    }
+
+    public function setTypes(array $types)
+    {
+        $this->types = $types;
+
+        return $this;
+    }
+
+    public function setStatuses(array $statuses)
+    {
+        $this->statuses = $statuses;
+
+        return $this;
+    }
+
+    public function setIndexUids(array $indexUids)
+    {
+        $this->indexUids = $indexUids;
+
+        return $this;
+    }
+
+    public function getIndexUids(): array
+    {
+        return $this->indexUids ?? [];
+    }
+
+    public function setUids(array $uids)
+    {
+        $this->uids = $uids;
+
+        return $this;
+    }
+
+    public function setCanceledBy(array $canceledBy)
+    {
+        $this->canceledBy = $canceledBy;
+
+        return $this;
+    }
+
+    public function setBeforeEnqueuedAt(\DateTime $date)
+    {
+        $this->beforeEnqueuedAt = $date;
+
+        return $this;
+    }
+
+    public function setAfterEnqueuedAt(\DateTime $date)
+    {
+        $this->afterEnqueuedAt = $date;
+
+        return $this;
+    }
+
+    public function setBeforeStartedAt(\DateTime $date)
+    {
+        $this->beforeStartedAt = $date;
+
+        return $this;
+    }
+
+    public function setAfterStartedAt(\DateTime $date)
+    {
+        $this->afterStartedAt = $date;
+
+        return $this;
+    }
+
+    public function setBeforeFinishedAt(\DateTime $date)
+    {
+        $this->beforeFinishedAt = $date;
+
+        return $this;
+    }
+
+    public function setAfterFinishedAt(\DateTime $date)
+    {
+        $this->afterFinishedAt = $date;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'next' => $this->next ?? null,
+            'beforeEnqueuedAt' => $this->formatDate($this->beforeEnqueuedAt ?? null),
+            'afterEnqueuedAt' => $this->formatDate($this->afterEnqueuedAt ?? null),
+            'beforeStartedAt' => $this->formatDate($this->beforeStartedAt ?? null),
+            'afterStartedAt' => $this->formatDate($this->afterStartedAt ?? null),
+            'beforeFinishedAt' => $this->formatDate($this->beforeFinishedAt ?? null),
+            'afterFinishedAt' => $this->formatDate($this->afterFinishedAt ?? null),
+            'statuses' => $this->formatArray($this->statuses ?? null),
+            'uids' => $this->formatArray($this->uids ?? null),
+            'canceledBy' => $this->formatArray($this->canceledBy ?? null),
+            'types' => $this->formatArray($this->types ?? null),
+            'indexUids' => $this->formatArray($this->indexUids ?? null),
+        ], function ($item) { return null != $item || is_numeric($item); });
+    }
+
+    private function formatDate(?\DateTime $date)
+    {
+        return isset($date) ? $date->format(\DateTime::RFC3339) : null;
+    }
+
+    private function formatArray(?array $arr)
+    {
+        return isset($arr) ? implode(',', $arr) : null;
+    }
+}

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -164,10 +164,10 @@ class Indexes extends Endpoint
     {
         $options = $options ?? new TasksQuery();
 
-        if (0 == \count($options->getUid())) {
-            $options->setUid(array_merge([$this->uid], $options->getUid()));
+        if (0 == \count($options->getIndexUids())) {
+            $options->setIndexUids(array_merge([$this->uid], $options->getIndexUids()));
         } else {
-            $options->setUid([$this->uid]);
+            $options->setIndexUids([$this->uid]);
         }
 
         $response = $this->http->get('/tasks', $options->toArray());

--- a/tests/Contracts/TasksQueryTest.php
+++ b/tests/Contracts/TasksQueryTest.php
@@ -23,6 +23,14 @@ class TasksQueryTest extends TestCase
         $this->assertEquals($data->toArray(), ['next' => 99]);
     }
 
+    public function testSetAnyDateFilter(): void
+    {
+        $date = new \DateTime();
+        $data = (new TasksQuery())->setBeforeEnqueuedAt($date);
+
+        $this->assertEquals($data->toArray(), ['beforeEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
+    }
+
     public function testToArrayWithSetLimit(): void
     {
         $data = (new TasksQuery())->setLimit(10);
@@ -39,7 +47,7 @@ class TasksQueryTest extends TestCase
 
     public function testToArrayWithDifferentSets(): void
     {
-        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatus(['enqueued']);
+        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
             'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',

--- a/tests/Contracts/TasksQueryTest.php
+++ b/tests/Contracts/TasksQueryTest.php
@@ -13,7 +13,7 @@ class TasksQueryTest extends TestCase
     {
         $data = (new TasksQuery())->setTypes(['abc', 'xyz']);
 
-        $this->assertEquals($data->toArray(), ['type' => 'abc,xyz']);
+        $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
     }
 
     public function testSetNext(): void
@@ -42,7 +42,7 @@ class TasksQueryTest extends TestCase
         $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatus(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
-            'limit' => 9, 'next' => 99, 'from' => 10, 'status' => 'enqueued',
+            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
         ]);
     }
 }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -185,7 +185,7 @@ final class IndexTest extends TestCase
         $promise = $this->index->addDocuments([['id' => 1, 'title' => 'Pride and Prejudice']]);
         $this->index->waitForTask($promise['taskUid']);
 
-        $tasks = $this->index->getTasks((new TasksQuery())->setUid(['other-index']));
+        $tasks = $this->index->getTasks((new TasksQuery())->setIndexUids(['other-index']));
 
         $allIndexUids = array_map(function ($val) { return $val['indexUid']; }, $tasks->getResults());
         $results = array_unique($allIndexUids);

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -109,7 +109,8 @@ final class TasksTest extends TestCase
 
     public function testGetAllTasksByIndexWithFilter(): void
     {
-        $response = $this->index->getTasks((new TasksQuery())->setStatus(['succeeded'])->setLimit(2));
+        $response = $this->index->getTasks((new TasksQuery())
+            ->setAfterEnqueuedAt(new \DateTime('yesterday'))->setStatuses(['succeeded'])->setLimit(2));
 
         $firstIndex = $response->getResults()[0]['uid'];
         $this->assertEquals($response->getResults()[0]['status'], 'succeeded');


### PR DESCRIPTION
### Add and Update filters to the `tasks` resource.

- Added `setUids(array<int>)` filter to match by `Task.uid`.
- Added `setCanceledBy(array<int>)` filter to match by `Task.canceledBy`
- Added `setBeforeEnqueuedAt(\DateTime)` filter to match by `Task.beforeEnqueuedAt`
- Added `setAfterEnqueuedAt(\DateTime)` filter to match by `Task.AfterEnqueuedAt`
- Added `setBeforeStartedAt(\DateTime)` filter to match by `Task.beforeStartedAt`
- Added `setAfterStartedAt(\DateTime)` filter to match by `Task.AfterStartedAt`
- Added `setBeforeFinishedAt(\DateTime)` filter to match by `Task.beforeFinishedAt`
- Added `setAfterFinishedAt(\DateTime)` filter to match by `Task.AfterFinishedAt`
- ⚠️⚠️  Renamed `setUid(array)` to `setIndexUids(array)` filter to match by `Task.indexUid`
- ⚠️⚠️  Renamed `setStatus(array)` to `setStatuses(array<string>)` filter to match by `Task.status`
