### PR TITLE
Ai powered api changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -742,7 +742,7 @@ distinct_attribute_guide_distinct_parameter_1: |-
 search_parameter_guide_matching_strategy_3: |-
   $client->index('movies')->search('white shirt', ['matchingStrategy' => 'frequency']);
 get_similar_post_1: |-
-  $similarQuery = new SimilarDocumentsQuery('TARGET_DOCUMENT_ID');
+  $similarQuery = new SimilarDocumentsQuery('TARGET_DOCUMENT_ID', 'default');
   $client->index('INDEX_NAME')->searchSimilarDocuments($similarQuery);
 multi_search_federated_1: |-
   $client->multiSearch([

--- a/src/Contracts/SimilarDocumentsQuery.php
+++ b/src/Contracts/SimilarDocumentsQuery.php
@@ -12,6 +12,11 @@ class SimilarDocumentsQuery
     private $id;
 
     /**
+     * @var non-empty-string
+     */
+    private string $embedder;
+
+    /**
      * @var non-negative-int|null
      */
     private ?int $offset = null;
@@ -20,11 +25,6 @@ class SimilarDocumentsQuery
      * @var positive-int|null
      */
     private ?int $limit = null;
-
-    /**
-     * @var non-empty-string|null
-     */
-    private ?string $embedder = null;
 
     /**
      * @var list<non-empty-string>|null
@@ -48,11 +48,13 @@ class SimilarDocumentsQuery
     private $rankingScoreThreshold;
 
     /**
-     * @param int|string $id
+     * @param int|string       $id
+     * @param non-empty-string $embedder
      */
-    public function __construct($id)
+    public function __construct($id, string $embedder)
     {
         $this->id = $id;
+        $this->embedder = $embedder;
     }
 
     /**
@@ -87,18 +89,6 @@ class SimilarDocumentsQuery
     public function setFilter(array $filter): self
     {
         $this->filter = $filter;
-
-        return $this;
-    }
-
-    /**
-     * @param non-empty-string $embedder
-     *
-     * @return $this
-     */
-    public function setEmbedder(string $embedder): self
-    {
-        $this->embedder = $embedder;
 
         return $this;
     }
@@ -166,10 +156,10 @@ class SimilarDocumentsQuery
     /**
      * @return array{
      *     id: int|string,
+     *     embedder: non-empty-string,
      *     offset?: non-negative-int,
      *     limit?: positive-int,
      *     filter?: array<int, array<int, string>|string>,
-     *     embedder?: non-empty-string,
      *     attributesToRetrieve?: list<non-empty-string>,
      *     showRankingScore?: bool,
      *     showRankingScoreDetails?: bool,
@@ -181,10 +171,10 @@ class SimilarDocumentsQuery
     {
         return array_filter([
             'id' => $this->id,
+            'embedder' => $this->embedder,
             'offset' => $this->offset,
             'limit' => $this->limit,
             'filter' => $this->filter,
-            'embedder' => $this->embedder,
             'attributesToRetrieve' => $this->attributesToRetrieve,
             'showRankingScore' => $this->showRankingScore,
             'showRankingScoreDetails' => $this->showRankingScoreDetails,

--- a/tests/Contracts/SimilarDocumentsQueryTest.php
+++ b/tests/Contracts/SimilarDocumentsQueryTest.php
@@ -10,54 +10,48 @@ use PHPUnit\Framework\TestCase;
 final class SimilarDocumentsQueryTest extends TestCase
 {
     /**
-     * @param int|string $id
+     * @param int|string       $id
+     * @param non-empty-string $embedder
      *
-     * @testWith [123]
-     *           ["test"]
+     * @testWith [123, "default"]
+     *           ["test", "manual"]
      */
-    public function testConstruct($id): void
+    public function testConstruct($id, string $embedder): void
     {
-        $data = new SimilarDocumentsQuery($id);
+        $data = new SimilarDocumentsQuery($id, $embedder);
 
-        self::assertSame(['id' => $id], $data->toArray());
+        self::assertSame(['id' => $id, 'embedder' => $embedder], $data->toArray());
     }
 
     public function testSetOffset(): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setOffset(66);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setOffset(66);
 
-        self::assertSame(['id' => 'test', 'offset' => 66], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'offset' => 66], $data->toArray());
     }
 
     public function testSetLimit(): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setLimit(50);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setLimit(50);
 
