### PR TITLE
Add `cancelTasks` method

### DIFF
--- a/src/Contracts/CancelTasksQuery.php
+++ b/src/Contracts/CancelTasksQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+use MeiliSearch\Delegates\TasksQueryTrait;
+
+class CancelTasksQuery
+{
+    use TasksQueryTrait;
+}

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints\Delegates;
 
+use MeiliSearch\Contracts\CancelTasksQuery;
 use MeiliSearch\Contracts\TasksQuery;
 use MeiliSearch\Contracts\TasksResults;
 
@@ -21,6 +22,11 @@ trait HandlesTasks
         $response = $this->tasks->all($query);
 
         return new TasksResults($response);
+    }
+
+    public function cancelTasks(CancelTasksQuery $options = null): array
+    {
+        return $this->tasks->cancelTasks($options);
     }
 
     public function waitForTask($uid, int $timeoutInMs = 5000, int $intervalInMs = 50): array

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MeiliSearch\Endpoints;
 
+use MeiliSearch\Contracts\CancelTasksQuery;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Exceptions\TimeOutException;
 
@@ -19,6 +20,14 @@ class Tasks extends Endpoint
     public function all(array $query = []): array
     {
         return $this->http->get(self::PATH.'/', $query);
+    }
+
+    public function cancelTasks(?CancelTasksQuery $options): array
+    {
+        $options = $options ?? new CancelTasksQuery();
+        $response = $this->http->post('/tasks/cancel', null, $options->toArray());
+
+        return $response;
     }
 
     /**

--- a/tests/Contracts/CancelTasksQueryTest.php
+++ b/tests/Contracts/CancelTasksQueryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use MeiliSearch\Contracts\TasksQuery;
+use PHPUnit\Framework\TestCase;
+
+class CancelTasksQueryTest extends TestCase
+{
+    public function testSetTypes(): void
+    {
+        $data = (new TasksQuery())->setTypes(['abc', 'xyz']);
+
+        $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
+    }
+
+    public function testSetNext(): void
+    {
+        $data = (new TasksQuery())->setNext(99);
+
+        $this->assertEquals($data->toArray(), ['next' => 99]);
+    }
+
+    public function testSetAnyDateFilter(): void
+    {
+        $date = new \DateTime();
+        $data = (new TasksQuery())->setBeforeEnqueuedAt($date);
+
+        $this->assertEquals($data->toArray(), ['beforeEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
+    }
+
+    public function testToArrayWithSetNextWithZero(): void
+    {
+        $data = (new TasksQuery())->setNext(0);
+
+        $this->assertEquals($data->toArray(), ['next' => 0]);
+    }
+
+    public function testToArrayWithDifferentSets(): void
+    {
+        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
+
+        $this->assertEquals($data->toArray(), [
+            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
+        ]);
+    }
+}

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use MeiliSearch\Contracts\CancelTasksQuery;
 use MeiliSearch\Contracts\TasksQuery;
 use MeiliSearch\Endpoints\Indexes;
 use MeiliSearch\Exceptions\ApiException;
@@ -122,6 +123,20 @@ final class TasksTest extends TestCase
         $newFirstIndex = $response->getResults()[0]['uid'];
 
         $this->assertEquals($firstIndex, $newFirstIndex);
+    }
+
+    public function testCancelTasksWithFilter(): void
+    {
+        $date = new \DateTime('yesterday');
+        $query = http_build_query(['afterEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
+        $promise = $this->client->cancelTasks((new CancelTasksQuery())->setAfterEnqueuedAt($date));
+
+        $this->assertEquals($promise['type'], 'taskCancelation');
+        $response = $this->client->waitForTask($promise['taskUid']);
+
+        $this->assertEquals($response['details']['originalFilter'], '?'.$query);
+        $this->assertEquals($response['type'], 'taskCancelation');
+        $this->assertEquals($response['status'], 'succeeded');
     }
 
     public function testExceptionIfNoTaskIdWhenGetting(): void


### PR DESCRIPTION
Allow users to cancel a processing or an enqueued task.

A new method `cancelTasks(CancelTasksQuery $query)`

```php
// CancelTasksQuery methods:
setNext(int $next)
setTypes(array $types)
setStatuses(array $statuses)
setIndexUids(array $indexUids)
setUids(array $uids)
setCanceledBy(array $canceledBy)
setBeforeEnqueuedAt(\DateTime $date)
setAfterEnqueuedAt(\DateTime $date)
setBeforeStartedAt(\DateTime $date)
setAfterStartedAt(\DateTime $date)
setBeforeFinishedAt(\DateTime $date)
setAfterFinishedAt(\DateTime $date)
```