### PR TITLE
Add `searchCutoffMs` method

### DIFF
--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -365,6 +365,23 @@ trait HandlesSettings
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/proximity-precision');
     }
 
+    // Settings - searchCutoffMs
+
+    public function getSearchCutoffMs(): ?int
+    {
+        return $this->http->get(self::PATH.'/'.$this->uid.'/settings/search-cutoff-ms');
+    }
+
+    public function updateSearchCutoffMs(int $value): array
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/settings/search-cutoff-ms', $value);
+    }
+
+    public function resetSearchCutoffMs(): array
+    {
+        return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/search-cutoff-ms');
+    }
+
     // Settings - Experimental: Embedders (hybrid search)
 
     public function getEmbedders(): ?array

--- a/tests/Settings/SearchCutoffMsTest.php
+++ b/tests/Settings/SearchCutoffMsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use Meilisearch\Endpoints\Indexes;
+use Tests\TestCase;
+
+final class SearchCutoffMsTest extends TestCase
+{
+    private Indexes $index;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
+    }
+
+    public function testGetDefaultSearchCutoffMs(): void
+    {
+        $default = $this->index->getSearchCutoffMs();
+
+        self::assertNull($default);
+    }
+
+    public function testUpdateSearchCutoffMs(): void
+    {
+        $promise = $this->index->updateSearchCutoffMs(50);
+        $this->assertIsValidPromise($promise);
+        $this->index->waitForTask($promise['taskUid']);
+
+        self::assertSame(50, $this->index->getSearchCutoffMs());
+    }
+
+    public function testResetSearchCutoffMs(): void
+    {
+        $promise = $this->index->updateSearchCutoffMs(50);
+        $this->assertIsValidPromise($promise);
+        $this->index->waitForTask($promise['taskUid']);
+
+        $promise = $this->index->resetSearchCutoffMs();
+
+        $this->assertIsValidPromise($promise);
+        $this->index->waitForTask($promise['taskUid']);
+
+        self::assertNull($this->index->getSearchCutoffMs());
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #630

## What does this PR do?
- Add three new methods according to the issue `updateSearchCutoffMs`, `getSearchCutoffMs` and `resetSearchCutoffMs`.


Thank you so much for contributing to Meilisearch!
