### PR TITLE
Implements localized attributes

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -10,6 +10,7 @@ class SearchQuery
 
     private string $q;
     private array $filter;
+    private array $locales;
     private array $attributesToRetrieve;
     private array $attributesToCrop;
     private ?int $cropLength;
@@ -42,6 +43,13 @@ class SearchQuery
     public function setFilter(array $filter): SearchQuery
     {
         $this->filter = $filter;
+
+        return $this;
+    }
+
+    public function setLocales(array $locales): SearchQuery
+    {
+        $this->locales = $locales;
 
         return $this;
     }
@@ -230,6 +238,7 @@ class SearchQuery
             'indexUid' => $this->indexUid ?? null,
             'q' => $this->q ?? null,
             'filter' => $this->filter ?? null,
+            'locales' => $this->locales ?? null,
             'attributesToRetrieve' => $this->attributesToRetrieve ?? null,
             'attributesToCrop' => $this->attributesToCrop ?? null,
             'cropLength' => $this->cropLength ?? null,

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -47,6 +47,9 @@ class SearchQuery
         return $this;
     }
 
+    /**
+     * @param list<non-empty-string> $locales
+     */
     public function setLocales(array $locales): SearchQuery
     {
         $this->locales = $locales;

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -102,6 +102,29 @@ trait HandlesSettings
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/displayed-attributes');
     }
 
+    // Settings - Localized attributes
+
+    /**
+     * @return array{ locales: list<non-empty-string>, attributesPattern: string }
+     */
+    public function getLocalizedAttributes(): ?array
+    {
+        return $this->http->get(self::PATH.'/'.$this->uid.'/settings/localized-attributes');
+    }
+
+    /**
+     * @param array{ locales: list<non-empty-string>, attributesPattern: string } $localizedAttributes
+     */
+    public function updateLocalizedAttributes(array $localizedAttributes): array
+    {
+        return $this->http->put(self::PATH.'/'.$this->uid.'/settings/localized-attributes', $localizedAttributes);
+    }
+
+    public function resetLocalizedAttributes(): array
+    {
+        return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/localized-attributes');
+    }
+
     // Settings - Faceting
 
     /**

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -105,7 +105,7 @@ trait HandlesSettings
     // Settings - Localized attributes
 
     /**
-     * @return array{locales: list<non-empty-string>, attributePatterns: string}
+     * @return list<array{attributePatterns: list<string>, locales: list<non-empty-string>}>|null
      */
     public function getLocalizedAttributes(): ?array
     {
@@ -113,7 +113,7 @@ trait HandlesSettings
     }
 
     /**
-     * @param array{locales: list<non-empty-string>, attributePatterns: string} $localizedAttributes
+     * @param list<array{attributePatterns: list<string>, locales: list<non-empty-string>}> $localizedAttributes
      */
     public function updateLocalizedAttributes(array $localizedAttributes): array
     {

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -105,7 +105,7 @@ trait HandlesSettings
     // Settings - Localized attributes
 
     /**
-     * @return array{ locales: list<non-empty-string>, attributesPattern: string }
+     * @return array{locales: list<non-empty-string>, attributePatterns: string}
      */
     public function getLocalizedAttributes(): ?array
     {
@@ -113,7 +113,7 @@ trait HandlesSettings
     }
 
     /**
-     * @param array{ locales: list<non-empty-string>, attributesPattern: string } $localizedAttributes
+     * @param array{locales: list<non-empty-string>, attributePatterns: string} $localizedAttributes
      */
     public function updateLocalizedAttributes(array $localizedAttributes): array
     {

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -883,7 +883,8 @@ final class SearchTest extends TestCase
     public function testSearchWithLocales(): void
     {
         $this->index = $this->createEmptyIndex($this->safeIndexName());
-        $promise = $this->index->updateDocuments(self::DOCUMENTS);
+        $this->index->updateDocuments(self::DOCUMENTS);
+        $promise = $this->index->updateLocalizedAttributes([['attributePatterns' => ['title', 'comment'], 'locales' => ['fra', 'eng']]]);
         $this->index->waitForTask($promise['taskUid']);
 
         $response = $this->index->search('french', [

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -879,4 +879,17 @@ final class SearchTest extends TestCase
         self::assertArrayHasKey('title', $response['hits'][0]);
         self::assertCount(1, $response['hits']);
     }
+
+    public function testSearchWithLocales(): void
+    {
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
+        $promise = $this->index->updateDocuments(self::DOCUMENTS);
+        $this->index->waitForTask($promise['taskUid']);
+
+        $response = $this->index->search('french', [
+            'locales' => ['fra', 'eng'],
+        ])->toArray();
+
+        self::assertCount(2, $response['hits']);
+    }
 }

--- a/tests/Settings/LocalizedAttributesTest.php
+++ b/tests/Settings/LocalizedAttributesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use Tests\TestCase;
+
+final class LocalizedAttributesTest extends TestCase
+{
+    public function testGetDefaultLocalizedAttributes(): void
+    {
+        $indexA = $this->createEmptyIndex($this->safeIndexName('books-1'));
+        $indexB = $this->createEmptyIndex($this->safeIndexName('books-2'), ['primaryKey' => 'objectID']);
+
+        $attributesA = $indexA->getLocalizedAttributes();
+        $attributesB = $indexB->getLocalizedAttributes();
+
+        self::assertNull($attributesA);
+        self::assertNull($attributesB);
+    }
+
+    public function testUpdateLocalizedAttributes(): void
+    {
+        $newAttributes = [['attributePatterns' => ['doggo'], 'locales' => ['fra']]];
+        $index = $this->createEmptyIndex($this->safeIndexName());
+
+        $promise = $index->updateLocalizedAttributes($newAttributes);
+
+        $this->assertIsValidPromise($promise);
+        $index->waitForTask($promise['taskUid']);
+
+        $localizedAttributes = $index->getLocalizedAttributes();
+
+        self::assertSame($newAttributes, $localizedAttributes);
+    }
+
+    public function testResetLocalizedAttributes(): void
+    {
+        $index = $this->createEmptyIndex($this->safeIndexName());
+        $newAttributes = [['attributePatterns' => ['doggo'], 'locales' => ['fra']]];
+
+        $promise = $index->updateLocalizedAttributes($newAttributes);
+        $index->waitForTask($promise['taskUid']);
+
+        $promise = $index->resetLocalizedAttributes();
+
+        $this->assertIsValidPromise($promise);
+
+        $index->waitForTask($promise['taskUid']);
+
+        $localizedAttributes = $index->getLocalizedAttributes();
+        self::assertNull($localizedAttributes);
+    }
+}


### PR DESCRIPTION
# Pull Request

> [!WARNING]  
> The tests won't work since the Meilisearch implementation is broken currently in rc0, see the following PR https://github.com/meilisearch/meilisearch/pull/4836
> I did the test on the branch that implemented the change though.

## Related issue
Fixes https://github.com/meilisearch/meilisearch-php/issues/660

## What does this PR do?
- [x] Add a new search parameter named `locales` to the `search` method
- [x] Ensure the `updateSettings` route can accept the new `localizedAttributes` setting
- [x] Create new methods `getLocalizedAttributes`, `updateLocalizedAttributes` and `resetLocalizedAttributes` corresponding to the sub settings `GET/PUT/DELETE` routes
- [x] Add tests
