### PR TITLE
Add support to `showRankingScore`

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -27,6 +27,7 @@ class SearchQuery
     private ?int $page;
     private ?array $vector;
     private ?array $attributesToSearchOn = null;
+    private ?bool $showRankingScore;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -101,6 +102,13 @@ class SearchQuery
     public function setShowMatchesPosition(?bool $showMatchesPosition): SearchQuery
     {
         $this->showMatchesPosition = $showMatchesPosition;
+
+        return $this;
+    }
+
+    public function setShowRankingScore(?bool $showRankingScore): SearchQuery
+    {
+        $this->showRankingScore = $showRankingScore;
 
         return $this;
     }
@@ -203,6 +211,7 @@ class SearchQuery
             'page' => $this->page ?? null,
             'vector' => $this->vector ?? null,
             'attributesToSearchOn' => $this->attributesToSearchOn,
+            'showRankingScore' => $this->showRankingScore ?? null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -27,7 +27,7 @@ class SearchQuery
     private ?int $page;
     private ?array $vector;
     private ?array $attributesToSearchOn = null;
-    private ?bool $showRankingScore;
+    private ?bool $showRankingScore = null;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -211,7 +211,7 @@ class SearchQuery
             'page' => $this->page ?? null,
             'vector' => $this->vector ?? null,
             'attributesToSearchOn' => $this->attributesToSearchOn,
-            'showRankingScore' => $this->showRankingScore ?? null,
+            'showRankingScore' => $this->showRankingScore,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -79,11 +79,13 @@ final class MultiSearchTest extends TestCase
         $query = (new SearchQuery())
             ->setIndexUid($this->booksIndex->getUid())
             ->setVector([1, 0.9, [0.9874]])
-            ->setAttributesToSearchOn(['comment']);
+            ->setAttributesToSearchOn(['comment'])
+            ->setShowRankingScore(true);
 
         $result = $query->toArray();
 
         $this->assertEquals([1, 0.9, [0.9874]], $result['vector']);
         $this->assertEquals(['comment'], $result['attributesToSearchOn']);
+        $this->assertEquals(true, $result['showRankingScore']);
     }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -749,6 +749,13 @@ final class SearchTest extends TestCase
         $this->assertEquals('The best book', $response->getHits()[0]['comment']);
     }
 
+    public function testSearchWithShowRankingScore(): void
+    {
+        $response = $this->index->search('the', ['showRankingScore' => true]);
+
+        $this->assertArrayHasKey('_rankingScore', $response->getHits()[0]);
+    }
+
     public function testBasicSearchWithTransformFacetsDritributionOptionToMap(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);


### PR DESCRIPTION
This feature aims to return ranking details for each document to understand and tweak the score of the documents more efficiently.

Ensure the SDKs can handle the new search parameter `showRankingScore`. Also, ensure the SDK can handle the `_rankingScore` attribute in the matched `hits`.
