### PR TITLE
Add more phpstan extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ max_line_length          = 80
 
 [*.{yaml,yml}]
 indent_size              = 2
+
+[*.{neon,neon.dist}]
+indent_style = tab
+indent_size = 4

--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,9 @@
         "guzzlehttp/guzzle": "^7.8.1",
         "http-interop/http-factory-guzzle": "^1.2.0",
         "phpstan/phpstan": "^2.0",
-        "phpstan/extension-installer": "^1.4.1",
-        "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0"
     },
     "scripts": {
         "lint": [
@@ -62,7 +61,6 @@
     },
     "config": {
         "allow-plugins": {
-            "phpstan/extension-installer": true,
             "php-http/discovery": true
         }
     }

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,14 @@
+includes:
+	- vendor/phpstan/phpstan-phpunit/extension.neon
+	- vendor/phpstan/phpstan-phpunit/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+	level: 5
+	paths:
+		- src
+		- tests
+	additionalConstructors:
+		- PHPUnit\Framework\TestCase::setUp

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,0 @@
-parameters:
-    level: 5
-    paths:
-        - src
-        - tests


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #747

## What does this PR do?
- Adds phpstan phpunit, deprecation-rules and strict-rules extensions;
- Remove phpstan extension installer to control what we import;
- Renames `phpstan.neon.dist` to `phpstan.dist.neon` which is recommended and understandable by IDE;
- Configure standard indent style/size for .neon files in `.editorconfig`;

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Someday we should reach for higher phpstan level :wink: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated indentation settings for `.neon` and `.neon.dist` files to use tabs with a size of 4.
	- Modified development dependencies and plugin configuration in the package manager settings.
	- Introduced a new static analysis configuration file and removed the previous one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->