### PR TITLE
Bump meilisearch v1.2.0 try pre release rc ci

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     name: integration-tests-against-rc (PHP ${{ matrix.php-versions }})
     steps:
     - uses: actions/checkout@v3
@@ -21,6 +21,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        coverage: none
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Install dependencies
@@ -35,11 +36,11 @@ jobs:
       run: |
         sh scripts/tests.sh
         composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
-    - name: Run test suite - php-http/guzzle6-adapter
+    - name: Run test suite - php-http/guzzle7-adapter
       run: |
-        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer require --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
         sh scripts/tests.sh
-        composer remove --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        composer remove --dev php-http/guzzle7-adapter http-interop/http-factory-guzzle
     - name: Run test suite - symfony/http-client
       run: |
         composer require --dev symfony/http-client nyholm/psr7
@@ -53,5 +54,33 @@ jobs:
     - name: Run test suite - kriswallsmith/buzz
       run: |
         composer require --dev kriswallsmith/buzz nyholm/psr7 --with-all-dependencies
+        composer update php-http/client-common:2.6.0 php-http/httplug:2.3.0 psr/http-message
         sh scripts/tests.sh
         composer remove --dev kriswallsmith/buzz nyholm/psr7
+
+  test_php_7_guzzle_6:
+    runs-on: ubuntu-latest
+    name: integration-tests (PHP 7.4 & Guzzle 6)
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        coverage: none
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+    - name: Install dependencies
+      run: |
+        composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction
+        composer update --prefer-dist --no-progress
+        composer remove --dev guzzlehttp/guzzle http-interop/http-factory-guzzle
+        composer update php-http/client-common:2.6.0 php-http/httplug:2.3.0 psr/http-message
+    - name: Get the latest Meilisearch RC
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+    - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
+    - name: Run test suite - php-http/guzzle6-adapter
+      run: |
+        composer require --dev php-http/guzzle6-adapter http-interop/http-factory-guzzle
+        sh scripts/tests.sh

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -474,9 +474,11 @@ final class DocumentsTest extends TestCase
 
     public function testMessageHintException(): void
     {
-        try {
-            $mockedException = new InvalidResponseBodyException($this->createMock(ResponseInterface::class), 'Invalid response');
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(0);
+        $mockedException = new InvalidResponseBodyException($responseMock, 'Invalid response');
 
+        try {
             $httpMock = $this->createMock(Http::class);
             $httpMock->expects(self::once())
                 ->method('post')
@@ -600,9 +602,11 @@ final class DocumentsTest extends TestCase
 
     public function testGetDocumentsMessageHintException(): void
     {
-        try {
-            $mockedException = new InvalidResponseBodyException($this->createMock(ResponseInterface::class), 'Invalid response');
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('getStatusCode')->willReturn(0);
+        $mockedException = new InvalidResponseBodyException($responseMock, 'Invalid response');
 
+        try {
             $httpMock = $this->createMock(Http::class);
             $httpMock->expects(self::once())
                 ->method('post')


### PR DESCRIPTION
Fix PHP HTTP libraries deprecations in the Pre-release CI structure.

Also, for some reason, only the `kriswallsmith/buzz` was breaking because of the way I set up the `ResponseInterface` mock.