### PR TITLE
Rename Meilisearch class to maintain autoload compatibility

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -13,7 +13,7 @@ use Meilisearch\Exceptions\InvalidResponseBodyException;
 use Meilisearch\Exceptions\JsonDecodingException;
 use Meilisearch\Exceptions\JsonEncodingException;
 use Meilisearch\Http\Serialize\Json;
-use Meilisearch\Meilisearch;
+use Meilisearch\MeiliSearch;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Client\NetworkExceptionInterface;
@@ -49,7 +49,7 @@ class Client implements Http
         $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
         $this->headers = array_filter([
-            'User-Agent' => implode(';', array_merge($clientAgents, [Meilisearch::qualifiedVersion()])),
+            'User-Agent' => implode(';', array_merge($clientAgents, [MeiliSearch::qualifiedVersion()])),
         ]);
         if (null != $this->apiKey) {
             $this->headers['Authorization'] = sprintf('Bearer %s', $this->apiKey);

--- a/src/MeiliSearch.php
+++ b/src/MeiliSearch.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch;
 
-class Meilisearch
+class MeiliSearch
 {
     public const VERSION = '0.26.1';
 

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -9,7 +9,7 @@ use Meilisearch\Exceptions\InvalidResponseBodyException;
 use Meilisearch\Exceptions\JsonDecodingException;
 use Meilisearch\Exceptions\JsonEncodingException;
 use Meilisearch\Http\Client;
-use Meilisearch\Meilisearch;
+use Meilisearch\MeiliSearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
@@ -217,7 +217,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo(Meilisearch::qualifiedVersion()),
+                    $this->equalTo(MeiliSearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),
@@ -247,7 +247,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo($customAgent.';'.Meilisearch::qualifiedVersion()),
+                    $this->equalTo($customAgent.';'.MeiliSearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),
@@ -276,7 +276,7 @@ class ClientTest extends TestCase
             ->withConsecutive(
                 [
                     $this->equalTo('User-Agent'),
-                    $this->equalTo(Meilisearch::qualifiedVersion()),
+                    $this->equalTo(MeiliSearch::qualifiedVersion()),
                 ],
                 [
                     $this->equalTo('Authorization'),

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests;
 
-use Meilisearch\Meilisearch;
+use Meilisearch\MeiliSearch;
 
 class VersionTest extends TestCase
 {
     public function testQualifiedVersion(): void
     {
-        $qualifiedVersion = sprintf('Meilisearch PHP (v%s)', Meilisearch::VERSION);
+        $qualifiedVersion = sprintf('Meilisearch PHP (v%s)', MeiliSearch::VERSION);
 
-        $this->assertEquals(Meilisearch::qualifiedVersion(), $qualifiedVersion);
+        $this->assertEquals(MeiliSearch::qualifiedVersion(), $qualifiedVersion);
     }
 }


### PR DESCRIPTION
#431 Renamed the namespace from `MeiliSearch` to `Meilisearch`, which isn't a problem because the Composer config was also updated to allow PSR-4 matching of both cases.

The problem is that the class `MeiliSearch\MeiliSearch` was also renamed to `Meilisearch\Meilisearch`, not just the namespace. This breaks Composer autoloading because Composer class-name matching is case-sensitive.

This PR fixes the name of this class in order to maintain compatibility.

**If** the renaming of the that class is both intentional and permanent:
 - the README should be updated with a notice
 - the version number should be incremented by at least a new point release (0.27.x) instead of sub-point (0.26.**1** is not ideal to make a breaking change)

If you need a quick fix for laravel/scout or other projects, `composer require meilisearch/meilisearch-php "0.26.0"` should do the trick.