### PR TITLE
Add support to attributesToSearchOn

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -26,6 +26,7 @@ class SearchQuery
     private ?int $hitsPerPage;
     private ?int $page;
     private ?array $vector;
+    private ?array $attributesToSearchOn;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -169,6 +170,13 @@ class SearchQuery
         return $this;
     }
 
+    public function setAttributesToSearchOn(array $attributesToSearchOn): SearchQuery
+    {
+        $this->attributesToSearchOn = $attributesToSearchOn;
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return array_filter([
@@ -191,6 +199,7 @@ class SearchQuery
             'hitsPerPage' => $this->hitsPerPage ?? null,
             'page' => $this->page ?? null,
             'vector' => $this->vector ?? null,
+            'attributesToSearchOn' => $this->attributesToSearchOn ?? null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -78,10 +78,12 @@ final class MultiSearchTest extends TestCase
     {
         $query = (new SearchQuery())
             ->setIndexUid($this->booksIndex->getUid())
-            ->setVector([1, 0.9, [0.9874]]);
+            ->setVector([1, 0.9, [0.9874]])
+            ->setAttributesToSearchOn(['comment']);
 
         $result = $query->toArray();
 
         $this->assertEquals([1, 0.9, [0.9874]], $result['vector']);
+        $this->assertEquals(['comment'], $result['attributesToSearchOn']);
     }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -738,6 +738,16 @@ final class SearchTest extends TestCase
         $this->assertEquals(2, $response->getFacetDistribution()['genre']['fantasy']);
     }
 
+    public function testSearchWithAttributesToSearchOn(): void
+    {
+        $response = $this->index->updateSearchableAttributes(['comment', 'title']);
+        $this->index->waitForTask($response['taskUid']);
+
+        $response = $this->index->search('the', ['attributesToSearchOn' => ['comment']]);
+
+        $this->assertEquals('The best book', $response->getHits()[0]['comment']);
+    }
+
     public function testBasicSearchWithTransformFacetsDritributionOptionToMap(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);


### PR DESCRIPTION
Add support for receiving a new key, `attributesToSearchOn` (which is an array of field names), that will enable running searches over a subset of `searchableAttributes` without modifying Meilisearch’s index settings.
