### PR TITLE
Handle the new federation options

### DIFF
--- a/src/Contracts/FederationOptions.php
+++ b/src/Contracts/FederationOptions.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class FederationOptions
+{
+    private ?float $weight = null;
+
+    public function setWeight(float $weight): FederationOptions
+    {
+        $this->weight = $weight;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'weight' => $this->weight,
+        ], static function ($item) { return null !== $item; });
+    }
+}

--- a/src/Contracts/MultiSearchFederation.php
+++ b/src/Contracts/MultiSearchFederation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class MultiSearchFederation
+{
+    private ?int $limit = null;
+    private ?int $offset = null;
+
+    public function setLimit(int $limit): MultiSearchFederation
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function setOffset(int $offset): MultiSearchFederation
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+        ], static function ($item) { return null !== $item; });
+    }
+}

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -282,7 +282,7 @@ class SearchQuery
             'showRankingScoreDetails' => $this->showRankingScoreDetails,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
-            'federationOptions' => $this->federationOptions ? $this->federationOptions->toArray() : null,
+            'federationOptions' => $this->federationOptions !== null ? $this->federationOptions->toArray() : null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -4,6 +4,25 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+class FederationOptions
+{
+    private ?float $weight = null;
+
+    public function setWeight(float $weight): FederationOptions
+    {
+        $this->weight = $weight;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'weight' => $this->weight ?? null,
+        ], function ($item) { return null !== $item; });
+    }
+}
+
 class SearchQuery
 {
     private string $indexUid;
@@ -31,6 +50,7 @@ class SearchQuery
     private ?bool $showRankingScoreDetails = null;
     private ?float $rankingScoreThreshold = null;
     private ?string $distinct = null;
+    private ?FederationOptions $federationOptions = null;
 
     public function setQuery(string $q): SearchQuery
     {
@@ -199,6 +219,17 @@ class SearchQuery
     }
 
     /**
+     * This option is only available while doing a federated search.
+     * If used in another context an error will be returned by Meilisearch.
+     */
+    public function setFederationOptions(FederationOptions $federationOptions): SearchQuery
+    {
+        $this->federationOptions = $federationOptions;
+
+        return $this;
+    }
+
+    /**
      * This is an EXPERIMENTAL feature, which may break without a major version.
      * It's available from Meilisearch v1.3.
      * To enable it properly and use vector store capabilities it's required to activate it through the /experimental-features route.
@@ -251,6 +282,7 @@ class SearchQuery
             'showRankingScoreDetails' => $this->showRankingScoreDetails,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
+            'federationOptions' => $this->federationOptions ? $this->federationOptions->toArray() : null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -4,6 +4,34 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+class MultiSearchFederation
+{
+    private ?int $limit = null;
+    private ?int $offset = null;
+
+    public function setLimit(int $limit): MultiSearchFederation
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function setOffset(int $offset): MultiSearchFederation
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+        ], static function ($item) { return null !== $item; });
+    }
+}
+
 class FederationOptions
 {
     private ?float $weight = null;

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -282,7 +282,7 @@ class SearchQuery
             'showRankingScoreDetails' => $this->showRankingScoreDetails,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
-            'federationOptions' => $this->federationOptions !== null ? $this->federationOptions->toArray() : null,
+            'federationOptions' => null !== $this->federationOptions ? $this->federationOptions->toArray() : null,
         ], function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -18,8 +18,8 @@ class FederationOptions
     public function toArray(): array
     {
         return array_filter([
-            'weight' => $this->weight ?? null,
-        ], function ($item) { return null !== $item; });
+            'weight' => $this->weight,
+        ], static function ($item) { return null !== $item; });
     }
 }
 

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -4,53 +4,6 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class MultiSearchFederation
-{
-    private ?int $limit = null;
-    private ?int $offset = null;
-
-    public function setLimit(int $limit): MultiSearchFederation
-    {
-        $this->limit = $limit;
-
-        return $this;
-    }
-
-    public function setOffset(int $offset): MultiSearchFederation
-    {
-        $this->offset = $offset;
-
-        return $this;
-    }
-
-    public function toArray(): array
-    {
-        return array_filter([
-            'limit' => $this->limit,
-            'offset' => $this->offset,
-        ], static function ($item) { return null !== $item; });
-    }
-}
-
-class FederationOptions
-{
-    private ?float $weight = null;
-
-    public function setWeight(float $weight): FederationOptions
-    {
-        $this->weight = $weight;
-
-        return $this;
-    }
-
-    public function toArray(): array
-    {
-        return array_filter([
-            'weight' => $this->weight,
-        ], static function ($item) { return null !== $item; });
-    }
-}
-
 class SearchQuery
 {
     private string $indexUid;

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -12,8 +12,9 @@ trait HandlesMultiSearch
 
     /**
      * @param list<\Meilisearch\Contracts\SearchQuery> $queries
+     * @param array $multiSearchParams
      */
-    public function multiSearch(array $queries = [])
+    public function multiSearch(array $queries = [], array $multiSearchParams = [])
     {
         $body = [];
 
@@ -21,6 +22,7 @@ trait HandlesMultiSearch
             $body[] = $query->toArray();
         }
 
-        return $this->http->post('/multi-search', ['queries' => $body]);
+        $payload = array_merge(['queries' => $body], $multiSearchParams);
+        return $this->http->post('/multi-search', $payload);
     }
 }

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -23,9 +23,10 @@ trait HandlesMultiSearch
         }
 
         $payload = ['queries' => $body];
