### PR TITLE
Update docs links

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,11 +68,11 @@ jobs:
       run: |
         sh scripts/tests.sh
         composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
-    - name: Run test suite - php-http/guzzle6-adapter
+    - name: Run test suite - php-http/guzzle7-adapter
       run: |
-        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer require --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
         sh scripts/tests.sh
-        composer remove --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer remove --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
     - name: Run test suite - symfony/http-client
       run: |
         composer require --dev symfony/http-client nyholm/psr7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,3 +88,31 @@ jobs:
         composer require --dev kriswallsmith/buzz nyholm/psr7 --with-all-dependencies
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
+
+  test_php_7_guzzle_6:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    runs-on: ubuntu-latest
+    name: integration-tests (PHP 7.4 & Guzzle 6)
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        coverage: none
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+    - name: Install dependencies
+      run: |
+        composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction
+        composer update --prefer-dist --no-progress
+        composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
+        composer update php-http/client-common:2.6.0 php-http/httplug:2.3.0 psr/http-message
+    - name: Meilisearch (latest version) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
+    - name: Run test suite - php-http/guzzle6-adapter
+      run: |
+        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        sh scripts/tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           coverage: none
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1
+FROM php:8.2
 
 RUN apt-get update && apt-get install -y \
     git \

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $documents = [
 $index->addDocuments($documents); // => { "uid": 0 }
 ```
 
-With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://docs.meilisearch.com/reference/api/tasks.html#get-task).
+With the `uid`, you can check the status (`enqueued`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/tasks#get-task).
 
 #### Basic Search <!-- omit in toc -->
 
@@ -136,7 +136,7 @@ Array
 
 #### Custom Search <!-- omit in toc -->
 
-All the supported options are described in the [search parameters](https://docs.meilisearch.com/reference/features/search_parameters.html) section of the documentation.
+All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) section of the documentation.
 
 💡 **More about the `search()` method in [the Wiki](https://github.com/meilisearch/meilisearch-php/wiki/Search).**
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "guzzlehttp/guzzle": "^7.1",
+        "guzzlehttp/guzzle": "^6 || ^7.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "phpstan/phpstan": "1.10.13",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "guzzlehttp/guzzle": "^6 || ^7.1",
+        "guzzlehttp/guzzle": "^7.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "phpstan/phpstan": "1.10.13",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
Just update one broken link and one old link that still works.

Fix #497 


Note for reviewers:

I had some issues giving an update on one of our peer dependencies, so I took some time to improve the code and also fix the problem.

- Updated PHP version in the linter jobs
- "Force" the usage of the Guzzle 7 in the PHP 8 matrixes 
- Create a new test with Guzzle 6 and PHP 7.4