### PR TITLE
Make createdAt and updatedAt DateTime types not string

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -27,8 +27,8 @@ class Indexes extends Endpoint
 
     private ?string $uid;
     private ?string $primaryKey;
-    private ?string $createdAt;
-    private ?string $updatedAt;
+    private ?\DateTime $createdAt;
+    private ?\DateTime $updatedAt;
     private Tasks $tasks;
 
     public function __construct(Http $http, $uid = null, $primaryKey = null, $createdAt = null, $updatedAt = null)
@@ -48,8 +48,8 @@ class Indexes extends Endpoint
             $this->http,
             $attributes['uid'],
             $attributes['primaryKey'],
-            $attributes['createdAt'],
-            $attributes['updatedAt'],
+            static::parseDate($attributes['createdAt']),
+            static::parseDate($attributes['updatedAt']),
         );
     }
 
@@ -60,8 +60,8 @@ class Indexes extends Endpoint
     {
         $this->uid = $attributes['uid'];
         $this->primaryKey = $attributes['primaryKey'];
-        $this->createdAt = $attributes['createdAt'];
-        $this->updatedAt = $attributes['updatedAt'];
+        $this->createdAt = static::parseDate($attributes['createdAt']);
+        $this->updatedAt = static::parseDate($attributes['updatedAt']);
 
         return $this;
     }
@@ -113,20 +113,10 @@ class Indexes extends Endpoint
 
     public function getCreatedAt(): ?\DateTime
     {
-        return static::parseDate($this->createdAt);
-    }
-
-    public function getCreatedAtString(): ?string
-    {
         return $this->createdAt;
     }
 
     public function getUpdatedAt(): ?\DateTime
-    {
-        return static::parseDate($this->updatedAt);
-    }
-
-    public function getUpdatedAtString(): ?string
     {
         return $this->updatedAt;
     }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -85,24 +85,6 @@ final class IndexTest extends TestCase
         $this->assertInstanceOf(\DateTimeInterface::class, $this->index->getUpdatedAt());
     }
 
-    public function testGetCreatedAtString(): void
-    {
-        $indexB = $this->client->index('indexB');
-        $rawInfo = $this->index->fetchRawInfo();
-
-        $this->assertNull($indexB->getCreatedAtString());
-        $this->assertSame($rawInfo['createdAt'], $this->index->getCreatedAtString());
-    }
-
-    public function testGetUpdatedAtString(): void
-    {
-        $indexB = $this->client->index('indexB');
-        $rawInfo = $this->index->fetchRawInfo();
-
-        $this->assertNull($indexB->getUpdatedAtString());
-        $this->assertSame($rawInfo['updatedAt'], $this->index->getUpdatedAtString());
-    }
-
     public function testFetchRawInfo(): void
     {
         $indexName = $this->safeIndexName('books-2');


### PR DESCRIPTION
- Replace the `string` type by `?DateTime` in `Endpoints\Indexes::createdAt` and `Endpoints\Indexes::updatedAt`