### PR TITLE
fix: pull the latest in the CI instead of forcing the v1.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
     name: integration-tests (PHP ${{ matrix.php-version }}) (${{ matrix.http-client }})
     services:
       meilisearch:
-        image: getmeili/meilisearch:v1.11.0
+        image: getmeili/meilisearch:latest
         ports:
           - '7700:7700'
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch:v1.10.0
+    image: getmeili/meilisearch:latest
     ports:
       - "7700"
     environment:


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #690

## What does this PR do?
Pull the `latest` in the CI instead of forcing the v1.11

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
