### PR TITLE
Add remote federated search

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -13,10 +13,12 @@ use Meilisearch\Endpoints\Delegates\HandlesMultiSearch;
 use Meilisearch\Endpoints\Delegates\HandlesSnapshots;
 use Meilisearch\Endpoints\Delegates\HandlesSystem;
 use Meilisearch\Endpoints\Delegates\HandlesTasks;
+use Meilisearch\Endpoints\Delegates\HandlesNetwork;
 use Meilisearch\Endpoints\Dumps;
 use Meilisearch\Endpoints\Health;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Endpoints\Keys;
+use Meilisearch\Endpoints\Network;
 use Meilisearch\Endpoints\Snapshots;
 use Meilisearch\Endpoints\Stats;
 use Meilisearch\Endpoints\Tasks;
@@ -37,6 +39,7 @@ class Client
     use HandlesSystem;
     use HandlesMultiSearch;
     use HandlesBatches;
+    use HandlesNetwork;
 
     /**
      * @param array<int, string> $clientAgents
@@ -60,5 +63,6 @@ class Client
         $this->dumps = new Dumps($this->http);
         $this->snapshots = new Snapshots($this->http);
         $this->tenantToken = new TenantToken($this->http, $apiKey);
+        $this->network = new Network($this->http);
     }
 }

--- a/src/Contracts/FederationOptions.php
+++ b/src/Contracts/FederationOptions.php
@@ -7,7 +7,7 @@ namespace Meilisearch\Contracts;
 class FederationOptions
 {
     private ?float $weight = null;
-
+    private ?string $remote = null;
     /**
      * @return $this
      */
@@ -19,6 +19,15 @@ class FederationOptions
     }
 
     /**
+     * @return $this
+     */
+    public function setRemote(string $remote): self
+    {
+        $this->remote = $remote;
+
+        return $this;
+    }
+    /**
      * @return array{
      *     weight?: float,
      * }
@@ -27,6 +36,7 @@ class FederationOptions
     {
         return array_filter([
             'weight' => $this->weight,
+            'remote' => $this->remote,
         ], static function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class NetworkResults extends Data {
+  private string $self;
+  private array $remotes;
+
+  public function __construct(array $params)
+  {
+    parent::__construct($params);
+
+    $this->self = $params['self'] ?? '';
+    $this->remotes = $params['remotes'] ?? [];
+  }
+
+  public function getSelf(): string
+  {
+    return $this->self;
+  }
+
+  public function getRemotes(): array
+  {
+    return $this->remotes;
+  }
+}

--- a/src/Endpoints/Delegates/HandlesNetwork.php
+++ b/src/Endpoints/Delegates/HandlesNetwork.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints\Delegates;
+
+use Meilisearch\Endpoints\Network;
+use Meilisearch\Contracts\NetworkResults;
+
+trait HandlesNetwork
+{
+    protected Network $network;
+
+    public function getNetwork(): NetworkResults
+    {
+        $response = $this->network->get();
+
+        return new NetworkResults($response);
+    }
+
+    public function updateNetwork(array $network): NetworkResults
+    {
+        $response = $this->network->update($network);
+
+        return new NetworkResults($response);
+    }
+}

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Meilisearch\Endpoints;
+
+use Meilisearch\Contracts\Endpoint;
+
+class Network extends Endpoint
+{
+    protected const PATH = '/network';
+
+    public function get(): array
+    {
+        return $this->http->get(self::PATH);
+    }
+
+    public function update(array $body): array
+    {
+        return $this->http->patch(self::PATH, $body);
+    }
+}

--- a/tests/Contracts/FederationOptionsTest.php
+++ b/tests/Contracts/FederationOptionsTest.php
@@ -22,4 +22,11 @@ final class FederationOptionsTest extends TestCase
 
         self::assertSame(['weight' => 2.369], $data->toArray());
     }
+
+    public function testSetRemote(): void
+    {
+        $data = (new FederationOptions())->setRemote('ms-00');
+
+        self::assertSame(['remote' => 'ms-00'], $data->toArray());
+    }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Endpoints;
+
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class NetworksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['network' => true]);
+    }
+
+    public function testUpdateNetworks(): void
+    {
+        $networks = [
+          "self" => "ms-00",
+          "remotes" => [
+            "ms-00" => [
+              "url" => "http://INSTANCE_URL",
+              "searchApiKey" => "INSTANCE_API_KEY"
+            ],
+            "ms-01" => [
+              "url" => "http://ANOTHER_INSTANCE_URL",
+              "searchApiKey" => "ANOTHER_INSTANCE_API_KEY"
+            ]
+          ]
+        ];
+
+        $response = $this->client->updateNetwork($networks);
+        self::assertEquals($networks['self'], $response->getSelf());
+        self::assertEquals($networks['remotes'], $response->getRemotes());
+
+        $response = $this->client->getNetwork();
+        self::assertEquals($networks['self'], $response->getSelf());
+        self::assertEquals($networks['remotes'], $response->getRemotes());
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #725

## What does this PR do?
- Add methods to interact with the [`/network` API](https://www.meilisearch.com/docs/reference/api/network#get-the-network-object)
- Add `remote` field to FederatedOptions

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
