### PR TITLE
Allow instantiating the Meilisearch client with custom HTTP headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -47,9 +47,10 @@ class Client
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null,
         array $clientAgents = [],
-        ?StreamFactoryInterface $streamFactory = null
+        ?StreamFactoryInterface $streamFactory = null,
+        $headers = []
     ) {
-        $this->http = new MeilisearchClientAdapter($url, $apiKey, $httpClient, $requestFactory, $clientAgents, $streamFactory);
+        $this->http = new MeilisearchClientAdapter($url, $apiKey, $httpClient, $requestFactory, $clientAgents, $streamFactory, $headers);
         $this->index = new Indexes($this->http);
         $this->health = new Health($this->http);
         $this->version = new Version($this->http);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -41,7 +41,8 @@ class Client implements Http
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $reqFactory = null,
         array $clientAgents = [],
-        ?StreamFactoryInterface $streamFactory = null
+        ?StreamFactoryInterface $streamFactory = null,
+        $headers = []
     ) {
         $this->baseUrl = $url;
         $this->http = $httpClient ?? Psr18ClientDiscovery::find();
@@ -53,6 +54,7 @@ class Client implements Http
         if (null !== $apiKey && '' !== $apiKey) {
             $this->headers['Authorization'] = \sprintf('Bearer %s', $apiKey);
         }
+        $this->headers = array_merge($this->headers, $headers);
         $this->json = new Json();
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #720 

## What does this PR do?
- Fixes the issue by introducing a new option in the meilisearch client builder.
- Passes it down to the http client
- Merges the headers passed in the option with the other headers already configured (ex: bearer)

## Improvement
- This solution is not the cleanest because if forces us to null all the optional parameters before it (if we don't use them).
 For example : `new Meilisearch(MEILISEARCH_HOST, MEILISEARCH_SEARCH_KEY, null, null, [], null, ["X-MS-USER-ID" => example])` => But it was the fastest solution and the less destructive.
- An other way would be to create a method in the Meilisearch Client object `addHeader()`
- An other way would be to pass all Meilisearch Client options in the form of an array, allowing us to only define used values in any order we like.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

## Extra info
First contribution of mine to this repo, maybe I missed some subtilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying custom HTTP headers when creating a client instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->