### PR TITLE
Added ability to init SearchQuery props on construction

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -26,6 +26,35 @@ class SearchQuery
     private ?int $hitsPerPage;
     private ?int $page;
 
+    // @phpstan-ignore-next-line
+    public function __construct(
+        string $indexUid = null,
+        string $q = null,
+        array $filter = null,
+        array $attributesToRetrieve = null,
+        array $attributesToCrop = null,
+        int $cropLength = null,
+        array $attributesToHighlight = null,
+        string $cropMarker = null,
+        string $highlightPreTag = null,
+        string $highlightPostTag = null,
+        array $facets = null,
+        bool $showMatchesPosition = null,
+        array $sort = null,
+        string $matchingStrategy = null,
+        int $offset = null,
+        int $limit = null,
+        int $hitsPerPage = null,
+        int $page = null,
+    ) {
+        foreach (get_defined_vars() as $name => $value) {
+            if (!\is_null($value) && property_exists($this, $name)) {
+                // @phpstan-ignore-next-line
+                $this->$name = $value;
+            }
+        }
+    }
+
     public function setQuery(string $q): SearchQuery
     {
         $this->q = $q;

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -42,6 +42,22 @@ final class MultiSearchTest extends TestCase
         ], $data->toArray());
     }
 
+    public function testSearchQueryDataInitArgs(): void
+    {
+        $data = new SearchQuery(...[
+            'indexUid' => $this->booksIndex->getUid(),
+            'q' => 'butler',
+            'sort' => ['author:desc'],
+            'page' => null,
+        ]);
+
+        $this->assertEquals([
+            'indexUid' => $this->booksIndex->getUid(),
+            'q' => 'butler',
+            'sort' => ['author:desc'],
+        ], $data->toArray());
+    }
+
     public function testMultiSearch(): void
     {
         $response = $this->client->multiSearch([


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This lets you init the `SearchQuery` props when the object is constructed.  I think the PHP library is the only one that doesn't yet let you do this or use a simple array instead.  I created this because I was using the `search()` method but needed to switch to `multiSearch()`, but found it works completely differently, this speeds up using it.

Previous way:
```
$data = (new SearchQuery())
   ->setIndexUid('books')
   ->setQuery('butler')
   ->setSort(['author:desc']);
```

Additional way: 
```
$data = new SearchQuery([
    'indexUid' => 'books',
    'q'        => 'butler',
    'sort'     => ['author:desc'],
]);
```

Note 1: My change currently does not pass the test due to the use of variable property access.  However I think it's safe because all the props are simple and typed.  If you think that's ok, I can have phpstan ignore that line.

```
 ------ -----------------------------------------------------------------------
  Line   src/Contracts/SearchQuery.php
 ------ -----------------------------------------------------------------------
  33     Variable property access on $this(Meilisearch\Contracts\SearchQuery).
 ------ -----------------------------------------------------------------------
```

Note 2: The initial code I based this on from `main` currently does not pass all the phpstan tests:

```
 ------ ------------------------------------------------------------------------------
  Line   tests/Endpoints/DocumentsTest.php
 ------ ------------------------------------------------------------------------------
  324    Call to an undefined method
         PHPUnit\Framework\MockObject\Rule\InvokedCount::numberOfInvocations().
  805    Call to an undefined method
         PHPUnit\Framework\MockObject\Rule\InvokedAtLeastOnce::numberOfInvocations().
 ------ ------------------------------------------------------------------------------
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
