### PR TITLE
Change casing of `MeiliSearch` to `Meilisearch`

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -423,7 +423,7 @@ getting_started_add_documents_md: |-
 
   require_once __DIR__ . '/vendor/autoload.php';
 
-  use MeiliSearch\Client;
+  use Meilisearch\Client;
 
   $client = new Client('http://localhost:7700');
 

--- a/.github/scripts/beta-docker-version.sh
+++ b/.github/scripts/beta-docker-version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-meilisearch_php_version=$(grep 'public const VERSION =' ./src/MeiliSearch.php | cut -d ' ' -f 9 | tr -d "'" | tr -d ";")
+meilisearch_php_version=$(grep 'public const VERSION =' ./src/Meilisearch.php | cut -d ' ' -f 9 | tr -d "'" | tr -d ";")
 beta_feature=$(echo $meilisearch_php_version | sed -r 's/[0-9]+.[0-9]+.[0-9]+-meilisearch-//')
 beta_feature=$(echo $beta_feature | sed -r 's/-beta\.[0-9]*$//')
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md).
 
-Make a PR modifying the file [`src/MeiliSearch.php`](/src/MeiliSearch.php) with the right version.
+Make a PR modifying the file [`src/Meilisearch.php`](/src/Meilisearch.php) with the right version.
 
 ```php
 const VERSION = 'X.X.X';

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ NB: you can also download Meilisearch from **Homebrew** or **APT** or even run i
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-use MeiliSearch\Client;
+use Meilisearch\Client;
 
 $client = new Client('http://127.0.0.1:7700', 'masterKey');
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "autoload": {
         "psr-4": {
-            "MeiliSearch\\": "src/"
+            "MeiliSearch\\": "src/",
+            "Meilisearch\\": "src/"
         }
     },
     "autoload-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch;
+namespace Meilisearch;
 
-use MeiliSearch\Contracts\Http as HttpContract;
-use MeiliSearch\Delegates\HandlesIndex;
-use MeiliSearch\Delegates\HandlesSystem;
-use MeiliSearch\Endpoints\Delegates\HandlesDumps;
-use MeiliSearch\Endpoints\Delegates\HandlesKeys;
-use MeiliSearch\Endpoints\Delegates\HandlesTasks;
-use MeiliSearch\Endpoints\Dumps;
-use MeiliSearch\Endpoints\Health;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Endpoints\Keys;
-use MeiliSearch\Endpoints\Stats;
-use MeiliSearch\Endpoints\Tasks;
-use MeiliSearch\Endpoints\TenantToken;
-use MeiliSearch\Endpoints\Version;
-use MeiliSearch\Http\Client as MeilisearchClientAdapter;
+use Meilisearch\Contracts\Http as HttpContract;
+use Meilisearch\Delegates\HandlesIndex;
+use Meilisearch\Delegates\HandlesSystem;
+use Meilisearch\Endpoints\Delegates\HandlesDumps;
+use Meilisearch\Endpoints\Delegates\HandlesKeys;
+use Meilisearch\Endpoints\Delegates\HandlesTasks;
+use Meilisearch\Endpoints\Dumps;
+use Meilisearch\Endpoints\Health;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Keys;
+use Meilisearch\Endpoints\Stats;
+use Meilisearch\Endpoints\Tasks;
+use Meilisearch\Endpoints\TenantToken;
+use Meilisearch\Endpoints\Version;
+use Meilisearch\Http\Client as MeilisearchClientAdapter;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/src/Contracts/CancelTasksQuery.php
+++ b/src/Contracts/CancelTasksQuery.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
-use MeiliSearch\Delegates\TasksQueryTrait;
+use Meilisearch\Delegates\TasksQueryTrait;
 
 class CancelTasksQuery
 {

--- a/src/Contracts/Data.php
+++ b/src/Contracts/Data.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class Data implements \ArrayAccess, \Countable, \IteratorAggregate
 {

--- a/src/Contracts/DeleteTasksQuery.php
+++ b/src/Contracts/DeleteTasksQuery.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
-use MeiliSearch\Delegates\TasksQueryTrait;
+use Meilisearch\Delegates\TasksQueryTrait;
 
 class DeleteTasksQuery
 {

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class DocumentsQuery
 {

--- a/src/Contracts/DocumentsResults.php
+++ b/src/Contracts/DocumentsResults.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class DocumentsResults extends Data
 {

--- a/src/Contracts/Endpoint.php
+++ b/src/Contracts/Endpoint.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 abstract class Endpoint
 {

--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 interface Http
 {

--- a/src/Contracts/Index/Settings.php
+++ b/src/Contracts/Index/Settings.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts\Index;
+namespace Meilisearch\Contracts\Index;
 
-use MeiliSearch\Contracts\Data;
+use Meilisearch\Contracts\Data;
 
 class Settings extends Data implements \JsonSerializable
 {

--- a/src/Contracts/Index/Synonyms.php
+++ b/src/Contracts/Index/Synonyms.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts\Index;
+namespace Meilisearch\Contracts\Index;
 
-use MeiliSearch\Contracts\Data;
+use Meilisearch\Contracts\Data;
 
 class Synonyms extends Data implements \JsonSerializable
 {

--- a/src/Contracts/Index/TypoTolerance.php
+++ b/src/Contracts/Index/TypoTolerance.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts\Index;
+namespace Meilisearch\Contracts\Index;
 
-use MeiliSearch\Contracts\Data;
+use Meilisearch\Contracts\Data;
 
 class TypoTolerance extends Data implements \JsonSerializable
 {

--- a/src/Contracts/IndexesQuery.php
+++ b/src/Contracts/IndexesQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class IndexesQuery
 {

--- a/src/Contracts/IndexesResults.php
+++ b/src/Contracts/IndexesResults.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 
 class IndexesResults extends Data
 {

--- a/src/Contracts/KeysQuery.php
+++ b/src/Contracts/KeysQuery.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class KeysQuery
 {

--- a/src/Contracts/KeysResults.php
+++ b/src/Contracts/KeysResults.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class KeysResults extends Data
 {

--- a/src/Contracts/TasksQuery.php
+++ b/src/Contracts/TasksQuery.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
-use MeiliSearch\Delegates\TasksQueryTrait;
+use Meilisearch\Delegates\TasksQueryTrait;
 
 class TasksQuery
 {

--- a/src/Contracts/TasksResults.php
+++ b/src/Contracts/TasksResults.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Contracts;
+namespace Meilisearch\Contracts;
 
 class TasksResults extends Data
 {

--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Delegates;
+namespace Meilisearch\Delegates;
 
-use MeiliSearch\Contracts\IndexesQuery;
-use MeiliSearch\Contracts\IndexesResults;
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Contracts\IndexesQuery;
+use Meilisearch\Contracts\IndexesResults;
+use Meilisearch\Endpoints\Indexes;
 
 trait HandlesIndex
 {

--- a/src/Delegates/HandlesSystem.php
+++ b/src/Delegates/HandlesSystem.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Delegates;
+namespace Meilisearch\Delegates;
 
 trait HandlesSystem
 {

--- a/src/Delegates/TasksQueryTrait.php
+++ b/src/Delegates/TasksQueryTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Delegates;
+namespace Meilisearch\Delegates;
 
 trait TasksQueryTrait
 {

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints\Delegates;
+namespace Meilisearch\Endpoints\Delegates;
 
-use MeiliSearch\Contracts\DocumentsQuery;
-use MeiliSearch\Contracts\DocumentsResults;
-use MeiliSearch\Exceptions\InvalidArgumentException;
+use Meilisearch\Contracts\DocumentsQuery;
+use Meilisearch\Contracts\DocumentsResults;
+use Meilisearch\Exceptions\InvalidArgumentException;
 
 trait HandlesDocuments
 {

--- a/src/Endpoints/Delegates/HandlesDumps.php
+++ b/src/Endpoints/Delegates/HandlesDumps.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints\Delegates;
+namespace Meilisearch\Endpoints\Delegates;
 
 trait HandlesDumps
 {

--- a/src/Endpoints/Delegates/HandlesKeys.php
+++ b/src/Endpoints/Delegates/HandlesKeys.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints\Delegates;
+namespace Meilisearch\Endpoints\Delegates;
 
-use MeiliSearch\Contracts\KeysQuery;
-use MeiliSearch\Contracts\KeysResults;
-use MeiliSearch\Endpoints\Keys;
+use Meilisearch\Contracts\KeysQuery;
+use Meilisearch\Contracts\KeysResults;
+use Meilisearch\Endpoints\Keys;
 
 trait HandlesKeys
 {

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints\Delegates;
+namespace Meilisearch\Endpoints\Delegates;
 
-use MeiliSearch\Contracts\Index\Synonyms;
-use MeiliSearch\Contracts\Index\TypoTolerance;
+use Meilisearch\Contracts\Index\Synonyms;
+use Meilisearch\Contracts\Index\TypoTolerance;
 
 trait HandlesSettings
 {

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints\Delegates;
+namespace Meilisearch\Endpoints\Delegates;
 
-use MeiliSearch\Contracts\CancelTasksQuery;
-use MeiliSearch\Contracts\DeleteTasksQuery;
-use MeiliSearch\Contracts\TasksQuery;
-use MeiliSearch\Contracts\TasksResults;
+use Meilisearch\Contracts\CancelTasksQuery;
+use Meilisearch\Contracts\DeleteTasksQuery;
+use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\TasksResults;
 
 trait HandlesTasks
 {

--- a/src/Endpoints/Dumps.php
+++ b/src/Endpoints/Dumps.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Endpoint;
 
 class Dumps extends Endpoint
 {

--- a/src/Endpoints/Health.php
+++ b/src/Endpoints/Health.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Endpoint;
 
 class Health extends Endpoint
 {

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
-use MeiliSearch\Contracts\Http;
-use MeiliSearch\Contracts\Index\Settings;
-use MeiliSearch\Contracts\IndexesQuery;
-use MeiliSearch\Contracts\IndexesResults;
-use MeiliSearch\Contracts\TasksQuery;
-use MeiliSearch\Contracts\TasksResults;
-use MeiliSearch\Endpoints\Delegates\HandlesDocuments;
-use MeiliSearch\Endpoints\Delegates\HandlesSettings;
-use MeiliSearch\Endpoints\Delegates\HandlesTasks;
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Search\SearchResult;
+use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Http;
+use Meilisearch\Contracts\Index\Settings;
+use Meilisearch\Contracts\IndexesQuery;
+use Meilisearch\Contracts\IndexesResults;
+use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\TasksResults;
+use Meilisearch\Endpoints\Delegates\HandlesDocuments;
+use Meilisearch\Endpoints\Delegates\HandlesSettings;
+use Meilisearch\Endpoints\Delegates\HandlesTasks;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Search\SearchResult;
 
 class Indexes extends Endpoint
 {

--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
-use MeiliSearch\Contracts\Http;
-use MeiliSearch\Contracts\KeysQuery;
-use MeiliSearch\Contracts\KeysResults;
+use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Http;
+use Meilisearch\Contracts\KeysQuery;
+use Meilisearch\Contracts\KeysResults;
 
 class Keys extends Endpoint
 {

--- a/src/Endpoints/Stats.php
+++ b/src/Endpoints/Stats.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Endpoint;
 
 class Stats extends Endpoint
 {

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\CancelTasksQuery;
-use MeiliSearch\Contracts\DeleteTasksQuery;
-use MeiliSearch\Contracts\Endpoint;
-use MeiliSearch\Exceptions\TimeOutException;
+use Meilisearch\Contracts\CancelTasksQuery;
+use Meilisearch\Contracts\DeleteTasksQuery;
+use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Exceptions\TimeOutException;
 
 class Tasks extends Endpoint
 {

--- a/src/Endpoints/TenantToken.php
+++ b/src/Endpoints/TenantToken.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
 use DateTime;
-use MeiliSearch\Contracts\Endpoint;
-use MeiliSearch\Exceptions\InvalidArgumentException;
-use MeiliSearch\Http\Serialize\Json;
+use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Exceptions\InvalidArgumentException;
+use Meilisearch\Http\Serialize\Json;
 
 class TenantToken extends Endpoint
 {

--- a/src/Endpoints/Version.php
+++ b/src/Endpoints/Version.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Endpoints;
+namespace Meilisearch\Endpoints;
 
-use MeiliSearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Endpoint;
 
 class Version extends Endpoint
 {

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Exceptions/CommunicationException.php
+++ b/src/Exceptions/CommunicationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 class CommunicationException extends \Exception
 {

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 final class InvalidArgumentException extends \Exception
 {

--- a/src/Exceptions/InvalidResponseBodyException.php
+++ b/src/Exceptions/InvalidResponseBodyException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Exceptions/JsonDecodingException.php
+++ b/src/Exceptions/JsonDecodingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 final class JsonDecodingException extends \Exception
 {

--- a/src/Exceptions/JsonEncodingException.php
+++ b/src/Exceptions/JsonEncodingException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 final class JsonEncodingException extends \Exception
 {

--- a/src/Exceptions/TimeOutException.php
+++ b/src/Exceptions/TimeOutException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Exceptions;
+namespace Meilisearch\Exceptions;
 
 class TimeOutException extends \Exception
 {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Http;
+namespace Meilisearch\Http;
 
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
-use MeiliSearch\Contracts\Http;
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\CommunicationException;
-use MeiliSearch\Exceptions\InvalidResponseBodyException;
-use MeiliSearch\Exceptions\JsonDecodingException;
-use MeiliSearch\Exceptions\JsonEncodingException;
-use MeiliSearch\Http\Serialize\Json;
-use MeiliSearch\MeiliSearch;
+use Meilisearch\Contracts\Http;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\CommunicationException;
+use Meilisearch\Exceptions\InvalidResponseBodyException;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
+use Meilisearch\Http\Serialize\Json;
+use Meilisearch\Meilisearch;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -49,7 +49,7 @@ class Client implements Http
         $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([
-            'User-Agent' => implode(';', array_merge($clientAgents, [MeiliSearch::qualifiedVersion()])),
+            'User-Agent' => implode(';', array_merge($clientAgents, [Meilisearch::qualifiedVersion()])),
         ]);
         if (null != $this->apiKey) {
             $this->headers['Authorization'] = sprintf('Bearer %s', $this->apiKey);

--- a/src/Http/Serialize/Json.php
+++ b/src/Http/Serialize/Json.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Http\Serialize;
+namespace Meilisearch\Http\Serialize;
 
-use MeiliSearch\Exceptions\JsonDecodingException;
-use MeiliSearch\Exceptions\JsonEncodingException;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
 
 class Json implements SerializerInterface
 {

--- a/src/Http/Serialize/SerializerInterface.php
+++ b/src/Http/Serialize/SerializerInterface.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Http\Serialize;
+namespace Meilisearch\Http\Serialize;
 
-use MeiliSearch\Exceptions\JsonDecodingException;
-use MeiliSearch\Exceptions\JsonEncodingException;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
 
 interface SerializerInterface
 {

--- a/src/Meilisearch.php
+++ b/src/Meilisearch.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch;
+namespace Meilisearch;
 
-class MeiliSearch
+class Meilisearch
 {
     public const VERSION = '0.26.0';
 
     public static function qualifiedVersion()
     {
-        return sprintf('Meilisearch PHP (v%s)', MeiliSearch::VERSION);
+        return sprintf('Meilisearch PHP (v%s)', self::VERSION);
     }
 }

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MeiliSearch\Search;
+namespace Meilisearch\Search;
 
 class SearchResult implements \Countable, \IteratorAggregate
 {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use MeiliSearch\Client;
-use MeiliSearch\Exceptions\CommunicationException;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\CommunicationException;
 
 class ClientTest extends TestCase
 {

--- a/tests/Contracts/CancelTasksQueryTest.php
+++ b/tests/Contracts/CancelTasksQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\TasksQuery;
 use PHPUnit\Framework\TestCase;
 
 class CancelTasksQueryTest extends TestCase

--- a/tests/Contracts/DeleteTasksQueryTest.php
+++ b/tests/Contracts/DeleteTasksQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\TasksQuery;
 use PHPUnit\Framework\TestCase;
 
 class DeleteTasksQueryTest extends TestCase

--- a/tests/Contracts/DocumentsQueryTest.php
+++ b/tests/Contracts/DocumentsQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\DocumentsQuery;
+use Meilisearch\Contracts\DocumentsQuery;
 use PHPUnit\Framework\TestCase;
 
 class DocumentsQueryTest extends TestCase

--- a/tests/Contracts/IndexesQueryTest.php
+++ b/tests/Contracts/IndexesQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\IndexesQuery;
+use Meilisearch\Contracts\IndexesQuery;
 use PHPUnit\Framework\TestCase;
 
 class IndexesQueryTest extends TestCase

--- a/tests/Contracts/KeysQueryTest.php
+++ b/tests/Contracts/KeysQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\KeysQuery;
+use Meilisearch\Contracts\KeysQuery;
 use PHPUnit\Framework\TestCase;
 
 class KeysQueryTest extends TestCase

--- a/tests/Contracts/TasksQueryTest.php
+++ b/tests/Contracts/TasksQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use MeiliSearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\TasksQuery;
 use PHPUnit\Framework\TestCase;
 
 class TasksQueryTest extends TestCase

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Client;
-use MeiliSearch\Contracts\IndexesQuery;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Client;
+use Meilisearch\Contracts\IndexesQuery;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class ClientTest extends TestCase

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Contracts\DocumentsQuery;
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\InvalidArgumentException;
-use MeiliSearch\Exceptions\JsonEncodingException;
+use Meilisearch\Contracts\DocumentsQuery;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\InvalidArgumentException;
+use Meilisearch\Exceptions\JsonEncodingException;
 use Tests\TestCase;
 
 final class DocumentsTest extends TestCase

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Contracts\DeleteTasksQuery;
-use MeiliSearch\Contracts\TasksQuery;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\TimeOutException;
+use Meilisearch\Contracts\DeleteTasksQuery;
+use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\TimeOutException;
 use Tests\TestCase;
 
 final class IndexTest extends TestCase

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Client;
-use MeiliSearch\Contracts\KeysQuery;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Client;
+use Meilisearch\Contracts\KeysQuery;
+use Meilisearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class KeysAndPermissionsTest extends TestCase
@@ -318,7 +318,7 @@ final class KeysAndPermissionsTest extends TestCase
           }
         ');
 
-        $newClient = new \MeiliSearch\Client('https://localhost:7700', null, $httpClient);
+        $newClient = new \Meilisearch\Client('https://localhost:7700', null, $httpClient);
 
         $response = $newClient->getKeys();
 

--- a/tests/Endpoints/KeysAndPermissionsTest.php
+++ b/tests/Endpoints/KeysAndPermissionsTest.php
@@ -318,7 +318,7 @@ final class KeysAndPermissionsTest extends TestCase
           }
         ');
 
-        $newClient = new \Meilisearch\Client('https://localhost:7700', null, $httpClient);
+        $newClient = new Client('https://localhost:7700', null, $httpClient);
 
         $response = $newClient->getKeys();
 

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class SearchTest extends TestCase

--- a/tests/Endpoints/SearchTestNestedFields.php
+++ b/tests/Endpoints/SearchTestNestedFields.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class SearchTestNestedFields extends TestCase

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Contracts\CancelTasksQuery;
-use MeiliSearch\Contracts\TasksQuery;
-use MeiliSearch\Endpoints\Indexes;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Contracts\CancelTasksQuery;
+use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class TasksTest extends TestCase

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use MeiliSearch\Client;
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\InvalidArgumentException;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\InvalidArgumentException;
 use Tests\TestCase;
 
 final class TenantTokenTest extends TestCase

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Exceptions;
 
 use Http\Discovery\Psr17FactoryDiscovery;
-use MeiliSearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\ApiException;
 use Tests\TestCase;
 
 final class ApiExceptionTest extends TestCase

--- a/tests/Exceptions/CommunicationExceptionTest.php
+++ b/tests/Exceptions/CommunicationExceptionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Exceptions;
 
-use MeiliSearch\Exceptions\CommunicationException;
+use Meilisearch\Exceptions\CommunicationException;
 use Tests\TestCase;
 
 final class CommunicationExceptionTest extends TestCase

--- a/tests/Exceptions/InvalidResponseBodyExceptionTest.php
+++ b/tests/Exceptions/InvalidResponseBodyExceptionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Exceptions;
 
 use Http\Discovery\Psr17FactoryDiscovery;
-use MeiliSearch\Exceptions\InvalidResponseBodyException;
+use Meilisearch\Exceptions\InvalidResponseBodyException;
 use Tests\TestCase;
 
 final class InvalidResponseBodyExceptionTest extends TestCase

--- a/tests/Exceptions/TimeOutExceptionTest.php
+++ b/tests/Exceptions/TimeOutExceptionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Exceptions;
 
-use MeiliSearch\Exceptions\TimeOutException;
+use Meilisearch\Exceptions\TimeOutException;
 use Tests\TestCase;
 
 final class TimeOutExceptionTest extends TestCase

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Http;
 
-use MeiliSearch\Exceptions\ApiException;
-use MeiliSearch\Exceptions\InvalidResponseBodyException;
-use MeiliSearch\Exceptions\JsonDecodingException;
-use MeiliSearch\Exceptions\JsonEncodingException;
-use MeiliSearch\Http\Client;
-use MeiliSearch\MeiliSearch;
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\InvalidResponseBodyException;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
+use Meilisearch\Http\Client;
+use Meilisearch\Meilisearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
@@ -217,7 +217,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo(MeiliSearch::qualifiedVersion()),
+                    $this->equalTo(Meilisearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),
@@ -230,7 +230,7 @@ class ClientTest extends TestCase
             ->method('createRequest')
             ->willReturn($requestStub);
 
-        $client = new \MeiliSearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory);
+        $client = new \Meilisearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory);
 
         $client->health();
     }
@@ -247,7 +247,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo($customAgent.';'.MeiliSearch::qualifiedVersion()),
+                    $this->equalTo($customAgent.';'.Meilisearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),
@@ -260,7 +260,7 @@ class ClientTest extends TestCase
             ->method('createRequest')
             ->willReturn($requestStub);
 
-        $client = new \MeiliSearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory, [$customAgent]);
+        $client = new \Meilisearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory, [$customAgent]);
 
         $client->health();
     }
@@ -276,7 +276,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo(MeiliSearch::qualifiedVersion()),
+                    $this->equalTo(Meilisearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),
@@ -289,7 +289,7 @@ class ClientTest extends TestCase
             ->method('createRequest')
             ->willReturn($requestStub);
 
-        $client = new \MeiliSearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory, []);
+        $client = new \Meilisearch\Client('http://localhost:7070', 'masterKey', $httpClient, $reqFactory, []);
 
         $client->health();
     }

--- a/tests/Http/Serialize/JsonTest.php
+++ b/tests/Http/Serialize/JsonTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Http\Serialize;
 
-use MeiliSearch\Exceptions\JsonDecodingException;
-use MeiliSearch\Exceptions\JsonEncodingException;
-use MeiliSearch\Http\Serialize\Json;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
+use Meilisearch\Http\Serialize\Json;
 use PHPUnit\Framework\TestCase;
 
 class JsonTest extends TestCase

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Search;
 
-use MeiliSearch\Search\SearchResult;
+use Meilisearch\Search\SearchResult;
 use PHPUnit\Framework\TestCase;
 
 final class SearchResultTest extends TestCase

--- a/tests/Settings/DistinctAttributeTest.php
+++ b/tests/Settings/DistinctAttributeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Settings;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class DistinctAttributeTest extends TestCase

--- a/tests/Settings/RankingRulesTest.php
+++ b/tests/Settings/RankingRulesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Settings;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class RankingRulesTest extends TestCase

--- a/tests/Settings/StopWordsTest.php
+++ b/tests/Settings/StopWordsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Settings;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class StopWordsTest extends TestCase

--- a/tests/Settings/SynonymsTest.php
+++ b/tests/Settings/SynonymsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Settings;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class SynonymsTest extends TestCase

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Settings;
 
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
 final class TypoToleranceTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use MeiliSearch\Client;
-use MeiliSearch\Endpoints\Indexes;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use MeiliSearch\MeiliSearch;
+use Meilisearch\Meilisearch;
 
 class VersionTest extends TestCase
 {
     public function testQualifiedVersion(): void
     {
-        $qualifiedVersion = sprintf('Meilisearch PHP (v%s)', MeiliSearch::VERSION);
+        $qualifiedVersion = sprintf('Meilisearch PHP (v%s)', Meilisearch::VERSION);
 
-        $this->assertEquals(MeiliSearch::qualifiedVersion(), $qualifiedVersion);
+        $this->assertEquals(Meilisearch::qualifiedVersion(), $qualifiedVersion);
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
This PR changes the casing from `MeiliSearch` to `Meilisearch`. 

To my surprise I discovered that PHP namespaces and classes are case insensitive and therefore recasing `Meilisearch` is possible. Therefore this change should not be breaking. I did some tests with the library and everything worked fine

See:

- https://www.php.net/manual/en/language.namespaces.rationale.php#:~:text=Note%3A%20Namespace%20names%20are%20case%2Dinsensitive.
- https://sebhastian.com/is-php-case-sensitive/

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
