### PR TITLE
Add patch to prevent breaking in laravel/scout

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -206,7 +206,7 @@ class Indexes extends Endpoint
         // patch to prevent breaking in laravel/scout getTotalCount method,
         // affects only Meilisearch >= v0.28.0.
         if (isset($result['estimatedTotalHits'])) {
-            $result['nbHits'] = $result['estimatedTotalHits'];
+            $result['totalHits'] = $result['nbHits'] = $result['estimatedTotalHits'];
         }
 
         return $result;


### PR DESCRIPTION
# Add patch to prevent breaking in laravel/scout

## What does this PR do?

Fixes Undefined array key "totalHits" in laravel/scout [10.x],

A patch was made to provide the `nbHits` but from v10 of Scout this is now `totalHits` to reflect the change from Meilisearch v1.

See the related code in scout v10, 
https://github.com/laravel/scout/blob/877bce500c7d1cc467176dea9bc0c87640c270fb/src/Engines/MeilisearchEngine.php#L319

```
   /**
     * Get the total count from a raw result returned by the engine.
     *
     * @param  mixed  $results
     * @return int
     */
    public function getTotalCount($results)
    {
        return $results['totalHits'];
    }
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
