### PR TITLE
Run tests only with a single http client

### DIFF
--- a/.github/workflows/meilisearch-beta-tests.yml
+++ b/.github/workflows/meilisearch-beta-tests.yml
@@ -27,7 +27,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     needs: ['meilisearch-version']
-    name: integration-tests-against-rc (PHP ${{ matrix.php-version }}) (${{ matrix.http-client }})
+    name: integration-tests-against-rc (PHP ${{ matrix.php-version }})
     services:
       meilisearch:
         image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
@@ -39,14 +39,6 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        http-client: ['Guzzle-7', 'Guzzle-7-Adapter', 'Symfony-HttpClient', 'PHP-HTTP-CurlClient', 'Kriswallsmith-Buzz']
-        exclude:
-          - php-version: '7.4'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.0'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.1'
-            http-client: 'Symfony-HttpClient'
 
     steps:
       - name: Checkout code
@@ -59,29 +51,6 @@ jobs:
 
       - name: Validate composer.json and composer.lock
         run: composer validate
-
-      - name: Switch to Guzzle7 Adapter
-        if: matrix.http-client == 'Guzzle-7-Adapter'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/guzzle7-adapter": "^1.0.0",/' composer.json
-
-      - name: Switch to Symfony HttpClient
-        if: matrix.http-client == 'Symfony-HttpClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"symfony\/http-client": "^7.1.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to PHP HTTP CurlClient
-        if: matrix.http-client == 'PHP-HTTP-CurlClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/curl-client": "^2.3.2",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to Kriswallsmith Buzz
-        if: matrix.http-client == 'Kriswallsmith-Buzz'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"kriswallsmith\/buzz": "^1.2.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
 
       - name: Install dependencies
         uses: ramsey/composer-install@v3

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -39,14 +39,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        http-client: ['Guzzle-7', 'Guzzle-7-Adapter', 'Symfony-HttpClient', 'PHP-HTTP-CurlClient', 'Kriswallsmith-Buzz']
-        exclude:
-          - php-version: '7.4'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.0'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.1'
-            http-client: 'Symfony-HttpClient'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,67 +53,8 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Switch to Guzzle7 Adapter
-        if: matrix.http-client == 'Guzzle-7-Adapter'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/guzzle7-adapter": "^1.0.0",/' composer.json
-
-      - name: Switch to Symfony HttpClient
-        if: matrix.http-client == 'Symfony-HttpClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"symfony\/http-client": "^7.1.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to PHP HTTP CurlClient
-        if: matrix.http-client == 'PHP-HTTP-CurlClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/curl-client": "^2.3.2",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to Kriswallsmith Buzz
-        if: matrix.http-client == 'Kriswallsmith-Buzz'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"kriswallsmith\/buzz": "^1.2.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
       - name: Install dependencies
         uses: ramsey/composer-install@v3
 
       - name: Run test suite
-        run: sh scripts/tests.sh
-
-  test_php_7_guzzle_6:
-    runs-on: ubuntu-latest
-    needs: ['meilisearch-version']
-    name: integration-tests-against-rc (PHP 7.4 & Guzzle 6)
-    services:
-      meilisearch:
-        image: getmeili/meilisearch:${{ needs.meilisearch-version.outputs.version }}
-        env:
-          MEILI_MASTER_KEY: 'masterKey'
-          MEILI_NO_ANALYTICS: 'true'
-        ports:
-          - '7700:7700'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Switch to Guzzle 6
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/guzzle6-adapter": "^2.0.2",/' composer.json
-
-      - name: Install dependencies
-        uses: ramsey/composer-install@v3
-
-      - name: Run test suite - php-http/guzzle6-adapter
         run: sh scripts/tests.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     runs-on: ubuntu-latest
-    name: integration-tests (PHP ${{ matrix.php-version }}) (${{ matrix.http-client }})
+    name: integration-tests (PHP ${{ matrix.php-version }})
     services:
       meilisearch:
         image: getmeili/meilisearch:latest
