### PR TITLE
Remove raw methods & Fix query classes

### DIFF
--- a/src/Contracts/CancelTasksQuery.php
+++ b/src/Contracts/CancelTasksQuery.php
@@ -9,23 +9,4 @@ use Meilisearch\Delegates\TasksQueryTrait;
 class CancelTasksQuery
 {
     use TasksQueryTrait;
-
-    private array $canceledBy;
-
-    public function setCanceledBy(array $canceledBy)
-    {
-        $this->canceledBy = $canceledBy;
-
-        return $this;
-    }
-
-    public function toArray(): array
-    {
-        return array_filter(
-            array_merge(
-                $this->baseArray(),
-                ['canceledBy' => $this->formatArray($this->canceledBy ?? null)]
-            ), function ($item) { return null != $item || is_numeric($item); }
-        );
-    }
 }

--- a/src/Contracts/CancelTasksQuery.php
+++ b/src/Contracts/CancelTasksQuery.php
@@ -9,4 +9,23 @@ use Meilisearch\Delegates\TasksQueryTrait;
 class CancelTasksQuery
 {
     use TasksQueryTrait;
+
+    private array $canceledBy;
+
+    public function setCanceledBy(array $canceledBy)
+    {
+        $this->canceledBy = $canceledBy;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            array_merge(
+                $this->baseArray(),
+                ['canceledBy' => $this->formatArray($this->canceledBy ?? null)]
+            ), function ($item) { return null != $item || is_numeric($item); }
+        );
+    }
 }

--- a/src/Contracts/DeleteTasksQuery.php
+++ b/src/Contracts/DeleteTasksQuery.php
@@ -9,4 +9,23 @@ use Meilisearch\Delegates\TasksQueryTrait;
 class DeleteTasksQuery
 {
     use TasksQueryTrait;
+
+    private array $canceledBy;
+
+    public function setCanceledBy(array $canceledBy)
+    {
+        $this->canceledBy = $canceledBy;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            array_merge(
+                $this->baseArray(),
+                ['canceledBy' => $this->formatArray($this->canceledBy ?? null)]
+            ), function ($item) { return null != $item || is_numeric($item); }
+        );
+    }
 }

--- a/src/Contracts/TasksQuery.php
+++ b/src/Contracts/TasksQuery.php
@@ -12,10 +12,18 @@ class TasksQuery
 
     private int $from;
     private int $limit;
+    private int $canceledBy;
 
     public function setFrom(int $from): TasksQuery
     {
         $this->from = $from;
+
+        return $this;
+    }
+
+    public function setCanceledBy(int $canceledBy): TasksQuery
+    {
+        $this->canceledBy = $canceledBy;
 
         return $this;
     }
