### PR TITLE
Add get documents

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     name: integration-tests-against-rc (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v3
@@ -21,6 +21,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        coverage: none
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Install dependencies
@@ -35,11 +36,11 @@ jobs:
       run: |
         sh scripts/tests.sh
         composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
-    - name: Run test suite - php-http/guzzle6-adapter
+    - name: Run test suite - php-http/guzzle7-adapter
       run: |
-        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer require --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
         sh scripts/tests.sh
-        composer remove --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer remove --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
     - name: Run test suite - symfony/http-client
       run: |
         composer require --dev symfony/http-client nyholm/psr7
@@ -53,5 +54,33 @@ jobs:
     - name: Run test suite - kriswallsmith/buzz
       run: |
         composer require --dev kriswallsmith/buzz nyholm/psr7 --with-all-dependencies
+        composer update php-http/client-common:2.6.0 php-http/httplug:2.3.0 psr/http-message
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
+
+  test_php_7_guzzle_6:
+    runs-on: ubuntu-latest
+    name: integration-tests (PHP 7.4 & Guzzle 6)
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        coverage: none
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+    - name: Install dependencies
+      run: |
+        composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction
+        composer update --prefer-dist --no-progress
+        composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
+        composer update php-http/client-common:2.6.0 php-http/httplug:2.3.0 psr/http-message
+    - name: Get the latest Meilisearch RC
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+    - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
+    - name: Run test suite - php-http/guzzle6-adapter
+      run: |
+        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        sh scripts/tests.sh

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -32,6 +32,13 @@ class DocumentsQuery
         return $this;
     }
 
+    /**
+     * Sets the filter for the DocumentsQuery.
+     *
+     * @param list<non-empty-string|list<non-empty-string>> $filter a filter expression written as an array of strings
+     *
+     * @return DocumentsQuery the updated DocumentsQuery instance
+     */
     public function setFilter(array $filter): DocumentsQuery
     {
         $this->filter = $filter;
@@ -39,6 +46,11 @@ class DocumentsQuery
         return $this;
     }
 
+    /**
+     * Checks if the $filter attribute has been set.
+     *
+     * @return bool true when filter contains at least an empty array
+     */
     public function hasFilter(): bool
     {
         return isset($this->filter);

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -49,7 +49,7 @@ class DocumentsQuery
     /**
      * Checks if the $filter attribute has been set.
      *
-     * @return bool true when filter contains at least an empty array
+     * @return bool true when filter contains at least a non-empty array
      */
     public function hasFilter(): bool
     {

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -9,6 +9,7 @@ class DocumentsQuery
     private int $offset;
     private int $limit;
     private array $fields;
+    private array $filter;
 
     public function setOffset(int $offset): DocumentsQuery
     {
@@ -31,11 +32,24 @@ class DocumentsQuery
         return $this;
     }
 
+    public function setFilter(array $filter): DocumentsQuery
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    public function hasFilter(): bool
+    {
+        return isset($this->filter);
+    }
+
     public function toArray(): array
     {
         return array_filter([
             'offset' => $this->offset ?? null,
             'limit' => $this->limit ?? null,
+            'filter' => $this->filter ?? null,
             'fields' => isset($this->fields) ? implode(',', $this->fields) : null,
         ], function ($item) { return null != $item || is_numeric($item); });
     }

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -22,10 +22,20 @@ trait HandlesDocuments
 
     public function getDocuments(DocumentsQuery $options = null): DocumentsResults
     {
-        $query = isset($options) ? $options->toArray() : [];
-        $response = $this->http->get(self::PATH.'/'.$this->uid.'/documents', $query);
+        try {
+            $options = $options ?? new DocumentsQuery();
+            $query = $options->toArray();
 
-        return new DocumentsResults($response);
+            if ($options->hasFilter()) {
+                $response = $this->http->post(self::PATH.'/'.$this->uid.'/documents/fetch', $query);
+            } else {
+                $response = $this->http->get(self::PATH.'/'.$this->uid.'/documents', $query);
+            }
+
+            return new DocumentsResults($response);
+        } catch (\Exception $e) {
+            throw ApiException::rethrowWithHint($e, __FUNCTION__);
+        }
     }
 
     public function addDocuments(array $documents, string $primaryKey = null)

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -474,9 +474,11 @@ final class DocumentsTest extends TestCase
 
     public function testMessageHintException(): void
     {
-        try {
-            $mockedException = new InvalidResponseBodyException($this->createMock(ResponseInterface::class), 'Invalid response');
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(0);
+        $mockedException = new InvalidResponseBodyException($responseMock, 'Invalid response');
 
+        try {
             $httpMock = $this->createMock(Http::class);
             $httpMock->expects(self::once())
                 ->method('post')
@@ -600,9 +602,11 @@ final class DocumentsTest extends TestCase
 
     public function testGetDocumentsMessageHintException(): void
     {
-        try {
-            $mockedException = new InvalidResponseBodyException($this->createMock(ResponseInterface::class), 'Invalid response');
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(0);
+        $mockedException = new InvalidResponseBodyException($responseMock, 'Invalid response');
 
+        try {
             $httpMock = $this->createMock(Http::class);
             $httpMock->expects(self::once())
                 ->method('post')


### PR DESCRIPTION
Introduces a new method, `setFilter` to `DocumentsQuery`, which will add the ability to `getDocuments` to find the documents easily without using the `search` method. 

⚠️ If you want to use the new feature, ensure you're using Meilisearch v1.2.0 or newer.