### PR TITLE
Update the version for the next release (v0.27.0)

### DIFF
--- a/src/Meilisearch.php
+++ b/src/Meilisearch.php
@@ -6,7 +6,7 @@ namespace Meilisearch;
 
 class Meilisearch
 {
-    public const VERSION = '0.26.1';
+    public const VERSION = '0.27.0';
 
     public static function qualifiedVersion()
     {


### PR DESCRIPTION
Release a new version to mark the latest changes as **breaking**.

The previous release `v0.26.1` will be deprecated in the packagist.

Related information can be verified here https://github.com/meilisearch/meilisearch-php/pull/441, https://github.com/meilisearch/meilisearch-php/pull/431