@@ -32,7 +40,6 @@ class TasksQuery
         return array_filter([
             'from' => $this->from ?? null,
             'limit' => $this->limit ?? null,
-            'next' => $this->next ?? null,
             'beforeEnqueuedAt' => $this->formatDate($this->beforeEnqueuedAt ?? null),
             'afterEnqueuedAt' => $this->formatDate($this->afterEnqueuedAt ?? null),
             'beforeStartedAt' => $this->formatDate($this->beforeStartedAt ?? null),

--- a/src/Contracts/TasksQuery.php
+++ b/src/Contracts/TasksQuery.php
@@ -12,7 +12,7 @@ class TasksQuery
 
     private int $from;
     private int $limit;
-    private int $canceledBy;
+    private array $canceledBy;
 
     public function setFrom(int $from): TasksQuery
     {
@@ -21,7 +21,7 @@ class TasksQuery
         return $this;
     }
 
-    public function setCanceledBy(int $canceledBy): TasksQuery
+    public function setCanceledBy(array $canceledBy): TasksQuery
     {
         $this->canceledBy = $canceledBy;
 
@@ -37,20 +37,15 @@ class TasksQuery
 
     public function toArray(): array
     {
-        return array_filter([
-            'from' => $this->from ?? null,
-            'limit' => $this->limit ?? null,
-            'beforeEnqueuedAt' => $this->formatDate($this->beforeEnqueuedAt ?? null),
-            'afterEnqueuedAt' => $this->formatDate($this->afterEnqueuedAt ?? null),
-            'beforeStartedAt' => $this->formatDate($this->beforeStartedAt ?? null),
-            'afterStartedAt' => $this->formatDate($this->afterStartedAt ?? null),
-            'beforeFinishedAt' => $this->formatDate($this->beforeFinishedAt ?? null),
-            'afterFinishedAt' => $this->formatDate($this->afterFinishedAt ?? null),
-            'statuses' => $this->formatArray($this->statuses ?? null),
-            'uids' => $this->formatArray($this->uids ?? null),
-            'canceledBy' => $this->formatArray($this->canceledBy ?? null),
-            'types' => $this->formatArray($this->types ?? null),
-            'indexUids' => $this->formatArray($this->indexUids ?? null),
-        ], function ($item) { return null != $item || is_numeric($item); });
+        return array_filter(
+            array_merge(
+                $this->baseArray(),
+                [
+                    'from' => $this->from ?? null,
+                    'limit' => $this->limit ?? null,
+                    'canceledBy' => $this->formatArray($this->canceledBy ?? null),
+                ]
+            ), function ($item) { return null != $item || is_numeric($item); }
+        );
     }
 }

--- a/src/Delegates/HandlesIndex.php
+++ b/src/Delegates/HandlesIndex.php
@@ -10,14 +10,9 @@ use Meilisearch\Endpoints\Indexes;
 
 trait HandlesIndex
 {
-    public function getAllIndexes(IndexesQuery $options = null): IndexesResults
+    public function getIndexes(IndexesQuery $options = null): IndexesResults
     {
         return $this->index->all($options ?? null);
-    }
-
-    public function getAllRawIndexes(IndexesQuery $options = null): array
-    {
-        return $this->index->allRaw($options ?? []);
     }
 
     public function getRawIndex(string $uid): array
@@ -38,17 +33,6 @@ trait HandlesIndex
     public function deleteIndex(string $uid): array
     {
         return $this->index($uid)->delete();
-    }
-
-    public function deleteAllIndexes(): array
-    {
-        $tasks = [];
-        $indexes = $this->getAllIndexes();
-        foreach ($indexes as $index) {
-            $tasks[] = $index->delete();
-        }
-
-        return $tasks;
     }
 
     public function createIndex(string $uid, array $options = []): array

--- a/src/Delegates/TasksQueryTrait.php
+++ b/src/Delegates/TasksQueryTrait.php
@@ -6,25 +6,16 @@ namespace Meilisearch\Delegates;
 
 trait TasksQueryTrait
 {
-    private int $next;
     private array $types;
     private array $statuses;
     private array $indexUids;
     private array $uids;
-    private array $canceledBy;
     private \DateTime $beforeEnqueuedAt;
     private \DateTime $afterEnqueuedAt;
     private \DateTime $beforeStartedAt;
     private \DateTime $afterStartedAt;
     private \DateTime $beforeFinishedAt;
     private \DateTime $afterFinishedAt;
-
-    public function setNext(int $next)
-    {
-        $this->next = $next;
-
-        return $this;
-    }
 
     public function setTypes(array $types)
     {
@@ -55,13 +46,6 @@ trait TasksQueryTrait
     public function setUids(array $uids)
     {
         $this->uids = $uids;
-
-        return $this;
-    }
-
-    public function setCanceledBy(array $canceledBy)
-    {
-        $this->canceledBy = $canceledBy;
 
         return $this;
     }
@@ -110,8 +94,15 @@ trait TasksQueryTrait
 
     public function toArray(): array
     {
-        return array_filter([
-            'next' => $this->next ?? null,
+        return array_filter(
+            $this->baseArray(),
+            function ($item) { return null != $item || is_numeric($item); }
+        );
+    }
+
+    protected function baseArray(): array
+    {
+        return [
             'beforeEnqueuedAt' => $this->formatDate($this->beforeEnqueuedAt ?? null),
             'afterEnqueuedAt' => $this->formatDate($this->afterEnqueuedAt ?? null),
             'beforeStartedAt' => $this->formatDate($this->beforeStartedAt ?? null),
@@ -120,10 +111,9 @@ trait TasksQueryTrait
             'afterFinishedAt' => $this->formatDate($this->afterFinishedAt ?? null),
             'statuses' => $this->formatArray($this->statuses ?? null),
             'uids' => $this->formatArray($this->uids ?? null),
-            'canceledBy' => $this->formatArray($this->canceledBy ?? null),
             'types' => $this->formatArray($this->types ?? null),
             'indexUids' => $this->formatArray($this->indexUids ?? null),
-        ], function ($item) { return null != $item || is_numeric($item); });
+        ];
     }
 
     private function formatDate(?\DateTime $date)

--- a/tests/Contracts/CancelTasksQueryTest.php
+++ b/tests/Contracts/CancelTasksQueryTest.php
@@ -26,10 +26,10 @@ class CancelTasksQueryTest extends TestCase
 
     public function testToArrayWithDifferentSets(): void
     {
-        $data = (new CancelTasksQuery())->setCanceledBy([1, 2, 3])->setStatuses(['enqueued']);
+        $data = (new CancelTasksQuery())->setUids([1, 2, 3])->setStatuses(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
-            'canceledBy' => '1,2,3', 'statuses' => 'enqueued',
+            'uids' => '1,2,3', 'statuses' => 'enqueued',
         ]);
     }
 }

--- a/tests/Contracts/CancelTasksQueryTest.php
+++ b/tests/Contracts/CancelTasksQueryTest.php
@@ -4,46 +4,32 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\CancelTasksQuery;
 use PHPUnit\Framework\TestCase;
 
 class CancelTasksQueryTest extends TestCase
 {
     public function testSetTypes(): void
     {
-        $data = (new TasksQuery())->setTypes(['abc', 'xyz']);
+        $data = (new CancelTasksQuery())->setTypes(['abc', 'xyz']);
 
         $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
-    }
-
-    public function testSetNext(): void
-    {
-        $data = (new TasksQuery())->setNext(99);
-
-        $this->assertEquals($data->toArray(), ['next' => 99]);
     }
 
     public function testSetAnyDateFilter(): void
     {
         $date = new \DateTime();
-        $data = (new TasksQuery())->setBeforeEnqueuedAt($date);
+        $data = (new CancelTasksQuery())->setBeforeEnqueuedAt($date);
 
         $this->assertEquals($data->toArray(), ['beforeEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
     }
 
-    public function testToArrayWithSetNextWithZero(): void
-    {
-        $data = (new TasksQuery())->setNext(0);
-
-        $this->assertEquals($data->toArray(), ['next' => 0]);
-    }
-
     public function testToArrayWithDifferentSets(): void
     {
-        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
+        $data = (new CancelTasksQuery())->setCanceledBy([1, 2, 3])->setStatuses(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
-            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
+            'canceledBy' => '1,2,3', 'statuses' => 'enqueued',
         ]);
     }
 }

--- a/tests/Contracts/DeleteTasksQueryTest.php
+++ b/tests/Contracts/DeleteTasksQueryTest.php
@@ -4,46 +4,32 @@ declare(strict_types=1);
 
 namespace Tests\Contracts;
 
-use Meilisearch\Contracts\TasksQuery;
+use Meilisearch\Contracts\DeleteTasksQuery;
 use PHPUnit\Framework\TestCase;
 
 class DeleteTasksQueryTest extends TestCase
 {
     public function testSetTypes(): void
     {
-        $data = (new TasksQuery())->setTypes(['abc', 'xyz']);
+        $data = (new DeleteTasksQuery())->setTypes(['abc', 'xyz']);
 
         $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
-    }
-
-    public function testSetNext(): void
-    {
-        $data = (new TasksQuery())->setNext(99);
-
-        $this->assertEquals($data->toArray(), ['next' => 99]);
     }
 
     public function testSetAnyDateFilter(): void
     {
         $date = new \DateTime();
-        $data = (new TasksQuery())->setBeforeEnqueuedAt($date);
+        $data = (new DeleteTasksQuery())->setCanceledBy([null])->setBeforeEnqueuedAt($date);
 
         $this->assertEquals($data->toArray(), ['beforeEnqueuedAt' => $date->format(\DateTime::RFC3339)]);
     }
 
-    public function testToArrayWithSetNextWithZero(): void
-    {
-        $data = (new TasksQuery())->setNext(0);
-
-        $this->assertEquals($data->toArray(), ['next' => 0]);
-    }
-
     public function testToArrayWithDifferentSets(): void
     {
-        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
+        $data = (new DeleteTasksQuery())->setCanceledBy([1, 2])->setStatuses(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
-            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
+            'canceledBy' => '1,2', 'statuses' => 'enqueued',
         ]);
     }
 }

--- a/tests/Contracts/TasksQueryTest.php
+++ b/tests/Contracts/TasksQueryTest.php
@@ -16,13 +16,6 @@ class TasksQueryTest extends TestCase
         $this->assertEquals($data->toArray(), ['types' => 'abc,xyz']);
     }
 
-    public function testSetNext(): void
-    {
-        $data = (new TasksQuery())->setNext(99);
-
-        $this->assertEquals($data->toArray(), ['next' => 99]);
-    }
-
     public function testSetAnyDateFilter(): void
     {
         $date = new \DateTime();
@@ -47,10 +40,10 @@ class TasksQueryTest extends TestCase
 
     public function testToArrayWithDifferentSets(): void
     {
-        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setNext(99)->setStatuses(['enqueued']);
+        $data = (new TasksQuery())->setFrom(10)->setLimit(9)->setCanceledBy([1, 4])->setStatuses(['enqueued']);
 
         $this->assertEquals($data->toArray(), [
-            'limit' => 9, 'next' => 99, 'from' => 10, 'statuses' => 'enqueued',
+            'limit' => 9, 'from' => 10, 'statuses' => 'enqueued', 'canceledBy' => '1,4',
         ]);
     }
 }

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -16,9 +16,7 @@ final class ClientTest extends TestCase
     {
         $index = $this->createEmptyIndex($this->safeIndexName());
         /* @phpstan-ignore-next-line */
-        $this->assertIsIterable($this->client->getAllIndexes());
-        /* @phpstan-ignore-next-line */
-        $this->assertIsArray($this->client->getAllRawIndexes()['results']);
+        $this->assertIsIterable($this->client->getIndexes());
         /* @phpstan-ignore-next-line */
         $this->assertIsArray($this->client->getRawIndex($index->getUid()));
     }
@@ -32,23 +30,16 @@ final class ClientTest extends TestCase
         $this->assertInstanceOf(Indexes::class, $this->client->index($index->getUid()));
     }
 
-    public function testGetAllIndexesWhenEmpty(): void
+    public function testgetIndexesWhenEmpty(): void
     {
-        $response = $this->client->getAllIndexes();
+        $response = $this->client->getIndexes();
 
         $this->assertEmpty($response);
     }
 
-    public function testGetAllIndexesWithPagination(): void
+    public function testgetIndexesWithPagination(): void
     {
-        $response = $this->client->getAllIndexes((new IndexesQuery())->setLimit(1)->setOffset(99999));
-
-        $this->assertEmpty($response);
-    }
-
-    public function testGetAllRawIndexesWhenEmpty(): void
-    {
-        $response = $this->client->getAllRawIndexes()['results'];
+        $response = $this->client->getIndexes((new IndexesQuery())->setLimit(1)->setOffset(99999));
 
         $this->assertEmpty($response);
     }
@@ -97,7 +88,7 @@ final class ClientTest extends TestCase
         $this->assertSame('ObjectId', $index->getPrimaryKey());
     }
 
