### PR TITLE
Update the version for the next release (v1.0.0)

### DIFF
--- a/src/Meilisearch.php
+++ b/src/Meilisearch.php
@@ -6,7 +6,7 @@ namespace Meilisearch;
 
 class Meilisearch
 {
-    public const VERSION = '0.27.0';
+    public const VERSION = '1.0.0';
 
     public static function qualifiedVersion()
     {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 :tada:
Check out the changelog of [Meilisearch v1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes.


### 💥 Breaking Changes

- `Endpoints/Indexes` date attributes `$createdAt` and `$updatedAt` are `DateTime` now instead of `string`.
  - Removed `getCreatedAtString` and `getUpdatedAtString` functions.
- Add `canceledBy`/`setCanceledBy` in `TasksQuery`
- Remove `next` attribute and `setNext` from `TasksQuery`.
- Remove `next` attribute and `setNext` from `DeleteTasksQuery`.
- Remove `next`, `canceledBy` attributes and `setNext`, `setCanceledBy` from `CancelTasksQuery`.
- Remove `deleteAllIndexes`, since they don't really delete all the indexes but only the first page.
- Remove `getAllRawIndexes` function.
- Rename `getAllIndexes` to `getIndexes`.
- Move all traits to `src/Endpoints/Delegates`.
  - `Meilisearch\Delegates\HandlesIndex` to `Meilisearch\Endpoints\Delegates\HandlesIndex`
  - `Meilisearch\Delegates\HandlesSystem` to `Meilisearch\Endpoints\Delegates\HandlesSystem`
  - `Meilisearch\Delegates\TasksQueryTrait` to `Meilisearch\Endpoints\Delegates\TasksQueryTrait`
