### PR TITLE
Fix failing documentation deployement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-phpdocumentor-
       - name: Build with phpDocumentor
-        run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -i tests/ -vv --target docs --cache-folder .phpdoc/cache --template default --title "$DOCUMENTATION_TITLE"
+        run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 run -d /data -i tests/ -vv --target /data/docs --cache-folder /data/.phpdoc/cache --template default --title "$DOCUMENTATION_TITLE"
       - name: Upload artifact to GitHub Pages
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,6 @@
 name: documentation
 
 on:
-  pull_request:
   push:
     branches: [main]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: documentation
 
 on:
+  pull_request:
   push:
     branches: [main]
 


### PR DESCRIPTION
# Pull Request

## Related issue

The documentation deployment is falling:
```
In Application.php line 725:
                                                                  
  [Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "tests/" is not defined.                                
                                                                  

Exception trace:
  at /opt/phpdoc/vendor/symfony/console/Application.php:725
 Symfony\Component\Console\Application->find() at /opt/phpdoc/vendor/symfony/console/Application.php:262
 Symfony\Component\Console\Application->doRun() at /opt/phpdoc/src/phpDocumentor/Console/Application.php:78
 phpDocumentor\Console\Application->doRun() at /opt/phpdoc/vendor/symfony/console/Application.php:174
 Symfony\Component\Console\Application->run() at /opt/phpdoc/bin/phpdoc:14

Error: Process completed with exit code 1.
```
[See the full logs](https://github.com/meilisearch/meilisearch-php/actions/runs/6045908915/job/16406637559)

## What does this PR do?
- This PR modifies the docker command who builds the documentation by using `-d /data` to specify the directory inside the container where the source code resides that data prefix makes sure we're referencing paths inside the Docker container correctly.

**Notes to the reviewer**:
- To see if it was working properly I added the action on the pull request then I finally removed it. you can [see the build logs here](https://github.com/meilisearch/meilisearch-php/actions/runs/6235081330?pr=581)
- The deployment hopefully is not allowed on other branch than main:
![Screenshot 2023-09-19 at 13 49 00](https://github.com/meilisearch/meilisearch-php/assets/16155041/e6659e20-c554-45fe-a621-dc63be6bb640)