### PR TITLE
Migrate docs hosting to Meilisearch subdomain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCUMENTATION_TITLE: "Meilisearch PHP | Documentation"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-phpdocumentor-
       - name: Build with phpDocumentor
-        run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -i tests/ -vv --target docs --cache-folder .phpdoc/cache --template default
+        run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -i tests/ -vv --target docs --cache-folder .phpdoc/cache --template default --title "$DOCUMENTATION_TITLE"
       - name: Upload artifact to GitHub Pages
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v3
       - name: Cache phpDocumentor build files
         id: phpdocumentor-cache
         uses: actions/cache@v3
@@ -33,18 +31,27 @@ jobs:
             ${{ runner.os }}-phpdocumentor-
       - name: Build with phpDocumentor
         run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -i tests/ -vv --target docs --cache-folder .phpdoc/cache --template default --title "$DOCUMENTATION_TITLE"
-      - name: Upload artifact to GitHub Pages
-        uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
-          path: docs
+          name: docs
+          path: docs/
 
   deploy:
     needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
       - name: Cache phpDocumentor build files
         id: phpdocumentor-cache
         uses: actions/cache@v3
@@ -31,27 +33,18 @@ jobs:
             ${{ runner.os }}-phpdocumentor-
       - name: Build with phpDocumentor
         run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -i tests/ -vv --target docs --cache-folder .phpdoc/cache --template default --title "$DOCUMENTATION_TITLE"
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifact to GitHub Pages
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: docs
-          path: docs/
+          path: docs
 
   deploy:
     needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
-        with:
-          name: docs
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 .php-cs-fixer.cache
 composer.lock
 phpunit.xml
-.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .php-cs-fixer.cache
 composer.lock
 phpunit.xml
+.vercel

--- a/.phpdoc/template/base.html.twig
+++ b/.phpdoc/template/base.html.twig
@@ -1,0 +1,11 @@
+{# 
+Extending the default phpDocumentor layout
+https://github.com/phpDocumentor/phpDocumentor/blob/master/data/templates/default/layout.html.twig 
+#}
+
+{% extends 'layout.html.twig' %}
+
+{% block javascripts %}
+  {{ parent() }}
+  <script src="https://cdn.usefathom.com/script.js" data-site="QNBPJXIV" defer></script>
+{% endblock %}

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+php-sdk-docs.meilisearch.com

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 ## 📖 Documentation
 
 
-To learn more about Meilisearch PHP, refer to the in-depth [Meilisearch PHP Documentation](https://meilisearch.github.io/meilisearch-php/). To learn more about Meilisearch in general, refer to our [documentation](https://www.meilisearch.com/docs/learn/getting_started/quick_start) or our [API reference](https://www.meilisearch.com/docs/reference/api/overview).
+To learn more about Meilisearch PHP, refer to the in-depth [Meilisearch PHP Documentation](https://php-sdk-docs.meilisearch.com). To learn more about Meilisearch in general, refer to our [documentation](https://www.meilisearch.com/docs/learn/getting_started/quick_start) or our [API reference](https://www.meilisearch.com/docs/reference/api/overview).
 
 ## ⚡ Supercharge your Meilisearch experience
 


### PR DESCRIPTION
# Pull Request

This PR aims at migrating the generated phpDocumentor docs to `php-sdk-docs.meilisearch.com` instead of Github Pages.

(Please ignore the Vercel preview below. It's not relevant anymore.)

## What does this PR do?

This PR:
- Adds the Fathom Analytics script to the generated HTML
- Update the title of the generated docs

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
