### PR TITLE
Cast federation payload explicilty to an object

### DIFF
--- a/src/Endpoints/Delegates/HandlesMultiSearch.php
+++ b/src/Endpoints/Delegates/HandlesMultiSearch.php
@@ -25,7 +25,7 @@ trait HandlesMultiSearch
 
         $payload = ['queries' => $body];
         if (null !== $federation) {
-            $payload['federation'] = $federation->toArray();
+            $payload['federation'] = (object) $federation->toArray();
         }
 
         return $this->http->post('/multi-search', $payload);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #685

## What does this PR do?
- It casts the `federation` payload explicitly to an object. This solves the error that appears when no `MultiSearchFederation` properties have been set. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?