-        if ($federation !== null) {
+        if (null !== $federation) {
             $payload['federation'] = $federation->toArray();
         }
+
         return $this->http->post('/multi-search', $payload);
     }
 }

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -21,8 +21,6 @@ trait HandlesMultiSearch
             $body[] = $query->toArray();
         }
 
-        $payload = array_merge(['queries' => $body], $multiSearchParams);
-
-        return $this->http->post('/multi-search', $payload);
+        return $this->http->post('/multi-search', ['queries' => $body, ...$multiSearchParams]);
     }
 }

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -12,7 +12,6 @@ trait HandlesMultiSearch
 
     /**
      * @param list<\Meilisearch\Contracts\SearchQuery> $queries
-     * @param array $multiSearchParams
      */
     public function multiSearch(array $queries = [], array $multiSearchParams = [])
     {
@@ -23,6 +22,7 @@ trait HandlesMultiSearch
         }
 
         $payload = array_merge(['queries' => $body], $multiSearchParams);
+
         return $this->http->post('/multi-search', $payload);
     }
 }

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -6,13 +6,14 @@ namespace Meilisearch\Endpoints\Delegates;
 
 use Meilisearch\Contracts\Http;
 use Meilisearch\Contracts\MultiSearchFederation;
+use Meilisearch\Contracts\SearchQuery;
 
 trait HandlesMultiSearch
 {
     protected Http $http;
 
     /**
-     * @param list<\Meilisearch\Contracts\SearchQuery> $queries
+     * @param list<SearchQuery> $queries
      */
     public function multiSearch(array $queries = [], ?MultiSearchFederation $federation = null)
     {

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Meilisearch\Endpoints\Delegates;
 
 use Meilisearch\Contracts\Http;
+use Meilisearch\Contracts\MultiSearchFederation;
 
 trait HandlesMultiSearch
 {
@@ -13,7 +14,7 @@ trait HandlesMultiSearch
     /**
      * @param list<\Meilisearch\Contracts\SearchQuery> $queries
      */
-    public function multiSearch(array $queries = [], array $multiSearchParams = [])
+    public function multiSearch(array $queries = [], ?MultiSearchFederation $federation = null)
     {
         $body = [];
 
@@ -21,6 +22,6 @@ trait HandlesMultiSearch
             $body[] = $query->toArray();
         }
 
-        return $this->http->post('/multi-search', ['queries' => $body, ...$multiSearchParams]);
+        return $this->http->post('/multi-search', ['queries' => $body, 'federation' => $federation->toArray()]);
     }
 }

--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -22,6 +22,10 @@ trait HandlesMultiSearch
             $body[] = $query->toArray();
         }
 
-        return $this->http->post('/multi-search', ['queries' => $body, 'federation' => $federation->toArray()]);
+        $payload = ['queries' => $body];
+        if ($federation !== null) {
+            $payload['federation'] = $federation->toArray();
+        }
+        return $this->http->post('/multi-search', $payload);
     }
 }

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use Meilisearch\Contracts\FederationOptions;
+use Meilisearch\Contracts\MultiSearchFederation;
 use Meilisearch\Contracts\SearchQuery;
 use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
@@ -88,7 +89,7 @@ final class MultiSearchTest extends TestCase
                 // By setting the weight to 0.9 this query should appear second
                 ->setFederationOptions((new FederationOptions())->setWeight(0.9)),
         ],
