### PR TITLE
Cast body to a string to force rewind of stream

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -177,16 +177,16 @@ class Client implements Http
         }
 
         if (!$this->isJSONResponse($response->getHeader('content-type'))) {
-            throw new InvalidResponseBodyException($response, $response->getBody()->getContents());
+            throw new InvalidResponseBodyException($response, (string) $response->getBody());
         }
 
         if ($response->getStatusCode() >= 300) {
-            $body = $this->json->unserialize($response->getBody()->getContents()) ?? $response->getReasonPhrase();
+            $body = $this->json->unserialize((string) $response->getBody()) ?? $response->getReasonPhrase();
 
             throw new ApiException($response, $body);
         }
 
-        return $this->json->unserialize($response->getBody()->getContents());
+        return $this->json->unserialize((string) $response->getBody());
     }
 
     /**

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -322,7 +322,7 @@ class ClientTest extends TestCase
     {
         $stream = $this->createMock(StreamInterface::class);
         $stream->expects(self::once())
-            ->method('getContents')
+            ->method('__toString')
             ->willReturn($content);
 
         $response = $this->createMock(ResponseInterface::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -153,7 +153,7 @@ abstract class TestCase extends BaseTestCase
     {
         $stream = $this->createMock(StreamInterface::class);
         $stream->expects(self::once())
-            ->method('getContents')
+            ->method('__toString')
             ->willReturn($content);
 
         $response = $this->createMock(ResponseInterface::class);


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Rewinds the PSR-7 StreamInterface

When reading a PSR-7 StreamInterface with getContents() the stream is not automatically rewound. If you for example attach a middleware in Guzzle that reads the StreamInterface but does not rewind it afterwards any calls afterwards will read from the end of the stream resulting in an empty string.

However, then casting the StreamInterface to a string using __toString() then the stream MUST attempt to seek to the beginning of the stream. See https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface
