### PR TITLE
Make `hitsCount` always the number of `hits` (and not `totalHits` value)

### DIFF
--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -58,7 +58,6 @@ class SearchResult implements \Countable, \IteratorAggregate
             $this->offset = $body['offset'];
             $this->limit = $body['limit'];
             $this->estimatedTotalHits = $body['estimatedTotalHits'];
-            $this->hitsCount = \count($body['hits']);
         } else {
             $this->numberedPagination = true;
 
@@ -66,11 +65,11 @@ class SearchResult implements \Countable, \IteratorAggregate
             $this->page = $body['page'];
             $this->totalPages = $body['totalPages'];
             $this->totalHits = $body['totalHits'];
-            $this->hitsCount = $body['totalHits'];
         }
 
         $this->semanticHitCount = $body['semanticHitCount'] ?? 0;
         $this->hits = $body['hits'] ?? [];
+        $this->hitsCount = \count($body['hits']);
         $this->processingTimeMs = $body['processingTimeMs'];
         $this->query = $body['query'];
         $this->facetDistribution = $body['facetDistribution'] ?? [];


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #700 

## What does this PR do?
- Ensures that `SearchResults::hitsCount` is consistent regardless of whether `estimatedTotalHits` is set.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