@@ -80,14 +80,6 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        http-client: ['Guzzle-7', 'Guzzle-7-Adapter', 'Symfony-HttpClient', 'PHP-HTTP-CurlClient', 'Kriswallsmith-Buzz']
-        exclude:
-          - php-version: '7.4'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.0'
-            http-client: 'Symfony-HttpClient'
-          - php-version: '8.1'
-            http-client: 'Symfony-HttpClient'
 
     steps:
       - uses: actions/checkout@v4
@@ -101,78 +93,17 @@ jobs:
       - name: Validate composer.json and composer.lock
         run: composer validate
 
-      - name: Switch to Guzzle7 Adapter
-        if: matrix.http-client == 'Guzzle-7-Adapter'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/guzzle7-adapter": "^1.0.0",/' composer.json
-
-      - name: Switch to Symfony HttpClient
-        if: matrix.http-client == 'Symfony-HttpClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"symfony\/http-client": "^7.1.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to PHP HTTP CurlClient
-        if: matrix.http-client == 'PHP-HTTP-CurlClient'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/curl-client": "^2.3.2",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
-      - name: Switch to Kriswallsmith Buzz
-        if: matrix.http-client == 'Kriswallsmith-Buzz'
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"kriswallsmith\/buzz": "^1.2.1",/' composer.json
-          sed -i 's/"http-interop\/http-factory-guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"nyholm\/psr7": "^1.8.1",/' composer.json
-
       - name: Install dependencies
         uses: ramsey/composer-install@v3
 
       - name: Run test suite
-        run: sh scripts/tests.sh --coverage-clover coverage-${{ matrix.php-version }}-${{ matrix.http-client }}.xml
+        run: sh scripts/tests.sh --coverage-clover coverage-${{ matrix.php-version }}.xml
 
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: 'phpunit-${{ matrix.php-version }}-${{ matrix.http-client }}-coverage'
+          name: 'phpunit-${{ matrix.php-version }}-coverage'
           path: 'coverage*.xml'
-
-  test_php_7_guzzle_6:
-    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
-    # Will still run for each push to bump-meilisearch-v*
-    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
-    runs-on: ubuntu-latest
-    services:
-      meilisearch:
-        image: getmeili/meilisearch:latest
-        ports:
-          - 7700:7700
-        env:
-          MEILI_MASTER_KEY: masterKey
-          MEILI_NO_ANALYTICS: true
-
-    name: integration-tests (PHP 7.4 & Guzzle 6)
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Switch to Guzzle 6
-        run: |
-          sed -i 's/"guzzlehttp\/guzzle": "^[0-9]\+\.[0-9]\+\.[0-9]\+\",/"php-http\/guzzle6-adapter": "^2.0.2",/' composer.json
-
-      - name: Install dependencies
-        uses: ramsey/composer-install@v3
-
-      - name: Run test suite - php-http/guzzle6-adapter
-        run: sh scripts/tests.sh
 
   upload-coverage:
     name: Upload coverage to Codecov

--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,18 @@
     },
     "suggest": {
         "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
-        "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle"
+        "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle",
+        "symfony/http-client": "Use Symfony Http client"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^10.5",
         "php-cs-fixer/shim": "^3.59.3",
-        "guzzlehttp/guzzle": "^7.8.1",
         "http-interop/http-factory-guzzle": "^1.2.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0"
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "symfony/http-client": "^5.4|^6.0|^7.0"
     },
     "scripts": {
         "lint": [


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Removes testing with multiple http clients as it's not sdk responsibility to test if they behaves correctly. PSR18 clients are interoperable, so they must work same by contract.

## Why?
- Because it blocks writing simple unit tests where we don't need to call meilisearch service like https://github.com/meilisearch/meilisearch-php/pull/757 - currently I'd need to adapt test based on available http client

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified test workflows by removing testing across multiple HTTP client implementations.
  - Removed jobs related to PHP 7.4 with Guzzle 6 from test workflows.
  - Updated development dependencies to replace Guzzle with Symfony HTTP client and added it as a suggested package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->