### PR TITLE
Remove unneeded deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "guzzlehttp/guzzle": "^7.1",
         "http-interop/http-factory-guzzle": "^1.0",
-        "phpstan/phpstan": "1.11.3",
+        "phpstan/phpstan": "1.11.5",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "php-http/discovery": "^1.7",
-        "php-http/httplug": "^2.1",
-        "php-http/client-common": "^2.0"
+        "psr/http-client": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #652

## What does this PR do?
- Removes unneeded `php-http/httplug` and `php-http/client-common` dependencies. This PR is based on #651 to see if it really doesn't break anything. So #651 should be merged before this and after that I'll rebase this PR.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
