### PR TITLE
Add CSV delimiter to csv document handler methods

### DIFF
--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -36,9 +36,9 @@ trait HandlesDocuments
         return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/json');
     }
 
-    public function addDocumentsCsv(string $documents, ?string $primaryKey = null)
+    public function addDocumentsCsv(string $documents, ?string $primaryKey = null, ?string $delimiter = null)
     {
-        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
+        return $this->http->post(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey, 'csvDelimiter' => $delimiter], 'text/csv');
     }
 
     public function addDocumentsNdjson(string $documents, ?string $primaryKey = null)
@@ -56,11 +56,12 @@ trait HandlesDocuments
         return $promises;
     }
 
-    public function addDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    public function addDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null, ?string $delimiter = null)
     {
         $promises = [];
+
         foreach (self::batchCsvString($documents, $batchSize) as $batch) {
-            $promises[] = $this->addDocumentsCsv($batch, $primaryKey);
+            $promises[] = $this->addDocumentsCsv($batch, $primaryKey, $delimiter);
         }
 
         return $promises;
@@ -86,9 +87,9 @@ trait HandlesDocuments
         return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'application/json');
     }
 
-    public function updateDocumentsCsv(string $documents, ?string $primaryKey = null)
+    public function updateDocumentsCsv(string $documents, ?string $primaryKey = null, ?string $delimiter = null)
     {
-        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey], 'text/csv');
+        return $this->http->put(self::PATH.'/'.$this->uid.'/documents', $documents, ['primaryKey' => $primaryKey, 'csvDelimiter' => $delimiter], 'text/csv');
     }
 
     public function updateDocumentsNdjson(string $documents, ?string $primaryKey = null)
@@ -106,11 +107,11 @@ trait HandlesDocuments
         return $promises;
     }
 
-    public function updateDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null)
+    public function updateDocumentsCsvInBatches(string $documents, ?int $batchSize = 1000, ?string $primaryKey = null, ?string $delimiter = null)
     {
         $promises = [];
         foreach (self::batchCsvString($documents, $batchSize) as $batch) {
-            $promises[] = $this->updateDocumentsCsv($batch, $primaryKey);
+            $promises[] = $this->updateDocumentsCsv($batch, $primaryKey, $delimiter);
         }
 
         return $promises;

--- a/tests/datasets/songs-custom-separator.csv
+++ b/tests/datasets/songs-custom-separator.csv
@@ -1,0 +1,7 @@
+id|title|album|artist|genre|country|released|duration|released-timestamp|duration-float:number
+702481615|Armatage Shanks|Dookie: The Ultimate Critical Review|Green Day|Rock|Europe|2005||1104537600|
+888221515|Old Folks|Six Classic Albums Plus Bonus Tracks|Harold Land|Jazz|Europe|2013|6:36|1356998400|6.36
+1382413601|คำขอร้อง|สำเนียงคนจันทร์ / เอาเถอะถ้าเห็นเขาดีกว่า|อิทธิพล บำรุงกุล|"Folk| World| & Country"|Thailand||||
+1362038801|Be There|Wasted Lines|Ex Norwegian|Rock|US|2014-11-18|3:27|1416268800|3.27
+297431014|Electric Nights|Teenage Neon Jungle|Candy (26)|Pop|US|2003-08-26|3:37|1061856000|3.37
+128391318|For What It's Worth|Old Man Snake And His 19 Friends|Sink (4)|Rock|UK|1990||631152000|


### PR DESCRIPTION
- Add `?string $delimiter` to `updateDocumentsCsv`, `addDocumentsCsv` and also `addDocumentsCsvInBatches` and `updateDocumentsCsvInBatches`.