### PR TITLE
Add missing `$` to documentation code sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -670,7 +670,7 @@ update_faceting_settings_1: |-
 reset_faceting_settings_1: |-
   $client->index('books')->resetFaceting();
 multi_search_1: |-
-  client->multiSearch([
+  $client->multiSearch([
       (new SearchQuery())
           ->setIndexUid('movies')
           ->setQuery('pooh')


### PR DESCRIPTION
## Related issue
Fixes [issue first reported on the documentation repo](https://github.com/meilisearch/documentation/issues/2782).

## What does this PR do?
Add missing `$` to documentation code sample