### PR TITLE
Fixed missing facetStats in SearchResult::toArray()

### DIFF
--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -223,6 +223,7 @@ class SearchResult implements \Countable, \IteratorAggregate
             'processingTimeMs' => $this->processingTimeMs,
             'query' => $this->query,
             'facetDistribution' => $this->facetDistribution,
+            'facetStats' => $this->facetStats,
         ];
 
         if (!$this->numberedPagination) {


### PR DESCRIPTION
# Pull Request

## Related issue

none

## What does this PR do?

- Fixes the missing `facetStats` when calling `SearchResult::toArray()`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now display additional facet statistics information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->