### PR TITLE
Feature/Vector store

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -156,7 +156,7 @@ class SearchQuery
     /**
      * This is an EXPERIMENTAL feature, which may break without a major version.
      * It's available from Meilisearch v1.3.
-     * To enable it properly and use vector store capabilities its required to opt-in through the /experimental-features route.
+     * To enable it properly and use vector store capabilities it's required to activate it through the /experimental-features route.
      *
      * More info: https://www.meilisearch.com/docs/reference/api/experimental-features
      *

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -155,7 +155,7 @@ class SearchQuery
 
     /**
      * This is an EXPERIMENTAL feature, which may break without a major version.
-     * It's available after Meilisearch v1.3.
+     * It's available from Meilisearch v1.3.
      * To enable it properly and use vector store capabilities its required to opt-in through the /experimental-features route.
      *
      * More info: https://www.meilisearch.com/docs/reference/api/experimental-features

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -25,6 +25,7 @@ class SearchQuery
     private ?int $limit;
     private ?int $hitsPerPage;
     private ?int $page;
+    private ?array $vector;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -152,6 +153,22 @@ class SearchQuery
         return $this;
     }
 
+    /**
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     * It's available after Meilisearch v1.3.
+     * To enable it properly and use vector store capabilities its required to opt-in through the /experimental-features route.
+     *
+     * More info: https://www.meilisearch.com/docs/reference/api/experimental-features
+     *
+     * @param array<float> $vector a multi-level array floats
+     */
+    public function setVector(array $vector): SearchQuery
+    {
+        $this->vector = $vector;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return array_filter([
@@ -173,6 +190,7 @@ class SearchQuery
             'limit' => $this->limit ?? null,
             'hitsPerPage' => $this->hitsPerPage ?? null,
             'page' => $this->page ?? null,
+            'vector' => $this->vector ?? null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -34,7 +34,12 @@ final class IndexTest extends TestCase
         );
         $this->assertSame([], $this->index->getFilterableAttributes());
         $this->assertSame(['*'], $this->index->getDisplayedAttributes());
-        $this->assertSame(['maxValuesPerFacet' => 100], $this->index->getFaceting());
+        $this->assertSame([
+            'maxValuesPerFacet' => 100,
+            'sortFacetValuesBy' => [
+                '*' => 'alpha',
+            ],
+        ], $this->index->getFaceting());
         $this->assertSame(['maxTotalHits' => 1000], $this->index->getPagination());
         $this->assertSame(
             [

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -73,4 +73,15 @@ final class MultiSearchTest extends TestCase
         $this->assertArrayHasKey('totalPages', $response['results'][1]);
         $this->assertCount(1, $response['results'][1]['hits']);
     }
+
+    public function testSupportedQueryParams(): void
+    {
+        $query = (new SearchQuery())
+            ->setIndexUid($this->booksIndex->getUid())
+            ->setVector([1, 0.9, [0.9874]]);
+
+        $result = $query->toArray();
+
+        $this->assertEquals([1, 0.9, [0.9874]], $result['vector']);
+    }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -704,6 +704,7 @@ final class SearchTest extends TestCase
 
         $this->assertEquals($hit['title'], 'Interestellar');
         $this->assertEquals($hit['_vectors'], [0.5, 0.53]);
+        $this->assertArrayHasKey('_semanticScore', $hit);
     }
 
     public function testBasicSearchWithTransformFacetsDritributionOptionToFilter(): void


### PR DESCRIPTION
It allows the user to store dense vectors to be retrieved later during search time.

What needs to be changed:

- Ensure sending the `vector` key during the search works: `index->search('query', ['vector' => [0.1, ...])` 
- Ensure it is possible to send during the data ingestion the `_vectors` special field in the documents: `index->addDocuments(['_vectors' => [0.1, ...]]);`
- The response can contain a `vector` key similar to the `q` key.

:warning: This feature is enabled by querying `PATCH /experimental-features` with `{ "vectorStore": true }`