### PR TITLE
Use proper typehint for proximityPrecision

### DIFF
--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -345,13 +345,16 @@ trait HandlesSettings
     // Settings - proximityPrecision
 
     /**
-     * @return non-empty-string
+     * @return 'byWord'|'byAttribute'
      */
     public function getProximityPrecision(): string
     {
         return $this->http->get(self::PATH.'/'.$this->uid.'/settings/proximity-precision');
     }
 
+    /**
+     * @param 'byWord'|'byAttribute' $type
+     */
     public function updateProximityPrecision(string $type): array
     {
         return $this->http->put(self::PATH.'/'.$this->uid.'/settings/proximity-precision', $type);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-php/pull/606#discussion_r1451919885

## What does this PR do?
- Declares proper typehint to know what values may be returned/accepted.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
