### PR TITLE
Add hybrid search for v1.6.0

### DIFF
--- a/src/Contracts/Index/Embedders.php
+++ b/src/Contracts/Index/Embedders.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts\Index;
+
+use Meilisearch\Contracts\Data;
+
+class Embedders extends Data implements \JsonSerializable
+{
+    public function jsonSerialize(): object
+    {
+        return (object) $this->getIterator()->getArrayCopy();
+    }
+}

--- a/src/Contracts/Index/Settings.php
+++ b/src/Contracts/Index/Settings.php
@@ -13,6 +13,9 @@ class Settings extends Data implements \JsonSerializable
         $data['synonyms'] = new Synonyms($data['synonyms'] ?? []);
         $data['typoTolerance'] = new TypoTolerance($data['typoTolerance'] ?? []);
         $data['faceting'] = new Faceting($data['faceting'] ?? []);
+        if (\array_key_exists('embedders', $data)) {
+            $data['embedders'] = new Embedders($data['embedders'] ?? []);
+        }
 
         parent::__construct($data);
     }

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -361,4 +361,21 @@ trait HandlesSettings
     {
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/proximity-precision');
     }
+
+    // Settings - Experimental: Embedders (hybrid search)
+
+    public function getEmbedders(): array
+    {
+        return $this->http->get(self::PATH.'/'.$this->uid.'/settings/embedders');
+    }
+
+    public function updateEmbedders(array $embedders): array
+    {
+        return $this->http->patch(self::PATH.'/'.$this->uid.'/settings/embedders', $embedders);
+    }
+
+    public function resetEmbedders(): array
+    {
+        return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/embedders');
+    }
 }

--- a/tests/Settings/EmbeddersTest.php
+++ b/tests/Settings/EmbeddersTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class EmbeddersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['vectorStore' => true]);
+    }
+
+    public function testGetEmbedders(): void
+    {
+        $index = $this->createEmptyIndex($this->safeIndexName('books-1'));
+        $embedders = $index->getEmbedders();
+
+        $this->assertEquals([], $embedders);
+    }
+
+    public function testUpdateEmbeddersWithOpenAi(): void
+    {
+        $embedderConfig = [
+            'source' => 'openAi',
+            'apiKey' => '<your-OpenAI-API-key>',
+            'model' => 'text-embedding-ada-002',
+            'documentTemplate' => "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
+        ];
+        $index = $this->createEmptyIndex($this->safeIndexName());
+
+        $promise = $index->updateEmbedders(['myEmbedder' => $embedderConfig]);
+
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $embedders = $index->getEmbedders();
+
+        $this->assertEquals($embedderConfig, $embedders['myEmbedder']);
+    }
+
+    public function testUpdateEmbeddersWithUserProvided(): void
+    {
+        $embedderConfig = [
+            'source' => 'userProvided',
+            'dimensions' => 1,
+        ];
+        $index = $this->createEmptyIndex($this->safeIndexName());
+
+        $promise = $index->updateEmbedders(['myEmbedder' => $embedderConfig]);
+
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $embedders = $index->getEmbedders();
+
+        $this->assertEquals($embedderConfig, $embedders['myEmbedder']);
+    }
+
+    public function testUpdateEmbeddersWithHuggingFace(): void
+    {
+        $embedderConfig = [
+            'source' => 'huggingFace',
+            'model' => 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2',
+            'documentTemplate' => "A movie titled '{{doc.title}}' whose description starts with {{doc.overview|truncatewords: 20}}",
+        ];
+        $index = $this->createEmptyIndex($this->safeIndexName());
+
+        $promise = $index->updateEmbedders(['myEmbedder' => $embedderConfig]);
+
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $embedders = $index->getEmbedders();
+
+        $this->assertEquals($embedderConfig, $embedders['myEmbedder']);
+    }
+
+    public function testResetEmbedders(): void
+    {
+        $embedderConfig = [
+            'source' => 'userProvided',
+            'dimensions' => 1,
+        ];
+        $index = $this->createEmptyIndex($this->safeIndexName());
+
+        $promise = $index->updateEmbedders(['myEmbedder' => $embedderConfig]);
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $promise = $index->resetEmbedders();
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $embedders = $index->getEmbedders();
+        $this->assertEquals([], $embedders);
+    }
+}

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -187,17 +187,22 @@ final class SettingsTest extends TestCase
     }
 
     // Here the test to prevent https://github.com/meilisearch/meilisearch-php/issues/204.
-    public function testGetThenUpdateSettings(): void
-    {
-        $index = $this->createEmptyIndex($this->safeIndexName());
+    // Rollback this comment after meilisearch v1.6.0 final release.
+    // Related to: https://github.com/meilisearch/meilisearch/issues/4323
+    //
+    // public function testGetThenUpdateSettings(): void
+    // {
+    //     $http = new \Meilisearch\Http\Client($this->host, getenv('MEILISEARCH_API_KEY'));
+    //     $http->patch('/experimental-features', ['vectorStore' => false]);
+    //     $index = $this->createEmptyIndex($this->safeIndexName());
 
-        $resetPromise = $index->resetSettings();
-        $this->assertIsValidPromise($resetPromise);
-        $index->waitForTask($resetPromise['taskUid']);
+    //     $resetPromise = $index->resetSettings();
+    //     $this->assertIsValidPromise($resetPromise);
+    //     $index->waitForTask($resetPromise['taskUid']);
 
-        $settings = $index->getSettings();
-        $promise = $index->updateSettings($settings);
-        $this->assertIsValidPromise($promise);
-        $index->waitForTask($promise['taskUid']);
-    }
+    //     $settings = $index->getSettings();
+    //     $promise = $index->updateSettings($settings);
+    //     $this->assertIsValidPromise($promise);
+    //     $index->waitForTask($promise['taskUid']);
+    // }
 }


### PR DESCRIPTION
Adds hybrid search to PHP SDK. 

There is a commented test that should be reverted as soon as the related issue is fixed on the engine.