### PR TITLE
Add `disableOnNumbers` to typo tolerance settings

### DIFF
--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -283,7 +283,8 @@ trait HandlesSettings
      *     enabled: bool,
      *     minWordSizeForTypos: array{oneTypo: int, twoTypos: int},
      *     disableOnWords: list<non-empty-string>,
-     *     disableOnAttributes: list<non-empty-string>
+     *     disableOnAttributes: list<non-empty-string>,
+     *     disableOnNumbers: bool
      * }
      */
     public function getTypoTolerance(): array
@@ -297,7 +298,8 @@ trait HandlesSettings
      *     enabled: bool,
      *     minWordSizeForTypos: array{oneTypo: int, twoTypos: int},
      *     disableOnWords: list<non-empty-string>,
-     *     disableOnAttributes: list<non-empty-string>
+     *     disableOnAttributes: list<non-empty-string>,
+     *     disableOnNumbers: bool
      * } $typoTolerance
      */
     public function updateTypoTolerance(array $typoTolerance): array

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -47,6 +47,7 @@ final class IndexTest extends TestCase
                 'minWordSizeForTypos' => ['oneTypo' => 5, 'twoTypos' => 9],
                 'disableOnWords' => [],
                 'disableOnAttributes' => [],
+                'disableOnNumbers' => false,
             ],
             $this->index->getTypoTolerance(),
         );

--- a/tests/Settings/SettingsTest.php
+++ b/tests/Settings/SettingsTest.php
@@ -25,6 +25,7 @@ final class SettingsTest extends TestCase
         ],
         'disableOnWords' => [],
         'disableOnAttributes' => [],
+        'disableOnNumbers' => false,
     ];
 
     public const DEFAULT_SEARCHABLE_ATTRIBUTES = ['*'];
@@ -123,6 +124,7 @@ final class SettingsTest extends TestCase
             ],
             'disableOnWords' => [],
             'disableOnAttributes' => [],
+            'disableOnNumbers' => false,
         ];
 
         $index = $this->createEmptyIndex($this->safeIndexName());

--- a/tests/Settings/TypoToleranceTest.php
+++ b/tests/Settings/TypoToleranceTest.php
@@ -19,6 +19,7 @@ final class TypoToleranceTest extends TestCase
         ],
         'disableOnWords' => [],
         'disableOnAttributes' => [],
+        'disableOnNumbers' => false,
     ];
 
     protected function setUp(): void
@@ -44,6 +45,7 @@ final class TypoToleranceTest extends TestCase
             ],
             'disableOnWords' => [],
             'disableOnAttributes' => ['title'],
+            'disableOnNumbers' => true,
         ];
         $promise = $this->index->updateTypoTolerance($newTypoTolerance);
         $this->index->waitForTask($promise['taskUid']);


### PR DESCRIPTION
# Pull Request

This PR updates the typo tolerance settings to allow [deactivating typo tolerance on high entropy words](https://meilisearch.notion.site/Deactivate-typo-tolerance-on-specific-kinds-of-terms-1a44b06b651f809d9cb7db67b322a4b8).

Related engine issue: https://github.com/meilisearch/meilisearch/issues/5344

## What does this PR do?
- Add `disableOnNumbers` field to typo tolerance settings
- Update tests

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to include the new typo tolerance setting: `disableOnNumbers`.

- **Tests**
  - Enhanced tests to verify the presence and correct handling of the `disableOnNumbers` option in typo tolerance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->