### PR TITLE
Add facetStats getter to the SearchResult class

### DIFF
--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -39,6 +39,11 @@ class SearchResult implements \Countable, \IteratorAggregate
     /**
      * @var array<string, mixed>
      */
+    private array $facetStats;
+
+    /**
+     * @var array<string, mixed>
+     */
     private array $raw;
 
     public function __construct(array $body)
@@ -64,6 +69,7 @@ class SearchResult implements \Countable, \IteratorAggregate
         $this->processingTimeMs = $body['processingTimeMs'];
         $this->query = $body['query'];
         $this->facetDistribution = $body['facetDistribution'] ?? [];
+        $this->facetStats = $body['facetStats'] ?? [];
         $this->raw = $body;
     }
 
@@ -177,6 +183,14 @@ class SearchResult implements \Countable, \IteratorAggregate
     public function getFacetDistribution(): array
     {
         return $this->facetDistribution;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFacetStats(): array
+    {
+        return $this->facetStats;
     }
 
     /**

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -782,4 +782,20 @@ final class SearchTest extends TestCase
         $this->assertEquals(2, $response->getFacetDistribution()['genre']['fantasy']);
         $this->assertEquals(1, $response->getFacetDistribution()['genre']['adventure']);
     }
+
+    public function testSearchAndRetrieveFacetStats(): void
+    {
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
+        $this->index->updateFilterableAttributes(['info.reviewNb']);
+
+        $promise = $this->index->updateDocuments(self::NESTED_DOCUMENTS);
+        $this->index->waitForTask($promise['taskUid']);
+
+        $response = $this->index->search(
+            null,
+            ['facets' => ['info.reviewNb']],
+        );
+
+        $this->assertEquals(['info.reviewNb' => ['min' => 50, 'max' => 1000]], $response->getFacetStats());
+    }
 }


### PR DESCRIPTION
I had to create a new getter to access this information from the body of the search response.

I've also updated the central issue to mention that. So be sure the SDKs have a proper way to access that information.