### PR TITLE
Add `deleteTasks` method

### DIFF
--- a/src/Contracts/DeleteTasksQuery.php
+++ b/src/Contracts/DeleteTasksQuery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MeiliSearch\Contracts;
+
+use MeiliSearch\Delegates\TasksQueryTrait;
+
+class DeleteTasksQuery
+{
+    use TasksQueryTrait;
+}

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints\Delegates;
 
 use MeiliSearch\Contracts\CancelTasksQuery;
+use MeiliSearch\Contracts\DeleteTasksQuery;
 use MeiliSearch\Contracts\TasksQuery;
 use MeiliSearch\Contracts\TasksResults;
 
@@ -22,6 +23,11 @@ trait HandlesTasks
         $response = $this->tasks->all($query);
 
         return new TasksResults($response);
+    }
+
+    public function deleteTasks(DeleteTasksQuery $options = null): array
+    {
+        return $this->tasks->deleteTasks($options);
     }
 
     public function cancelTasks(CancelTasksQuery $options = null): array

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MeiliSearch\Endpoints;
 
 use MeiliSearch\Contracts\CancelTasksQuery;
+use MeiliSearch\Contracts\DeleteTasksQuery;
 use MeiliSearch\Contracts\Endpoint;
 use MeiliSearch\Exceptions\TimeOutException;
 
@@ -26,6 +27,14 @@ class Tasks extends Endpoint
     {
         $options = $options ?? new CancelTasksQuery();
         $response = $this->http->post('/tasks/cancel', null, $options->toArray());
+
+        return $response;
+    }
+
+    public function deleteTasks(?DeleteTasksQuery $options): array
+    {
+        $options = $options ?? new DeleteTasksQuery();
+        $response = $this->http->delete(self::PATH, $options->toArray());
 
         return $response;
     }

--- a/tests/Contracts/DeleteTasksQueryTest.php
+++ b/tests/Contracts/DeleteTasksQueryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use MeiliSearch\Contracts\TasksQuery;
+use PHPUnit\Framework\TestCase;
+
+class DeleteTasksQueryTest extends TestCase
+{
+    public function testSetTypes(): void
+    {
+        $data = (new TasksQuery())->setTypes(['abc', 'xyz']);
+
+        $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
+    }
+
+    public function testSetNext(): void
+    {
+        $data = (new TasksQuery())->setNext(99);
+
+        $this->assertEquals($data->toArray(), ['next' => 99]);
+    }
+
+    public function testSetAnyDateFilter(): void
+    {
+        $date = new \DateTime();
+        $data = (new TasksQuery())->setBeforeEnqueuedAt($date);
+
+        $this->assertEquals($data->toArray(), ['beforeEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
+    }
+
+    public function testToArrayWithSetNextWithZero(): void
+    {
+        $data = (new TasksQuery())->setNext(0);
+
+        $this->assertEquals($data->toArray(), ['next' => 0]);
+    }
+
+    public function testToArrayWithDifferentSets(): void
+    {
+        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
+
+        $this->assertEquals($data->toArray(), [
+            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
+        ]);
+    }
+}

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use MeiliSearch\Contracts\DeleteTasksQuery;
 use MeiliSearch\Contracts\TasksQuery;
 use MeiliSearch\Endpoints\Indexes;
 use MeiliSearch\Exceptions\TimeOutException;
@@ -274,6 +275,15 @@ final class IndexTest extends TestCase
         $response = $this->client->waitForTask($promise['taskUid']);
 
         $this->assertSame($response['details']['swaps'], [['indexes' => ['indexA', 'indexB']], ['indexes' => ['indexC', 'indexD']]]);
+    }
+
+    public function testDeleteTasks(): void
+    {
+        $promise = $this->client->deleteTasks((new DeleteTasksQuery())->setUids([1, 2]));
+        $response = $this->client->waitForTask($promise['taskUid']);
+
+        $this->assertSame($response['details']['originalFilter'], '?uids=1%2C2');
+        $this->assertIsNumeric($response['details']['matchedTasks']);
     }
 
     public function testParseDate(): void


### PR DESCRIPTION
Allow users to delete processed, failed and canceled tasks.

A new method `deleteTasks(DeleteTasksQuery $query)`

```php
// DeleteTasksQuery methods:
setNext(int $next)
setTypes(array $types)
setStatuses(array $statuses)
setIndexUids(array $indexUids)
setUids(array $uids)
setCanceledBy(array $canceledBy)
setBeforeEnqueuedAt(\DateTime $date)
setAfterEnqueuedAt(\DateTime $date)
setBeforeStartedAt(\DateTime $date)
setAfterStartedAt(\DateTime $date)
setBeforeFinishedAt(\DateTime $date)
setAfterFinishedAt(\DateTime $date)
```