### PR TITLE
Use wildcards in tests

### DIFF
--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -26,7 +26,7 @@ final class TenantTokenTest extends TestCase
         $this->key = $this->client->createKey([
             'description' => 'tenant token key',
             'actions' => ['*'],
-            'indexes' => ['*'],
+            'indexes' => ['tenant*'],
             'expiresAt' => '2055-10-02T00:00:00Z',
         ]);
 


### PR DESCRIPTION
Just use a wildcard somewhere to ensure the suite will still work after it.