-        self::assertSame(['id' => 'test', 'limit' => 50], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'limit' => 50], $data->toArray());
     }
 
     public function testSetFilter(): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setFilter([
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setFilter([
             ['genres = horror', 'genres = mystery'],
             "director = 'Jordan Peele'",
         ]);
 
-        self::assertSame(['id' => 'test', 'filter' => [['genres = horror', 'genres = mystery'], "director = 'Jordan Peele'"]], $data->toArray());
-    }
-
-    public function testSetEmbedder(): void
-    {
-        $data = (new SimilarDocumentsQuery('test'))->setEmbedder('default');
-
-        self::assertSame(['id' => 'test', 'embedder' => 'default'], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'filter' => [['genres = horror', 'genres = mystery'], "director = 'Jordan Peele'"]], $data->toArray());
     }
 
     public function testSetAttributesToRetrieve(): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setAttributesToRetrieve(['name', 'price']);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setAttributesToRetrieve(['name', 'price']);
 
-        self::assertSame(['id' => 'test', 'attributesToRetrieve' => ['name', 'price']], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'attributesToRetrieve' => ['name', 'price']], $data->toArray());
     }
 
     /**
@@ -66,9 +60,9 @@ final class SimilarDocumentsQueryTest extends TestCase
      */
     public function testSetShowRankingScore(bool $showRankingScore): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setShowRankingScore($showRankingScore);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setShowRankingScore($showRankingScore);
 
-        self::assertSame(['id' => 'test', 'showRankingScore' => $showRankingScore], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'showRankingScore' => $showRankingScore], $data->toArray());
     }
 
     /**
@@ -77,9 +71,9 @@ final class SimilarDocumentsQueryTest extends TestCase
      */
     public function testSetShowRankingScoreDetails(bool $showRankingScoreDetails): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setShowRankingScoreDetails($showRankingScoreDetails);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setShowRankingScoreDetails($showRankingScoreDetails);
 
-        self::assertSame(['id' => 'test', 'showRankingScoreDetails' => $showRankingScoreDetails], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'showRankingScoreDetails' => $showRankingScoreDetails], $data->toArray());
     }
 
     /**
@@ -88,9 +82,9 @@ final class SimilarDocumentsQueryTest extends TestCase
      */
     public function testSetRetrieveVectors(bool $retrieveVectors): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setRetrieveVectors($retrieveVectors);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setRetrieveVectors($retrieveVectors);
 
-        self::assertSame(['id' => 'test', 'retrieveVectors' => $retrieveVectors], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'retrieveVectors' => $retrieveVectors], $data->toArray());
     }
 
     /**
@@ -101,8 +95,8 @@ final class SimilarDocumentsQueryTest extends TestCase
      */
     public function testSetRankingScoreThreshold($rankingScoreThreshold): void
     {
-        $data = (new SimilarDocumentsQuery('test'))->setRankingScoreThreshold($rankingScoreThreshold);
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setRankingScoreThreshold($rankingScoreThreshold);
 
-        self::assertSame(['id' => 'test', 'rankingScoreThreshold' => $rankingScoreThreshold], $data->toArray());
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'rankingScoreThreshold' => $rankingScoreThreshold], $data->toArray());
     }
 }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -701,12 +701,12 @@ final class SearchTest extends TestCase
         $this->assertIsValidPromise($promise);
         $index->waitForTask($promise['taskUid']);
 
