### PR TITLE
PHPStan 2 + fixed uninitialized properties in SearchResult

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,11 @@
         "php-cs-fixer/shim": "^3.59.3",
         "guzzlehttp/guzzle": "^7.8.1",
         "http-interop/http-factory-guzzle": "^1.2.0",
-        "phpstan/phpstan": "^1.11.5",
+        "phpstan/phpstan": "^2.0",
         "phpstan/extension-installer": "^1.4.1",
-        "phpstan/phpstan-strict-rules": "^1.6.0",
-        "phpstan/phpstan-phpunit": "^1.4.0",
-        "phpstan/phpstan-deprecation-rules": "^1.2.0"
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0"
     },
     "scripts": {
         "lint": [

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -47,9 +47,9 @@ class Client implements Http
         $this->http = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $reqFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
-        $this->headers = array_filter([
+        $this->headers = [
             'User-Agent' => implode(';', array_merge($clientAgents, [Meilisearch::qualifiedVersion()])),
-        ]);
+        ];
         if (null !== $apiKey && '' !== $apiKey) {
             $this->headers['Authorization'] = \sprintf('Bearer %s', $apiKey);
         }

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -19,16 +19,16 @@ class SearchResult implements \Countable, \IteratorAggregate
      * and its value will not be modified by the methods in this class.
      * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
      */
-    private ?int $estimatedTotalHits;
-    private ?int $hitsCount;
-    private ?int $offset;
-    private ?int $limit;
-    private ?int $semanticHitCount;
+    private ?int $estimatedTotalHits = null;
+    private int $hitsCount;
+    private ?int $offset = null;
+    private ?int $limit = null;
+    private int $semanticHitCount;
 
-    private ?int $hitsPerPage;
-    private ?int $page;
-    private ?int $totalPages;
-    private ?int $totalHits;
+    private ?int $hitsPerPage = null;
+    private ?int $page = null;
+    private ?int $totalPages = null;
+    private ?int $totalHits = null;
 
     private int $processingTimeMs;
     private bool $numberedPagination;
@@ -126,12 +126,12 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->hits;
     }
 
-    public function getOffset(): int
+    public function getOffset(): ?int
     {
         return $this->offset;
     }
 
-    public function getLimit(): int
+    public function getLimit(): ?int
     {
         return $this->limit;
     }
@@ -154,7 +154,7 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->hitsCount;
     }
 
-    public function getEstimatedTotalHits(): int
+    public function getEstimatedTotalHits(): ?int
     {
         return $this->estimatedTotalHits;
     }

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -26,8 +26,16 @@ final class SearchTest extends TestCase
         $response = $this->index->search('prince');
 
         $this->assertEstimatedPagination($response->toArray());
-        self::assertSame(2, $response->getEstimatedTotalHits());
         self::assertCount(2, $response->getHits());
+
+        self::assertSame(2, $response->getEstimatedTotalHits());
+        self::assertSame(0, $response->getOffset());
+        self::assertSame(20, $response->getLimit());
+
+        self::assertNull($response->getHitsPerPage());
+        self::assertNull($response->getPage());
+        self::assertNull($response->getTotalPages());
+        self::assertNull($response->getTotalHits());
 
         $response = $this->index->search('prince', [], [
             'raw' => true,
@@ -43,6 +51,15 @@ final class SearchTest extends TestCase
 
         $this->assertFinitePagination($response->toArray());
         self::assertCount(2, $response->getHits());
+
+        self::assertSame(2, $response->getHitsPerPage());
+        self::assertSame(1, $response->getPage());
+        self::assertSame(1, $response->getTotalPages());
+        self::assertSame(2, $response->getTotalHits());
+
+        self::assertNull($response->getEstimatedTotalHits());
+        self::assertNull($response->getOffset());
+        self::assertNull($response->getLimit());
 
         $response = $this->index->search('prince', ['hitsPerPage' => 2], [
             'raw' => true,


### PR DESCRIPTION
## What does this PR do?
- new version of PHPStan
- fixed errors reported by PHPStan
- fixed a possible case when some properties could be accesses before initialization in SearchResult class
