### PR TITLE
[FIX]: Remove duplicated key on code-samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -85,8 +85,6 @@ delete_an_index_1: |-
   $client->deleteIndex('movies');
 get_one_document_1: |-
   $client->index('movies')->getDocument(25684, ['id', 'title', 'poster', 'release_date']);
-get_documents_1: |-
-  $client->index('movies')->getDocuments((new DocumentsQuery())->setLimit(2));
 add_or_replace_documents_1: |-
   $client->index('movies')->addDocuments([
     [


### PR DESCRIPTION
# Pull Request
Hey @brunoocasali, Joaco from the basement team here, found this duplicated key while building meilisearch.com so thought of opening a PR 😁 

## What does this PR do?
- Removes duplicated key `get_documents_1` since it was causing errors on the docs deployment. Removed second examples since it seemed the first one was more useful, but correct me if I'm wrong.
EDIT: The other `get_documents_1` is in line 15.


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
