### PR TITLE
Feature/Add `showRankingScoreDetails`

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -28,6 +28,7 @@ class SearchQuery
     private ?array $vector;
     private ?array $attributesToSearchOn = null;
     private ?bool $showRankingScore = null;
+    private ?bool $showRankingScoreDetails;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -109,6 +110,22 @@ class SearchQuery
     public function setShowRankingScore(?bool $showRankingScore): SearchQuery
     {
         $this->showRankingScore = $showRankingScore;
+
+        return $this;
+    }
+
+    /**
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     * It's available after Meilisearch v1.3.
+     * To enable it properly and use ranking scoring details its required to opt-in through the /experimental-features route.
+     *
+     * More info: https://www.meilisearch.com/docs/reference/api/experimental-features
+     *
+     * @param bool $showRankingScoreDetails whether the feature is enabled or not
+     */
+    public function setShowRankingScoreDetails(?bool $showRankingScoreDetails): SearchQuery
+    {
+        $this->showRankingScoreDetails = $showRankingScoreDetails;
 
         return $this;
     }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -28,7 +28,7 @@ class SearchQuery
     private ?array $vector;
     private ?array $attributesToSearchOn = null;
     private ?bool $showRankingScore = null;
-    private ?bool $showRankingScoreDetails;
+    private ?bool $showRankingScoreDetails = null;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -229,6 +229,7 @@ class SearchQuery
             'vector' => $this->vector ?? null,
             'attributesToSearchOn' => $this->attributesToSearchOn,
             'showRankingScore' => $this->showRankingScore,
+            'showRankingScoreDetails' => $this->showRankingScoreDetails,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -80,12 +80,14 @@ final class MultiSearchTest extends TestCase
             ->setIndexUid($this->booksIndex->getUid())
             ->setVector([1, 0.9, [0.9874]])
             ->setAttributesToSearchOn(['comment'])
-            ->setShowRankingScore(true);
+            ->setShowRankingScore(true)
+            ->setShowRankingScoreDetails(true);
 
         $result = $query->toArray();
 
         $this->assertEquals([1, 0.9, [0.9874]], $result['vector']);
         $this->assertEquals(['comment'], $result['attributesToSearchOn']);
         $this->assertEquals(true, $result['showRankingScore']);
+        $this->assertEquals(true, $result['showRankingScoreDetails']);
     }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -707,6 +707,17 @@ final class SearchTest extends TestCase
         $this->assertArrayHasKey('_semanticScore', $hit);
     }
 
+    public function testShowRankingScoreDetails(): void
+    {
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['scoreDetails' => true]);
+
+        $response = $this->index->search('the', ['showRankingScoreDetails' => true]);
+        $hit = $response->getHits()[0];
+
+        $this->assertArrayHasKey('_rankingScoreDetails', $hit);
+    }
+
     public function testBasicSearchWithTransformFacetsDritributionOptionToFilter(): void
     {
         $response = $this->index->updateFilterableAttributes(['genre']);


### PR DESCRIPTION
This feature aims to return ranking details for each document to understand and tweak the score of the documents more easily.

Ensure the SDKs can handle the new search parameter `showRankingScoreDetails`. Also ensure the SDK can handle the `_rankingScoreDetails` attributes in the matched `hits`.

:warning: This feature is enabled by querying `PATCH /experimental-features` with `{ "scoreDetails": true }`