-    public function testGetAllIndexes(): void
+    public function testgetIndexes(): void
     {
         $booksIndex1 = $this->safeIndexName('books-1');
         $booksIndex2 = $this->safeIndexName('books-2');
@@ -106,23 +97,9 @@ final class ClientTest extends TestCase
         $response = $this->client->createIndex($booksIndex2);
         $this->client->waitForTask($response['taskUid']);
 
-        $indexes = $this->client->getAllIndexes();
+        $indexes = $this->client->getIndexes();
 
         $this->assertCount(2, $indexes);
-    }
-
-    public function testGetAllRawIndexes(): void
-    {
-        $booksIndex1 = $this->safeIndexName('books-1');
-        $booksIndex2 = $this->safeIndexName('books-2');
-        $response = $this->client->createIndex($booksIndex1);
-        $this->client->waitForTask($response['taskUid']);
-        $response = $this->client->createIndex($booksIndex2);
-        $this->client->waitForTask($response['taskUid']);
-
-        $res = $this->client->getAllRawIndexes()['results'];
-
-        $this->assertNotInstanceOf(Indexes::class, $res[0]);
     }
 
     public function testGetRawIndex(): void
@@ -151,7 +128,7 @@ final class ClientTest extends TestCase
     {
         $this->createEmptyIndex($this->safeIndexName());
 
-        $response = $this->client->getAllIndexes();
+        $response = $this->client->getIndexes();
         $this->assertCount(1, $response);
 
         $response = $this->client->deleteIndex('index');
@@ -161,44 +138,9 @@ final class ClientTest extends TestCase
         $index = $this->client->getIndex('index');
 
         $this->assertEmpty($index);
-        $indexes = $this->client->getAllIndexes();
+        $indexes = $this->client->getIndexes();
 
         $this->assertCount(0, $indexes);
-    }
-
-    public function testDeleteAllIndexes(): void
-    {
-        $this->createEmptyIndex($this->safeIndexName('books-1'));
-        $this->createEmptyIndex($this->safeIndexName('books-2'));
-
-        $response = $this->client->getAllIndexes();
-
-        $this->assertCount(2, $response);
-
-        $res = $this->client->deleteAllIndexes();
-
-        $taskUids = array_map(function ($task) {
-            return $task['taskUid'];
-        }, $res);
-        $res = $this->client->waitForTasks($taskUids);
-
-        $response = $this->client->getAllIndexes();
-
-        $this->assertCount(0, $response);
-    }
-
-    public function testDeleteAllIndexesWhenThereAreNoIndexes(): void
-    {
-        $response = $this->client->getAllIndexes();
-        $this->assertCount(0, $response);
-
-        $res = $this->client->deleteAllIndexes();
-        $taskUids = array_map(function ($task) {
-            return $task['taskUid'];
-        }, $res);
-        $this->client->waitForTasks($taskUids);
-
-        $this->assertCount(0, $response);
     }
 
     public function testGetIndex(): void

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -212,6 +212,7 @@ class ClientTest extends TestCase
         $reqFactory = $this->createMock(RequestFactoryInterface::class);
         $requestStub = $this->createMock(RequestInterface::class);
 