-            ['federation' => ['limit' => 2]]
+            (new MultiSearchFederation())->setLimit(2)
         );
 
         self::assertArrayHasKey('hits', $response);

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Endpoints;
 
 use Meilisearch\Contracts\SearchQuery;
+use Meilisearch\Contracts\FederationOptions;
 use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
@@ -73,6 +74,48 @@ final class MultiSearchTest extends TestCase
         self::assertArrayHasKey('totalHits', $response['results'][1]);
         self::assertArrayHasKey('totalPages', $response['results'][1]);
         self::assertCount(1, $response['results'][1]['hits']);
+    }
+
+    public function testFederation(): void
+    {
+        $response = $this->client->multiSearch([
+            (new SearchQuery())->setIndexUid($this->booksIndex->getUid())
+                ->setQuery('princ')
+                ->setSort(['author:desc']),
+            (new SearchQuery())->setIndexUid($this->songsIndex->getUid())
+                ->setQuery('be')
+                ->setFilter(['duration-float > 3'])
+                # By setting the weight to 0.9 this query should appear second
+                ->setFederationOptions((new FederationOptions())->setWeight(0.9)),
+            ],
+            ['federation' => ['limit' => 2]]
+        );
+
+        self::assertArrayHasKey('hits', $response);
+        self::assertArrayHasKey('processingTimeMs', $response);
+        self::assertArrayHasKey('limit', $response);
+        self::assertArrayHasKey('offset', $response);
+        self::assertArrayHasKey('estimatedTotalHits', $response);
+        self::assertCount(2, $response['hits']);
+        self::assertSame(2, $response['limit']);
+        self::assertSame(0, $response['offset']);
+
+        self::assertArrayHasKey('id', $response['hits'][0]);
+        self::assertArrayHasKey('_federation', $response['hits'][0]);
+        self::assertArrayHasKey('indexUid', $response['hits'][0]['_federation']);
+        self::assertArrayHasKey('queriesPosition', $response['hits'][0]['_federation']);
+        self::assertArrayHasKey('weightedRankingScore', $response['hits'][0]['_federation']);
+        self::assertStringStartsWith('books', $response['hits'][0]['_federation']['indexUid']);
+        self::assertSame(0, $response['hits'][0]['_federation']['queriesPosition']);
+
+        self::assertArrayHasKey('id', $response['hits'][1]);
+        self::assertArrayHasKey('_federation', $response['hits'][1]);
+        self::assertArrayHasKey('indexUid', $response['hits'][1]['_federation']);
+        self::assertArrayHasKey('queriesPosition', $response['hits'][1]['_federation']);
+        self::assertArrayHasKey('weightedRankingScore', $response['hits'][1]['_federation']);
+        self::assertStringStartsWith('songs', $response['hits'][1]['_federation']['indexUid']);
+        self::assertSame(1, $response['hits'][1]['_federation']['queriesPosition']);
+
     }
 
     public function testSupportedQueryParams(): void

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use Meilisearch\Contracts\SearchQuery;
 use Meilisearch\Contracts\FederationOptions;
+use Meilisearch\Contracts\SearchQuery;
 use Meilisearch\Endpoints\Indexes;
 use Tests\TestCase;
 
@@ -85,9 +85,9 @@ final class MultiSearchTest extends TestCase
             (new SearchQuery())->setIndexUid($this->songsIndex->getUid())
                 ->setQuery('be')
                 ->setFilter(['duration-float > 3'])
-                # By setting the weight to 0.9 this query should appear second
+                // By setting the weight to 0.9 this query should appear second
                 ->setFederationOptions((new FederationOptions())->setWeight(0.9)),
-            ],
+        ],
             ['federation' => ['limit' => 2]]
         );
 
@@ -115,7 +115,6 @@ final class MultiSearchTest extends TestCase
         self::assertArrayHasKey('weightedRankingScore', $response['hits'][1]['_federation']);
         self::assertStringStartsWith('songs', $response['hits'][1]['_federation']['indexUid']);
         self::assertSame(1, $response['hits'][1]['_federation']['queriesPosition']);
-
     }
 
     public function testSupportedQueryParams(): void


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-php/issues/659

## What does this PR do?
- Create a new object, `federationOptions`, which can specify the weight of a query.
- Add a method to provide the federationOptions to a search request
- Adds the `federation` field parameter in the multi-search
- Add a test

Hey @norkunas, since you reviewed https://github.com/meilisearch/meilisearch-php/pull/662 and are definitely better than me in PHP I added you as a reviewer in this PR as well.
If you don't have the time don't worry we'll find another reviewer 👍 