-        $response = $index->search('', ['vector' => [-0.5, 0.3, 0.85], 'hybrid' => ['semanticRatio' => 1.0]]);
+        $response = $index->search('', ['vector' => [-0.5, 0.3, 0.85], 'hybrid' => ['semanticRatio' => 1.0, 'embedder' => 'manual']]);
 
         self::assertSame(5, $response->getSemanticHitCount());
         self::assertArrayNotHasKey('_vectors', $response->getHit(0));
 
-        $response = $index->search('', ['vector' => [-0.5, 0.3, 0.85], 'hybrid' => ['semanticRatio' => 1.0], 'retrieveVectors' => true]);
+        $response = $index->search('', ['vector' => [-0.5, 0.3, 0.85], 'hybrid' => ['semanticRatio' => 1.0, 'embedder' => 'manual'], 'retrieveVectors' => true]);
 
         self::assertSame(5, $response->getSemanticHitCount());
         self::assertArrayHasKey('_vectors', $response->getHit(0));

--- a/tests/Endpoints/SimilarDocumentsTest.php
+++ b/tests/Endpoints/SimilarDocumentsTest.php
@@ -30,14 +30,14 @@ final class SimilarDocumentsTest extends TestCase
         self::assertSame(1, $response->getHitsCount());
 
         $documentId = $response->getHit(0)['id'];
-        $response = $this->index->searchSimilarDocuments(new SimilarDocumentsQuery($documentId));
+        $response = $this->index->searchSimilarDocuments(new SimilarDocumentsQuery($documentId, 'manual'));
 
         self::assertGreaterThanOrEqual(4, $response->getHitsCount());
         self::assertArrayNotHasKey('_vectors', $response->getHit(0));
         self::assertArrayHasKey('id', $response->getHit(0));
         self::assertSame($documentId, $response->getId());
 
-        $similarQuery = new SimilarDocumentsQuery($documentId);
+        $similarQuery = new SimilarDocumentsQuery($documentId, 'manual');
         $response = $this->index->searchSimilarDocuments($similarQuery->setRetrieveVectors(true));
         self::assertGreaterThanOrEqual(4, $response->getHitsCount());
         self::assertArrayHasKey('_vectors', $response->getHit(0));

--- a/tests/Settings/EmbeddersTest.php
+++ b/tests/Settings/EmbeddersTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class EmbeddersTest extends TestCase
+{
+    private Indexes $index;
+
+    public const DEFAULT_EMBEDDER = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['vectorStore' => true]);
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
+    }
+
+    public function testGetDefaultEmbedders(): void
+    {
+        $response = $this->index->getEmbedders();
+
+        self::assertSame(self::DEFAULT_EMBEDDER, $response);
+    }
+
+    public function testUpdateEmbedders(): void
+    {
+        $newEmbedders = ['manual' => ['source' => 'userProvided', 'dimensions' => 3, 'binaryQuantized' => true]];
+
+        $promise = $this->index->updateEmbedders($newEmbedders);
+
+        $this->assertIsValidPromise($promise);
+        $this->index->waitForTask($promise['taskUid']);
+
+        $embedders = $this->index->getEmbedders();
+
+        self::assertSame($newEmbedders, $embedders);
+    }
+
+    public function testResetEmbedders(): void
+    {
+        $promise = $this->index->resetEmbedders();
+
+        $this->assertIsValidPromise($promise);
+
+        $this->index->waitForTask($promise['taskUid']);
+        $embedders = $this->index->getEmbedders();
+
+        self::assertSame(self::DEFAULT_EMBEDDER, $embedders);
+    }
+}

--- a/tests/Settings/EmbeddersTest.php
+++ b/tests/Settings/EmbeddersTest.php
@@ -12,7 +12,7 @@ final class EmbeddersTest extends TestCase
 {
     private Indexes $index;
 
-    public const DEFAULT_EMBEDDER = null;
+    private const DEFAULT_EMBEDDER = null;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Fix #682

- Fix broken tests due to the newly mandatory `embedder` field
- Add test for embedder settings
- Change `SimilarDocumentsQuery` struct:
  - make the `embedder` field mandatory when constructing the struct
  - remove the `setEmbedder` method