+        /* @phpstan-ignore-next-line */
         $requestStub->expects($this->any())
             ->method('withAddedHeader')
             ->withConsecutive(
@@ -242,6 +243,7 @@ class ClientTest extends TestCase
         $reqFactory = $this->createMock(RequestFactoryInterface::class);
         $requestStub = $this->createMock(RequestInterface::class);
 
+        /* @phpstan-ignore-next-line */
         $requestStub->expects($this->any())
             ->method('withAddedHeader')
             ->withConsecutive(
@@ -271,6 +273,7 @@ class ClientTest extends TestCase
         $reqFactory = $this->createMock(RequestFactoryInterface::class);
         $requestStub = $this->createMock(RequestInterface::class);
 
+        /* @phpstan-ignore-next-line */
         $requestStub->expects($this->any())
             ->method('withAddedHeader')
             ->withConsecutive(


### PR DESCRIPTION
- Add `canceledBy` and remove `next` from toArray in `TasksQuery`
- Correct `DeleteTasksQuery` allowed attributes: removed `next`.
- Correct `CancelTasksQuery` allowed attributes: removed `next` and `canceledBy`.
- Correct `TasksQuery` allowed attributes: removed `next`. 
- Remove non-generic methods from `TasksQueryTrait` 
- Remove `deleteAllIndexes`, `getAllRawIndexes`.
- Rename `getAllIndexes` to `getIndexes`.
- Refactor `tearDown` after removing `deleteAllIndexes`