### PR TITLE
Do not modify http client state

### DIFF
--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -4,15 +4,46 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Exceptions\JsonDecodingException;
+use Meilisearch\Exceptions\JsonEncodingException;
+
 interface Http
 {
+    /**
+     * @throws ApiException
+     * @throws JsonDecodingException
+     */
     public function get(string $path, array $query = []);
 
+    /**
+     * @param non-empty-string|null $contentType
+     *
+     * @throws ApiException
+     * @throws JsonEncodingException
+     * @throws JsonDecodingException
+     */
     public function post(string $path, $body = null, array $query = [], ?string $contentType = null);
 
+    /**
+     * @param non-empty-string|null $contentType
+     *
+     * @throws ApiException
+     * @throws JsonEncodingException
+     * @throws JsonDecodingException
+     */
     public function put(string $path, $body = null, array $query = [], ?string $contentType = null);
 
+    /**
+     * @throws ApiException
+     * @throws JsonEncodingException
+     * @throws JsonDecodingException
+     */
     public function patch(string $path, $body = null, array $query = []);
 
+    /**
+     * @throws ApiException
+     * @throws JsonDecodingException
+     */
     public function delete(string $path, array $query = []);
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -27,12 +27,18 @@ class Client implements Http
     private ClientInterface $http;
     private RequestFactoryInterface $requestFactory;
     private StreamFactoryInterface $streamFactory;
-    /** @var array<string,string> */
+    /**
+     * @var array<string, string|string[]>
+     */
     private array $headers;
+    /**
+     * @var non-empty-string
+     */
     private string $baseUrl;
     private Json $json;
 
     /**
+     * @param non-empty-string   $url
      * @param array<int, string> $clientAgents
      */
     public function __construct(
@@ -72,7 +78,7 @@ class Client implements Http
     }
 
     /**
-     * @param mixed|null $body
+     * @param non-empty-string|null $contentType
      *
      * @throws ApiException
      * @throws ClientExceptionInterface
@@ -81,10 +87,7 @@ class Client implements Http
      */
     public function post(string $path, $body = null, array $query = [], ?string $contentType = null)
     {
-        if (!\is_null($contentType)) {
-            $this->headers['Content-type'] = $contentType;
-        } else {
-            $this->headers['Content-type'] = 'application/json';
+        if (null === $contentType) {
             $body = $this->json->serialize($body);
         }
         $request = $this->requestFactory->createRequest(
@@ -92,15 +95,20 @@ class Client implements Http
             $this->baseUrl.$path.$this->buildQueryString($query)
         )->withBody($this->streamFactory->createStream($body));
 
-        return $this->execute($request);
+        return $this->execute($request, ['Content-type' => $contentType ?? 'application/json']);
     }
 
+    /**
+     * @param non-empty-string|null $contentType
+     *
+     * @throws ApiException
+     * @throws ClientExceptionInterface
+     * @throws CommunicationException
+     * @throws JsonEncodingException
+     */
     public function put(string $path, $body = null, array $query = [], ?string $contentType = null)
     {
-        if (!\is_null($contentType)) {
-            $this->headers['Content-type'] = $contentType;
-        } else {
-            $this->headers['Content-type'] = 'application/json';
+        if (null === $contentType) {
             $body = $this->json->serialize($body);
         }
         $request = $this->requestFactory->createRequest(
@@ -108,30 +116,19 @@ class Client implements Http
             $this->baseUrl.$path.$this->buildQueryString($query)
         )->withBody($this->streamFactory->createStream($body));
 
-        return $this->execute($request);
+        return $this->execute($request, ['Content-type' => $contentType ?? 'application/json']);
     }
 
-    /**
-     * @param mixed|null $body
-     *
-     * @throws ApiException
-     * @throws JsonEncodingException
-     */
     public function patch(string $path, $body = null, array $query = [])
     {
-        $this->headers['Content-type'] = 'application/json';
         $request = $this->requestFactory->createRequest(
             'PATCH',
             $this->baseUrl.$path.$this->buildQueryString($query)
         )->withBody($this->streamFactory->createStream($this->json->serialize($body)));
 
-        return $this->execute($request);
+        return $this->execute($request, ['Content-type' => 'application/json']);
     }
 
-    /**
-     * @throws ClientExceptionInterface
-     * @throws ApiException
-     */
     public function delete(string $path, array $query = [])
     {
         $request = $this->requestFactory->createRequest(
@@ -143,13 +140,15 @@ class Client implements Http
     }
 
     /**
+     * @param array<string, string|string[]> $headers
+     *
      * @throws ApiException
      * @throws ClientExceptionInterface
      * @throws CommunicationException
      */
-    private function execute(RequestInterface $request)
+    private function execute(RequestInterface $request, array $headers = [])
     {
-        foreach ($this->headers as $header => $value) {
+        foreach (array_merge($this->headers, $headers) as $header => $value) {
             $request = $request->withAddedHeader($header, $value);
         }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Instead of overriding `headers` default state in http client, now pass the custom headers to `execute` method instead;
- Adds missing phpdoc hints to `Http` interface and the `Client`;

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved support for custom request headers, allowing per-request header overrides without affecting global client settings.

- **Documentation**
	- Enhanced documentation for method parameters and exceptions, providing clearer information for developers.

- **Refactor**
	- Updated internal handling of request headers for greater flexibility and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->