### PR TITLE
add mixed return type

### DIFF
--- a/src/Contracts/Data.php
+++ b/src/Contracts/Data.php
@@ -29,7 +29,7 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->data[$offset])) {
             return $this->data[$offset];


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #726 

## What does this PR do?

Gets rid of the deprecation notice.  But I forget when 'mixed' was introduced and if this library is supporting a version of php that doesn't allow this.
