### PR TITLE
Add conversational search

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Meilisearch;
 
 use Meilisearch\Endpoints\Batches;
+use Meilisearch\Endpoints\ChatWorkspaces;
 use Meilisearch\Endpoints\Delegates\HandlesBatches;
+use Meilisearch\Endpoints\Delegates\HandlesChatWorkspaces;
 use Meilisearch\Endpoints\Delegates\HandlesDumps;
 use Meilisearch\Endpoints\Delegates\HandlesIndex;
 use Meilisearch\Endpoints\Delegates\HandlesKeys;
@@ -31,6 +33,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 class Client
 {
+    use HandlesChatWorkspaces;
     use HandlesDumps;
     use HandlesIndex;
     use HandlesTasks;
@@ -53,6 +56,7 @@ class Client
         ?StreamFactoryInterface $streamFactory = null
     ) {
         $this->http = new MeilisearchClientAdapter($url, $apiKey, $httpClient, $requestFactory, $clientAgents, $streamFactory);
+        $this->chats = new ChatWorkspaces($this->http);
         $this->index = new Indexes($this->http);
         $this->health = new Health($this->http);
         $this->version = new Version($this->http);

--- a/src/Contracts/ChatWorkspacePromptsSettings.php
+++ b/src/Contracts/ChatWorkspacePromptsSettings.php
@@ -4,20 +4,29 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+/**
+ * @phpstan-type ChatWorkspacePromptsArray array{
+ *     system: string,
+ *     searchDescription: string,
+ *     searchQParam: non-empty-string,
+ *     searchIndexUidParam: non-empty-string
+ * }
+ */
 class ChatWorkspacePromptsSettings extends Data
 {
     public string $system;
     public string $searchDescription;
+    /**
+     * @var non-empty-string
+     */
     public string $searchQParam;
+    /**
+     * @var non-empty-string
+     */
     public string $searchIndexUidParam;
 
     /**
-     * @param array{
-     *     system: string,
-     *     searchDescription: string,
-     *     searchQParam: string,
-     *     searchIndexUidParam: string
-     * } $params
+     * @param ChatWorkspacePromptsArray $params
      */
     public function __construct(array $params)
     {
@@ -39,23 +48,24 @@ class ChatWorkspacePromptsSettings extends Data
         return $this->searchDescription;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getSearchQParam(): string
     {
         return $this->searchQParam;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getSearchIndexUidParam(): string
     {
         return $this->searchIndexUidParam;
     }
 
     /**
-     * @return array{
-     *     system: string,
-     *     searchDescription: string,
-     *     searchQParam: string,
-     *     searchIndexUidParam: string
-     * }
+     * @return ChatWorkspacePromptsArray
      */
     public function toArray(): array
     {

--- a/src/Contracts/ChatWorkspacePromptsSettings.php
+++ b/src/Contracts/ChatWorkspacePromptsSettings.php
@@ -14,16 +14,16 @@ namespace Meilisearch\Contracts;
  */
 class ChatWorkspacePromptsSettings extends Data
 {
-    public string $system;
-    public string $searchDescription;
+    private string $system;
+    private string $searchDescription;
     /**
      * @var non-empty-string
      */
-    public string $searchQParam;
+    private string $searchQParam;
     /**
      * @var non-empty-string
      */
-    public string $searchIndexUidParam;
+    private string $searchIndexUidParam;
 
     /**
      * @param ChatWorkspacePromptsArray $params

--- a/src/Contracts/ChatWorkspacePromptsSettings.php
+++ b/src/Contracts/ChatWorkspacePromptsSettings.php
@@ -12,16 +12,9 @@ namespace Meilisearch\Contracts;
  *     searchIndexUidParam: non-empty-string
  * }
  */
-
 class ChatWorkspacePromptsSettings extends Data
 {
-    /**
-     * @var string
-     */
     public string $system;
-    /**
-     * @var string
-     */
     public string $searchDescription;
     /**
      * @var non-empty-string

--- a/src/Contracts/ChatWorkspacePromptsSettings.php
+++ b/src/Contracts/ChatWorkspacePromptsSettings.php
@@ -12,9 +12,16 @@ namespace Meilisearch\Contracts;
  *     searchIndexUidParam: non-empty-string
  * }
  */
+
 class ChatWorkspacePromptsSettings extends Data
 {
+    /**
+     * @var string
+     */
     public string $system;
+    /**
+     * @var string
+     */
     public string $searchDescription;
     /**
      * @var non-empty-string

--- a/src/Contracts/ChatWorkspacePromptsSettings.php
+++ b/src/Contracts/ChatWorkspacePromptsSettings.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class ChatWorkspacePromptsSettings extends Data
+{
+    public string $system;
+    public string $searchDescription;
+    public string $searchQParam;
+    public string $searchIndexUidParam;
+
+    /**
+     * @param array{
+     *     system: string,
+     *     searchDescription: string,
+     *     searchQParam: string,
+     *     searchIndexUidParam: string
+     * } $params
+     */
+    public function __construct(array $params)
+    {
+        parent::__construct($params);
+
+        $this->system = $params['system'];
+        $this->searchDescription = $params['searchDescription'];
+        $this->searchQParam = $params['searchQParam'];
+        $this->searchIndexUidParam = $params['searchIndexUidParam'];
+    }
+
+    public function getSystem(): string
+    {
+        return $this->system;
+    }
+
+    public function getSearchDescription(): string
+    {
+        return $this->searchDescription;
+    }
+
+    public function getSearchQParam(): string
+    {
+        return $this->searchQParam;
+    }
+
+    public function getSearchIndexUidParam(): string
+    {
+        return $this->searchIndexUidParam;
+    }
+
+    /**
+     * @return array{
+     *     system: string,
+     *     searchDescription: string,
+     *     searchQParam: string,
+     *     searchIndexUidParam: string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'system' => $this->system,
+            'searchDescription' => $this->searchDescription,
+            'searchQParam' => $this->searchQParam,
+            'searchIndexUidParam' => $this->searchIndexUidParam,
+        ];
+    }
+}

--- a/src/Contracts/ChatWorkspaceSettings.php
+++ b/src/Contracts/ChatWorkspaceSettings.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class ChatWorkspaceSettings extends Data
+{
+    private ?string $source;
+    private ?string $orgId;
+    private ?string $projectId;
+    private ?string $apiVersion;
+    private ?string $deploymentId;
+    private ?string $baseUrl;
+    private ?string $apiKey;
+    private array $prompts;
+
+    public function __construct(array $params)
+    {
+        parent::__construct($params);
+
+        $this->source = $params['source'] ?? null;
+        $this->orgId = $params['orgId'] ?? null;
+        $this->projectId = $params['projectId'] ?? null;
+        $this->apiVersion = $params['apiVersion'] ?? null;
+        $this->deploymentId = $params['deploymentId'] ?? null;
+        $this->baseUrl = $params['baseUrl'] ?? null;
+        $this->apiKey = $params['apiKey'] ?? null;
+        $this->prompts = $params['prompts'] ?? [];
+    }
+
+    public function getSource(): ?string
+    {
+        return $this->source;
+    }
+
+    public function getOrgId(): ?string
+    {
+        return $this->orgId;
+    }
+
+    public function getProjectId(): ?string
+    {
+        return $this->projectId;
+    }
+
+    public function getApiVersion(): ?string
+    {
+        return $this->apiVersion;
+    }
+
+    public function getDeploymentId(): ?string
+    {
+        return $this->deploymentId;
+    }
+
+    public function getBaseUrl(): ?string
+    {
+        return $this->baseUrl;
+    }
+
+    public function getApiKey(): ?string
+    {
+        return $this->apiKey;
+    }
+
+    /**
+     * @return array{system?: string, searchDescription?: string, searchQParam?: string, searchIndexUidParam?: string}
+     */
+    public function getPrompts(): array
+    {
+        return $this->prompts;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'source' => $this->source,
+            'orgId' => $this->orgId,
+            'projectId' => $this->projectId,
+            'apiVersion' => $this->apiVersion,
+            'deploymentId' => $this->deploymentId,
+            'baseUrl' => $this->baseUrl,
+            'apiKey' => $this->apiKey,
+            'prompts' => $this->prompts,
+        ];
+    }
+}

--- a/src/Contracts/ChatWorkspaceSettings.php
+++ b/src/Contracts/ChatWorkspaceSettings.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-use Meilisearch\Contracts\ChatWorkspacePromptsSettings;
-
 class ChatWorkspaceSettings extends Data
 {
     private string $source;
@@ -15,7 +13,7 @@ class ChatWorkspaceSettings extends Data
     private ?string $deploymentId;
     private ?string $baseUrl;
     private ?string $apiKey;
-    private ?ChatWorkspacePromptsSettings $prompts;
+    private ChatWorkspacePromptsSettings $prompts;
 
     /**
      * @param array{
@@ -26,7 +24,7 @@ class ChatWorkspaceSettings extends Data
      *     deploymentId?: string,
      *     baseUrl?: string,
      *     apiKey?: string,
-     *     prompts?: array{
+     *     prompts: array{
      *         system: string,
      *         searchDescription: string,
      *         searchQParam: string,
@@ -45,7 +43,7 @@ class ChatWorkspaceSettings extends Data
         $this->deploymentId = $params['deploymentId'] ?? null;
         $this->baseUrl = $params['baseUrl'] ?? null;
         $this->apiKey = $params['apiKey'] ?? null;
-        $this->prompts = $params['prompts'] === null ? null : new ChatWorkspacePromptsSettings($params['prompts']);
+        $this->prompts = new ChatWorkspacePromptsSettings($params['prompts']);
     }
 
     public function getSource(): string
@@ -83,7 +81,7 @@ class ChatWorkspaceSettings extends Data
         return $this->apiKey;
     }
 
-    public function getPrompts(): ?ChatWorkspacePromptsSettings
+    public function getPrompts(): ChatWorkspacePromptsSettings
     {
         return $this->prompts;
     }
@@ -97,7 +95,7 @@ class ChatWorkspaceSettings extends Data
      *     deploymentId?: string,
      *     baseUrl?: string,
      *     apiKey?: string,
-     *     prompts?: array{
+     *     prompts: array{
      *         system: string,
      *         searchDescription: string,
      *         searchQParam: string,
@@ -115,7 +113,7 @@ class ChatWorkspaceSettings extends Data
             'deploymentId' => $this->deploymentId,
             'baseUrl' => $this->baseUrl,
             'apiKey' => $this->apiKey,
-            'prompts' => $this->prompts === null ? null : $this->prompts->toArray(),
+            'prompts' => $this->prompts->toArray(),
         ];
     }
 }

--- a/src/Contracts/ChatWorkspaceSettings.php
+++ b/src/Contracts/ChatWorkspaceSettings.php
@@ -4,32 +4,51 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+use Meilisearch\Contracts\ChatWorkspacePromptsSettings;
+
 class ChatWorkspaceSettings extends Data
 {
-    private ?string $source;
+    private string $source;
     private ?string $orgId;
     private ?string $projectId;
     private ?string $apiVersion;
     private ?string $deploymentId;
     private ?string $baseUrl;
     private ?string $apiKey;
-    private array $prompts;
+    private ?ChatWorkspacePromptsSettings $prompts;
 
+    /**
+     * @param array{
+     *     source: string,
+     *     orgId?: string,
+     *     projectId?: string,
+     *     apiVersion?: string,
+     *     deploymentId?: string,
+     *     baseUrl?: string,
+     *     apiKey?: string,
+     *     prompts?: array{
+     *         system: string,
+     *         searchDescription: string,
+     *         searchQParam: string,
+     *         searchIndexUidParam: string
+     *     }
+     * } $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);
 
-        $this->source = $params['source'] ?? null;
+        $this->source = $params['source'];
         $this->orgId = $params['orgId'] ?? null;
         $this->projectId = $params['projectId'] ?? null;
         $this->apiVersion = $params['apiVersion'] ?? null;
         $this->deploymentId = $params['deploymentId'] ?? null;
         $this->baseUrl = $params['baseUrl'] ?? null;
         $this->apiKey = $params['apiKey'] ?? null;
-        $this->prompts = $params['prompts'] ?? [];
+        $this->prompts = $params['prompts'] === null ? null : new ChatWorkspacePromptsSettings($params['prompts']);
     }
 
-    public function getSource(): ?string
+    public function getSource(): string
     {
         return $this->source;
     }
@@ -64,14 +83,28 @@ class ChatWorkspaceSettings extends Data
         return $this->apiKey;
     }
 
-    /**
-     * @return array{system?: string, searchDescription?: string, searchQParam?: string, searchIndexUidParam?: string}
-     */
-    public function getPrompts(): array
+    public function getPrompts(): ?ChatWorkspacePromptsSettings
     {
         return $this->prompts;
     }
 
+    /**
+     * @return array{
+     *     source: string,
+     *     orgId?: string,
+     *     projectId?: string,
+     *     apiVersion?: string,
+     *     deploymentId?: string,
+     *     baseUrl?: string,
+     *     apiKey?: string,
+     *     prompts?: array{
+     *         system: string,
+     *         searchDescription: string,
+     *         searchQParam: string,
+     *         searchIndexUidParam: string
+     *     }
+     * }
+     */
     public function toArray(): array
     {
         return [
@@ -82,7 +115,7 @@ class ChatWorkspaceSettings extends Data
             'deploymentId' => $this->deploymentId,
             'baseUrl' => $this->baseUrl,
             'apiKey' => $this->apiKey,
-            'prompts' => $this->prompts,
+            'prompts' => $this->prompts === null ? null : $this->prompts->toArray(),
         ];
     }
 }

--- a/src/Contracts/ChatWorkspaceSettings.php
+++ b/src/Contracts/ChatWorkspaceSettings.php
@@ -33,9 +33,6 @@ class ChatWorkspaceSettings extends Data
      * @var non-empty-string|null
      */
     private ?string $baseUrl;
-    /**
-     * @var string|null
-     */
     private ?string $apiKey;
     private ChatWorkspacePromptsSettings $prompts;
 

--- a/src/Contracts/ChatWorkspaceSettings.php
+++ b/src/Contracts/ChatWorkspaceSettings.php
@@ -4,31 +4,55 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+/**
+ * @phpstan-type ChatWorkspaceSource 'openAi'|'azureOpenAi'|'mistral'|'gemini'|'vLlm'
+ */
 class ChatWorkspaceSettings extends Data
 {
+    /**
+     * @var ChatWorkspaceSource
+     */
     private string $source;
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $orgId;
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $projectId;
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $apiVersion;
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $deploymentId;
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $baseUrl;
+    /**
+     * @var string|null
+     */
     private ?string $apiKey;
     private ChatWorkspacePromptsSettings $prompts;
 
     /**
      * @param array{
-     *     source: string,
-     *     orgId?: string,
-     *     projectId?: string,
-     *     apiVersion?: string,
-     *     deploymentId?: string,
-     *     baseUrl?: string,
+     *     source: ChatWorkspaceSource,
+     *     orgId?: non-empty-string,
+     *     projectId?: non-empty-string,
+     *     apiVersion?: non-empty-string,
+     *     deploymentId?: non-empty-string,
+     *     baseUrl?: non-empty-string,
      *     apiKey?: string,
      *     prompts: array{
      *         system: string,
      *         searchDescription: string,
-     *         searchQParam: string,
-     *         searchIndexUidParam: string
+     *         searchQParam: non-empty-string,
+     *         searchIndexUidParam: non-empty-string
      *     }
      * } $params
      */
@@ -46,36 +70,57 @@ class ChatWorkspaceSettings extends Data
         $this->prompts = new ChatWorkspacePromptsSettings($params['prompts']);
     }
 
+    /**
+     * @return ChatWorkspaceSource
+     */
     public function getSource(): string
     {
         return $this->source;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getOrgId(): ?string
     {
         return $this->orgId;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getProjectId(): ?string
     {
         return $this->projectId;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getApiVersion(): ?string
     {
         return $this->apiVersion;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getDeploymentId(): ?string
     {
         return $this->deploymentId;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getBaseUrl(): ?string
     {
         return $this->baseUrl;
     }
 
+    /**
+     * @return non-empty-string|null
+     */
     public function getApiKey(): ?string
     {
         return $this->apiKey;
@@ -88,18 +133,18 @@ class ChatWorkspaceSettings extends Data
 
     /**
      * @return array{
-     *     source: string,
-     *     orgId?: string,
-     *     projectId?: string,
-     *     apiVersion?: string,
-     *     deploymentId?: string,
-     *     baseUrl?: string,
+     *     source: ChatWorkspaceSource,
+     *     orgId?: non-empty-string,
+     *     projectId?: non-empty-string,
+     *     apiVersion?: non-empty-string,
+     *     deploymentId?: non-empty-string,
+     *     baseUrl?: non-empty-string,
      *     apiKey?: string,
      *     prompts: array{
      *         system: string,
      *         searchDescription: string,
-     *         searchQParam: string,
-     *         searchIndexUidParam: string
+     *         searchQParam: non-empty-string,
+     *         searchIndexUidParam: non-empty-string
      *     }
      * }
      */

--- a/src/Contracts/ChatWorkspacesResults.php
+++ b/src/Contracts/ChatWorkspacesResults.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class ChatWorkspacesResults extends Data
+{
+    private int $offset;
+    private int $limit;
+    private int $total;
+
+    public function __construct(array $params)
+    {
+        parent::__construct($params['results'] ?? []);
+
+        $this->offset = $params['offset'];
+        $this->limit = $params['limit'];
+        $this->total = $params['total'] ?? 0;
+    }
+
+    /**
+     * @return array<int, array{uid: string}>
+     */
+    public function getResults(): array
+    {
+        return $this->data;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'results' => $this->data,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'total' => $this->total,
+        ];
+    }
+
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+}

--- a/src/Contracts/ChatWorkspacesResults.php
+++ b/src/Contracts/ChatWorkspacesResults.php
@@ -6,8 +6,19 @@ namespace Meilisearch\Contracts;
 
 class ChatWorkspacesResults extends Data
 {
+    /**
+     * @var non-negative-int
+     */
     private int $offset;
+    
+    /**
+     * @var non-negative-int
+     */
     private int $limit;
+    
+    /**
+     * @var non-negative-int
+     */
     private int $total;
 
     public function __construct(array $params)

--- a/src/Contracts/ChatWorkspacesResults.php
+++ b/src/Contracts/ChatWorkspacesResults.php
@@ -38,16 +38,25 @@ class ChatWorkspacesResults extends Data
         return $this->data;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getTotal(): int
     {
         return $this->total;

--- a/src/Contracts/ChatWorkspacesResults.php
+++ b/src/Contracts/ChatWorkspacesResults.php
@@ -10,12 +10,12 @@ class ChatWorkspacesResults extends Data
      * @var non-negative-int
      */
     private int $offset;
-    
+
     /**
      * @var non-negative-int
      */
     private int $limit;
-    
+
     /**
      * @var non-negative-int
      */
@@ -62,6 +62,14 @@ class ChatWorkspacesResults extends Data
         return $this->total;
     }
 
+    /**
+     * @return array{
+     *     results: array,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     total: non-negative-int
+     * }
+     */
     public function toArray(): array
     {
         return [
@@ -72,6 +80,9 @@ class ChatWorkspacesResults extends Data
         ];
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function count(): int
     {
         return \count($this->data);

--- a/src/Contracts/ChatWorkspacesResults.php
+++ b/src/Contracts/ChatWorkspacesResults.php
@@ -12,11 +12,11 @@ class ChatWorkspacesResults extends Data
 
     public function __construct(array $params)
     {
-        parent::__construct($params['results'] ?? []);
+        parent::__construct($params['results']);
 
         $this->offset = $params['offset'];
         $this->limit = $params['limit'];
-        $this->total = $params['total'] ?? 0;
+        $this->total = $params['total'];
     }
 
     /**

--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -7,6 +7,7 @@ namespace Meilisearch\Contracts;
 use Meilisearch\Exceptions\ApiException;
 use Meilisearch\Exceptions\JsonDecodingException;
 use Meilisearch\Exceptions\JsonEncodingException;
+use Psr\Http\Message\StreamInterface;
 
 interface Http
 {
@@ -18,7 +19,6 @@ interface Http
 
     /**
      * @param non-empty-string|null $contentType
-     *
      * @throws ApiException
      * @throws JsonEncodingException
      * @throws JsonDecodingException
@@ -51,5 +51,5 @@ interface Http
      * @throws ApiException
      * @throws JsonEncodingException
      */
-    public function postStream(string $path, $body = null, array $query = []): \Psr\Http\Message\StreamInterface;
+    public function postStream(string $path, $body = null, array $query = []): StreamInterface;
 }

--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -46,4 +46,10 @@ interface Http
      * @throws JsonDecodingException
      */
     public function delete(string $path, array $query = []);
+
+    /**
+     * @throws ApiException
+     * @throws JsonEncodingException
+     */
+    public function postStream(string $path, $body = null, array $query = []): \Psr\Http\Message\StreamInterface;
 }

--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -19,6 +19,7 @@ interface Http
 
     /**
      * @param non-empty-string|null $contentType
+     *
      * @throws ApiException
      * @throws JsonEncodingException
      * @throws JsonDecodingException

--- a/src/Endpoints/ChatWorkspaces.php
+++ b/src/Endpoints/ChatWorkspaces.php
@@ -19,13 +19,28 @@ class ChatWorkspaces extends Endpoint
         parent::__construct($http);
     }
 
+    public function listWorkspaces(): array
+    {
+        return $this->http->get(self::PATH);
+    }
+
     public function workspace(string $workspaceName): self
     {
         return new self($this->http, $workspaceName);
     }
 
+    public function getSettings(): array
+    {
+        return $this->http->get(self::PATH.'/'.$this->workspaceName.'/settings');
+    }
+
     public function updateSettings(array $settings): array
     {
         return $this->http->patch(self::PATH.'/'.$this->workspaceName.'/settings', $settings);
+    }
+
+    public function resetSettings(): array
+    {
+        return $this->http->delete(self::PATH.'/'.$this->workspaceName.'/settings');
     }
 }

--- a/src/Endpoints/ChatWorkspaces.php
+++ b/src/Endpoints/ChatWorkspaces.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints;
 
+use Meilisearch\Contracts\ChatWorkspacesResults;
+use Meilisearch\Contracts\ChatWorkspaceSettings;
 use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\Http;
+use Meilisearch\Endpoints\Delegates\HandlesChatWorkspaceSettings;
 
 class ChatWorkspaces extends Endpoint
 {
+    use HandlesChatWorkspaceSettings;
+
     protected const PATH = '/chats';
 
     private ?string $workspaceName;
@@ -19,28 +24,15 @@ class ChatWorkspaces extends Endpoint
         parent::__construct($http);
     }
 
-    public function listWorkspaces(): array
+    public function listWorkspaces(): ChatWorkspacesResults
     {
-        return $this->http->get(self::PATH);
+        $response = $this->http->get(self::PATH);
+
+        return new ChatWorkspacesResults($response);
     }
 
     public function workspace(string $workspaceName): self
     {
         return new self($this->http, $workspaceName);
-    }
-
-    public function getSettings(): array
-    {
-        return $this->http->get(self::PATH.'/'.$this->workspaceName.'/settings');
-    }
-
-    public function updateSettings(array $settings): array
-    {
-        return $this->http->patch(self::PATH.'/'.$this->workspaceName.'/settings', $settings);
-    }
-
-    public function resetSettings(): array
-    {
-        return $this->http->delete(self::PATH.'/'.$this->workspaceName.'/settings');
     }
 }

--- a/src/Endpoints/ChatWorkspaces.php
+++ b/src/Endpoints/ChatWorkspaces.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Meilisearch\Endpoints;
 
 use Meilisearch\Contracts\ChatWorkspacesResults;
-use Meilisearch\Contracts\ChatWorkspaceSettings;
 use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\Http;
 use Meilisearch\Endpoints\Delegates\HandlesChatWorkspaceSettings;

--- a/src/Endpoints/ChatWorkspaces.php
+++ b/src/Endpoints/ChatWorkspaces.php
@@ -15,6 +15,9 @@ class ChatWorkspaces extends Endpoint
 
     protected const PATH = '/chats';
 
+    /**
+     * @var non-empty-string|null
+     */
     private ?string $workspaceName;
 
     public function __construct(Http $http, ?string $workspaceName = null)

--- a/src/Endpoints/ChatWorkspaces.php
+++ b/src/Endpoints/ChatWorkspaces.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints;
+
+use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Http;
+
+class ChatWorkspaces extends Endpoint
+{
+    protected const PATH = '/chats';
+
+    private ?string $workspaceName;
+
+    public function __construct(Http $http, ?string $workspaceName = null)
+    {
+        $this->workspaceName = $workspaceName;
+        parent::__construct($http);
+    }
+
+    public function workspace(string $workspaceName): self
+    {
+        return new self($this->http, $workspaceName);
+    }
+
+    public function updateSettings(array $settings): array
+    {
+        return $this->http->patch(self::PATH.'/'.$this->workspaceName.'/settings', $settings);
+    }
+}

--- a/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
@@ -33,12 +33,7 @@ trait HandlesChatWorkspaceSettings
      *     deploymentId?: string,
      *     baseUrl?: string,
      *     apiKey?: string,
-     *     prompts?: array{
-     *         system?: string,
-     *         searchDescription?: string,
-     *         searchQParam?: string,
-     *         searchIndexUidParam?: string
-     *     }
+     *     prompts?: array<string, string>
      * } $settings
      */
     public function updateSettings(array $settings): ChatWorkspaceSettings
@@ -67,15 +62,13 @@ trait HandlesChatWorkspaceSettings
     }
 
     /**
-     * Create a streaming chat completion.
+     * Create a streaming chat completion using OpenAI-compatible API.
      *
      * @param array{
      *     model: string,
      *     messages: array<array{role: string, content: string}>,
-     *     stream: bool,
-     *     temperature?: float,
-     *     max_tokens?: int
-     * } $options
+     *     stream: bool
+     * } $options The request body for the chat completion
      */
     public function streamCompletion(array $options): \Psr\Http\Message\StreamInterface
     {

--- a/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
@@ -13,7 +13,7 @@ trait HandlesChatWorkspaceSettings
      */
     public function getSettings(): ChatWorkspaceSettings
     {
-        if (!$this->workspaceName) {
+        if (null === $this->workspaceName) {
             throw new \InvalidArgumentException('Workspace name is required to get settings');
         }
 
@@ -43,7 +43,7 @@ trait HandlesChatWorkspaceSettings
      */
     public function updateSettings(array $settings): ChatWorkspaceSettings
     {
-        if (!$this->workspaceName) {
+        if (null === $this->workspaceName) {
             throw new \InvalidArgumentException('Workspace name is required to update settings');
         }
 
@@ -57,12 +57,32 @@ trait HandlesChatWorkspaceSettings
      */
     public function resetSettings(): ChatWorkspaceSettings
     {
-        if (!$this->workspaceName) {
+        if (null === $this->workspaceName) {
             throw new \InvalidArgumentException('Workspace name is required to reset settings');
         }
 
         $response = $this->http->delete('/chats/'.$this->workspaceName.'/settings');
 
         return new ChatWorkspaceSettings($response);
+    }
+
+    /**
+     * Create a streaming chat completion.
+     *
+     * @param array{
+     *     model: string,
+     *     messages: array<array{role: string, content: string}>,
+     *     stream: bool,
+     *     temperature?: float,
+     *     max_tokens?: int
+     * } $options
+     */
+    public function streamCompletion(array $options): \Psr\Http\Message\StreamInterface
+    {
+        if (null === $this->workspaceName) {
+            throw new \InvalidArgumentException('Workspace name is required for chat completion');
+        }
+
+        return $this->http->postStream('/chats/'.$this->workspaceName.'/chat/completions', $options);
     }
 }

--- a/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Meilisearch\Endpoints\Delegates;
 
 use Meilisearch\Contracts\ChatWorkspaceSettings;
+use Psr\Http\Message\StreamInterface;
 
 trait HandlesChatWorkspaceSettings
 {
@@ -70,7 +71,7 @@ trait HandlesChatWorkspaceSettings
      *     stream: bool
      * } $options The request body for the chat completion
      */
-    public function streamCompletion(array $options): \Psr\Http\Message\StreamInterface
+    public function streamCompletion(array $options): StreamInterface
     {
         if (null === $this->workspaceName) {
             throw new \InvalidArgumentException('Workspace name is required for chat completion');

--- a/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaceSettings.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints\Delegates;
+
+use Meilisearch\Contracts\ChatWorkspaceSettings;
+
+trait HandlesChatWorkspaceSettings
+{
+    /**
+     * Get the current settings for this chat workspace.
+     */
+    public function getSettings(): ChatWorkspaceSettings
+    {
+        if (!$this->workspaceName) {
+            throw new \InvalidArgumentException('Workspace name is required to get settings');
+        }
+
+        $response = $this->http->get('/chats/'.$this->workspaceName.'/settings');
+
+        return new ChatWorkspaceSettings($response);
+    }
+
+    /**
+     * Update the settings for this chat workspace.
+     *
+     * @param array{
+     *     source?: 'openAi'|'azureOpenAi'|'mistral'|'gemini'|'vLlm',
+     *     orgId?: string,
+     *     projectId?: string,
+     *     apiVersion?: string,
+     *     deploymentId?: string,
+     *     baseUrl?: string,
+     *     apiKey?: string,
+     *     prompts?: array{
+     *         system?: string,
+     *         searchDescription?: string,
+     *         searchQParam?: string,
+     *         searchIndexUidParam?: string
+     *     }
+     * } $settings
+     */
+    public function updateSettings(array $settings): ChatWorkspaceSettings
+    {
+        if (!$this->workspaceName) {
+            throw new \InvalidArgumentException('Workspace name is required to update settings');
+        }
+
+        $response = $this->http->patch('/chats/'.$this->workspaceName.'/settings', $settings);
+
+        return new ChatWorkspaceSettings($response);
+    }
+
+    /**
+     * Reset the settings for this chat workspace to default values.
+     */
+    public function resetSettings(): ChatWorkspaceSettings
+    {
+        if (!$this->workspaceName) {
+            throw new \InvalidArgumentException('Workspace name is required to reset settings');
+        }
+
+        $response = $this->http->delete('/chats/'.$this->workspaceName.'/settings');
+
+        return new ChatWorkspaceSettings($response);
+    }
+}

--- a/src/Endpoints/Delegates/HandlesChatWorkspaces.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaces.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints\Delegates;
+
+use Meilisearch\Endpoints\ChatWorkspaces;
+
+trait HandlesChatWorkspaces
+{
+    public ChatWorkspaces $chats;
+}

--- a/src/Endpoints/Delegates/HandlesChatWorkspaces.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaces.php
@@ -9,7 +9,7 @@ use Meilisearch\Endpoints\ChatWorkspaces;
 
 trait HandlesChatWorkspaces
 {
-    public ChatWorkspaces $chats;
+    private ChatWorkspaces $chats;
 
     /**
      * List all chat workspaces.

--- a/src/Endpoints/Delegates/HandlesChatWorkspaces.php
+++ b/src/Endpoints/Delegates/HandlesChatWorkspaces.php
@@ -4,9 +4,26 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints\Delegates;
 
+use Meilisearch\Contracts\ChatWorkspacesResults;
 use Meilisearch\Endpoints\ChatWorkspaces;
 
 trait HandlesChatWorkspaces
 {
     public ChatWorkspaces $chats;
+
+    /**
+     * List all chat workspaces.
+     */
+    public function getChatWorkspaces(): ChatWorkspacesResults
+    {
+        return $this->chats->listWorkspaces();
+    }
+
+    /**
+     * Get a specific chat workspace instance.
+     */
+    public function chatWorkspace(string $workspaceName): ChatWorkspaces
+    {
+        return $this->chats->workspace($workspaceName);
+    }
 }

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -504,6 +504,7 @@ trait HandlesSettings
 
     /**
      * @since Meilisearch v1.15.1
+     *
      * @return array{
      *     description: string,
      *     documentTemplate: string,
@@ -546,6 +547,7 @@ trait HandlesSettings
 
     /**
      * @since Meilisearch v1.15.1
+     *
      * @param array{
      *     description: string,
      *     documentTemplate: string,

--- a/src/Endpoints/Delegates/HandlesSettings.php
+++ b/src/Endpoints/Delegates/HandlesSettings.php
@@ -418,18 +418,27 @@ trait HandlesSettings
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/search-cutoff-ms');
     }
 
-    // Settings - Experimental: Embedders (hybrid search)
+    // Settings - Embedders
 
+    /**
+     * @since Meilisearch v1.13.0
+     */
     public function getEmbedders(): ?array
     {
         return $this->http->get(self::PATH.'/'.$this->uid.'/settings/embedders');
     }
 
+    /**
+     * @since Meilisearch v1.13.0
+     */
     public function updateEmbedders(array $embedders): array
     {
         return $this->http->patch(self::PATH.'/'.$this->uid.'/settings/embedders', $embedders);
     }
 
+    /**
+     * @since Meilisearch v1.13.0
+     */
     public function resetEmbedders(): array
     {
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/embedders');
@@ -489,5 +498,91 @@ trait HandlesSettings
     public function resetPrefixSearch(): array
     {
         return $this->http->delete(self::PATH.'/'.$this->uid.'/settings/prefix-search');
+    }
+
+    // Settings - Chat
+
+    /**
+     * @since Meilisearch v1.15.1
+     * @return array{
+     *     description: string,
+     *     documentTemplate: string,
+     *     documentTemplateMaxBytes: int,
+     *     searchParameters: array{
+     *         indexUid?: non-empty-string,
+     *         q?: string,
+     *         filter?: list<non-empty-string|list<non-empty-string>>,
+     *         locales?: list<non-empty-string>,
+     *         attributesToRetrieve?: list<non-empty-string>,
+     *         attributesToCrop?: list<non-empty-string>,
+     *         cropLength?: positive-int,
+     *         attributesToHighlight?: list<non-empty-string>,
+     *         cropMarker?: string,
+     *         highlightPreTag?: string,
+     *         highlightPostTag?: string,
+     *         facets?: list<non-empty-string>,
+     *         showMatchesPosition?: bool,
+     *         sort?: list<non-empty-string>,
+     *         matchingStrategy?: 'last'|'all'|'frequency',
+     *         offset?: non-negative-int,
+     *         limit?: non-negative-int,
+     *         hitsPerPage?: non-negative-int,
+     *         page?: non-negative-int,
+     *         vector?: non-empty-list<float|non-empty-list<float>>,
+     *         hybrid?: array<mixed>,
+     *         attributesToSearchOn?: non-empty-list<non-empty-string>,
+     *         showRankingScore?: bool,
+     *         showRankingScoreDetails?: bool,
+     *         rankingScoreThreshold?: float,
+     *         distinct?: non-empty-string,
+     *         federationOptions?: array<mixed>
+     *     }
+     * }
+     */
+    public function getChat(): array
+    {
+        return $this->http->get(self::PATH.'/'.$this->uid.'/settings/chat');
+    }
+
+    /**
+     * @since Meilisearch v1.15.1
+     * @param array{
+     *     description: string,
+     *     documentTemplate: string,
+     *     documentTemplateMaxBytes: int,
+     *     searchParameters: array{
+     *         indexUid?: non-empty-string,
+     *         q?: string,
+     *         filter?: list<non-empty-string|list<non-empty-string>>,
+     *         locales?: list<non-empty-string>,
+     *         attributesToRetrieve?: list<non-empty-string>,
+     *         attributesToCrop?: list<non-empty-string>,
+     *         cropLength?: positive-int,
+     *         attributesToHighlight?: list<non-empty-string>,
+     *         cropMarker?: string,
+     *         highlightPreTag?: string,
+     *         highlightPostTag?: string,
+     *         facets?: list<non-empty-string>,
+     *         showMatchesPosition?: bool,
+     *         sort?: list<non-empty-string>,
+     *         matchingStrategy?: 'last'|'all'|'frequency',
+     *         offset?: non-negative-int,
+     *         limit?: non-negative-int,
+     *         hitsPerPage?: non-negative-int,
+     *         page?: non-negative-int,
+     *         vector?: non-empty-list<float|non-empty-list<float>>,
+     *         hybrid?: array<mixed>,
+     *         attributesToSearchOn?: non-empty-list<non-empty-string>,
+     *         showRankingScore?: bool,
+     *         showRankingScoreDetails?: bool,
+     *         rankingScoreThreshold?: float,
+     *         distinct?: non-empty-string,
+     *         federationOptions?: array<mixed>
+     *     }
+     * } $chatSettings
+     */
+    public function updateChat(array $chatSettings): array
+    {
+        return $this->http->patch(self::PATH.'/'.$this->uid.'/settings/chat', $chatSettings);
     }
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -182,7 +182,7 @@ class Client implements Http
      * @throws ClientExceptionInterface
      * @throws CommunicationException
      */
-    private function executeStream(RequestInterface $request, array $headers = []): \Psr\Http\Message\StreamInterface
+    private function executeStream(RequestInterface $request, array $headers = []): StreamInterface
     {
         foreach (array_merge($this->headers, $headers) as $header => $value) {
             $request = $request->withAddedHeader($header, $value);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -199,10 +199,10 @@ class Client implements Http
                     try {
                         $body = $this->json->unserialize($bodyContent) ?? $response->getReasonPhrase();
                     } catch (\JsonException $e) {
-                        $body = $bodyContent !== '' ? $bodyContent : $response->getReasonPhrase();
+                        $body = '' !== $bodyContent ? $bodyContent : $response->getReasonPhrase();
                     }
                 } else {
-                    $body = $bodyContent !== '' ? $bodyContent : $response->getReasonPhrase();
+                    $body = '' !== $bodyContent ? $bodyContent : $response->getReasonPhrase();
                 }
 
                 throw new ApiException($response, $body);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 
 class Client implements Http
 {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -145,7 +145,7 @@ class Client implements Http
      * @throws CommunicationException
      * @throws JsonEncodingException
      */
-    public function postStream(string $path, $body = null, array $query = []): \Psr\Http\Message\StreamInterface
+    public function postStream(string $path, $body = null, array $query = []): StreamInterface
     {
         $request = $this->requestFactory->createRequest(
             'POST',

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -199,10 +199,10 @@ class Client implements Http
                     try {
                         $body = $this->json->unserialize($bodyContent) ?? $response->getReasonPhrase();
                     } catch (\JsonException $e) {
-                        $body = $bodyContent ?: $response->getReasonPhrase();
+                        $body = $bodyContent !== '' ? $bodyContent : $response->getReasonPhrase();
                     }
                 } else {
-                    $body = $bodyContent ?: $response->getReasonPhrase();
+                    $body = $bodyContent !== '' ? $bodyContent : $response->getReasonPhrase();
                 }
 
                 throw new ApiException($response, $body);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -198,7 +198,7 @@ class Client implements Http
                 if ($this->isJSONResponse($response->getHeader('content-type'))) {
                     try {
                         $body = $this->json->unserialize($bodyContent) ?? $response->getReasonPhrase();
-                    } catch (\JsonException $e) {
+                    } catch (JsonDecodingException $e) {
                         $body = '' !== $bodyContent ? $bodyContent : $response->getReasonPhrase();
                     }
                 } else {

--- a/tests/Endpoints/ChatTest.php
+++ b/tests/Endpoints/ChatTest.php
@@ -43,4 +43,48 @@ final class ChatTest extends TestCase
         // Meilisearch will mask the API key in the response
         self::assertSame('XXX...', $response['apiKey']);
     }
+
+    public function testGetWorkspaceSettings(): void
+    {
+        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+
+        $response = $this->client->chats->workspace('myWorkspace')->getSettings();
+        self::assertSame($this->workspaceSettings['source'], $response['source']);
+        self::assertSame($this->workspaceSettings['orgId'], $response['orgId']);
+        self::assertSame($this->workspaceSettings['projectId'], $response['projectId']);
+        self::assertSame($this->workspaceSettings['apiVersion'], $response['apiVersion']);
+        self::assertSame($this->workspaceSettings['deploymentId'], $response['deploymentId']);
+        self::assertSame($this->workspaceSettings['baseUrl'], $response['baseUrl']);
+        self::assertSame($this->workspaceSettings['prompts']['system'], $response['prompts']['system']);
+        // Meilisearch will mask the API key in the response
+        self::assertSame('XXX...', $response['apiKey']);
+    }
+
+    public function testListWorkspaces(): void
+    {
+        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $response = $this->client->chats->listWorkspaces();
+        self::assertSame([
+          ['uid' => 'myWorkspace'],
+        ], $response['results']);
+    }
+
+    public function testDeleteWorkspaceSettings(): void
+    {
+        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $this->client->chats->workspace('myWorkspace')->resetSettings();
+        $settingsResponse = $this->client->chats->workspace('myWorkspace')->getSettings();
+        self::assertSame('openAi', $settingsResponse['source']);
+        self::assertNull($settingsResponse['orgId']);
+        self::assertNull($settingsResponse['projectId']);
+        self::assertNull($settingsResponse['apiVersion']);
+        self::assertNull($settingsResponse['deploymentId']);
+        self::assertNull($settingsResponse['baseUrl']);
+        self::assertNull($settingsResponse['apiKey']);
+
+        $listResponse = $this->client->chats->listWorkspaces();
+        self::assertSame([
+          ['uid' => 'myWorkspace'],
+        ], $listResponse['results']);
+    }
 }

--- a/tests/Endpoints/ChatTest.php
+++ b/tests/Endpoints/ChatTest.php
@@ -33,15 +33,15 @@ final class ChatTest extends TestCase
     public function testUpdateWorkspacesSettings(): void
     {
         $response = $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
-        self::assertSame($this->workspaceSettings['source'], $response['source']);
-        self::assertSame($this->workspaceSettings['orgId'], $response['orgId']);
-        self::assertSame($this->workspaceSettings['projectId'], $response['projectId']);
-        self::assertSame($this->workspaceSettings['apiVersion'], $response['apiVersion']);
-        self::assertSame($this->workspaceSettings['deploymentId'], $response['deploymentId']);
-        self::assertSame($this->workspaceSettings['baseUrl'], $response['baseUrl']);
-        self::assertSame($this->workspaceSettings['prompts']['system'], $response['prompts']['system']);
+        self::assertSame($this->workspaceSettings['source'], $response->getSource());
+        self::assertSame($this->workspaceSettings['orgId'], $response->getOrgId());
+        self::assertSame($this->workspaceSettings['projectId'], $response->getProjectId());
+        self::assertSame($this->workspaceSettings['apiVersion'], $response->getApiVersion());
+        self::assertSame($this->workspaceSettings['deploymentId'], $response->getDeploymentId());
+        self::assertSame($this->workspaceSettings['baseUrl'], $response->getBaseUrl());
+        self::assertSame($this->workspaceSettings['prompts']['system'], $response->getPrompts()['system']);
         // Meilisearch will mask the API key in the response
-        self::assertSame('XXX...', $response['apiKey']);
+        self::assertSame('XXX...', $response->getApiKey());
     }
 
     public function testGetWorkspaceSettings(): void
@@ -49,15 +49,15 @@ final class ChatTest extends TestCase
         $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
 
         $response = $this->client->chats->workspace('myWorkspace')->getSettings();
-        self::assertSame($this->workspaceSettings['source'], $response['source']);
-        self::assertSame($this->workspaceSettings['orgId'], $response['orgId']);
-        self::assertSame($this->workspaceSettings['projectId'], $response['projectId']);
-        self::assertSame($this->workspaceSettings['apiVersion'], $response['apiVersion']);
-        self::assertSame($this->workspaceSettings['deploymentId'], $response['deploymentId']);
-        self::assertSame($this->workspaceSettings['baseUrl'], $response['baseUrl']);
-        self::assertSame($this->workspaceSettings['prompts']['system'], $response['prompts']['system']);
+        self::assertSame($this->workspaceSettings['source'], $response->getSource());
+        self::assertSame($this->workspaceSettings['orgId'], $response->getOrgId());
+        self::assertSame($this->workspaceSettings['projectId'], $response->getProjectId());
+        self::assertSame($this->workspaceSettings['apiVersion'], $response->getApiVersion());
+        self::assertSame($this->workspaceSettings['deploymentId'], $response->getDeploymentId());
+        self::assertSame($this->workspaceSettings['baseUrl'], $response->getBaseUrl());
+        self::assertSame($this->workspaceSettings['prompts']['system'], $response->getPrompts()['system']);
         // Meilisearch will mask the API key in the response
-        self::assertSame('XXX...', $response['apiKey']);
+        self::assertSame('XXX...', $response->getApiKey());
     }
 
     public function testListWorkspaces(): void
@@ -66,7 +66,7 @@ final class ChatTest extends TestCase
         $response = $this->client->chats->listWorkspaces();
         self::assertSame([
           ['uid' => 'myWorkspace'],
-        ], $response['results']);
+        ], $response->getResults());
     }
 
     public function testDeleteWorkspaceSettings(): void
@@ -74,17 +74,17 @@ final class ChatTest extends TestCase
         $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
         $this->client->chats->workspace('myWorkspace')->resetSettings();
         $settingsResponse = $this->client->chats->workspace('myWorkspace')->getSettings();
-        self::assertSame('openAi', $settingsResponse['source']);
-        self::assertNull($settingsResponse['orgId']);
-        self::assertNull($settingsResponse['projectId']);
-        self::assertNull($settingsResponse['apiVersion']);
-        self::assertNull($settingsResponse['deploymentId']);
-        self::assertNull($settingsResponse['baseUrl']);
-        self::assertNull($settingsResponse['apiKey']);
+        self::assertSame('openAi', $settingsResponse->getSource());
+        self::assertNull($settingsResponse->getOrgId());
+        self::assertNull($settingsResponse->getProjectId());
+        self::assertNull($settingsResponse->getApiVersion());
+        self::assertNull($settingsResponse->getDeploymentId());
+        self::assertNull($settingsResponse->getBaseUrl());
+        self::assertNull($settingsResponse->getApiKey());
 
         $listResponse = $this->client->chats->listWorkspaces();
         self::assertSame([
           ['uid' => 'myWorkspace'],
-        ], $listResponse['results']);
+        ], $listResponse->getResults());
     }
 }

--- a/tests/Endpoints/ChatTest.php
+++ b/tests/Endpoints/ChatTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Endpoints;
+
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class ChatTest extends TestCase
+{
+    private array $workspaceSettings = [
+      "source" => "openAi",
+      "orgId" => "some-org-id",
+      "projectId" => "some-project-id",
+      "apiVersion" => "some-api-version",
+      "deploymentId" => "some-deployment-id",
+      "baseUrl" => "https://baseurl.com",
+      "apiKey" => "sk-abc...",
+      "prompts" => [
+        "system" => "You are a helpful assistant that answers questions based on the provided context.",
+      ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['chatCompletions' => true]);
+    }
+
+    public function testUpdateWorkspacesSettings(): void
+    {
+        $response = $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        self::assertSame($this->workspaceSettings['source'], $response['source']);
+        self::assertSame($this->workspaceSettings['orgId'], $response['orgId']);
+        self::assertSame($this->workspaceSettings['projectId'], $response['projectId']);
+        self::assertSame($this->workspaceSettings['apiVersion'], $response['apiVersion']);
+        self::assertSame($this->workspaceSettings['deploymentId'], $response['deploymentId']);
+        self::assertSame($this->workspaceSettings['baseUrl'], $response['baseUrl']);
+        self::assertSame($this->workspaceSettings['prompts']['system'], $response['prompts']['system']);
+        // Meilisearch will mask the API key in the response
+        self::assertSame('XXX...', $response['apiKey']);
+    }
+}

--- a/tests/Endpoints/ChatWorkspaceTest.php
+++ b/tests/Endpoints/ChatWorkspaceTest.php
@@ -20,6 +20,9 @@ final class ChatWorkspaceTest extends TestCase
         'apiKey' => 'sk-abc...',
         'prompts' => [
             'system' => 'You are a helpful assistant that answers questions based on the provided context.',
+            'searchDescription' => 'You are a helpful assistant that answers questions based on the provided context.',
+            'searchQParam' => 'q',
+            'searchIndexUidParam' => 'indexUid',
         ],
     ];
 
@@ -29,6 +32,8 @@ final class ChatWorkspaceTest extends TestCase
 
         $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
         $http->patch('/experimental-features', ['chatCompletions' => true]);
+
+        // List workspaces and
     }
 
     public function testUpdateWorkspacesSettings(): void
@@ -67,9 +72,9 @@ final class ChatWorkspaceTest extends TestCase
         self::assertSame('XXX...', $response->getApiKey());
 
         self::assertSame($this->workspaceSettings['prompts']['system'], $response->getPrompts()->getSystem());
-        self::assertNotEmpty($response->getPrompts()->getSearchDescription());
-        self::assertNotEmpty($response->getPrompts()->getSearchQParam());
-        self::assertNotEmpty($response->getPrompts()->getSearchIndexUidParam());
+        self::assertSame($this->workspaceSettings['prompts']['searchDescription'], $response->getPrompts()->getSearchDescription());
+        self::assertSame($this->workspaceSettings['prompts']['searchQParam'], $response->getPrompts()->getSearchQParam());
+        self::assertSame($this->workspaceSettings['prompts']['searchIndexUidParam'], $response->getPrompts()->getSearchIndexUidParam());
     }
 
     public function testListWorkspaces(): void

--- a/tests/Endpoints/ChatWorkspaceTest.php
+++ b/tests/Endpoints/ChatWorkspaceTest.php
@@ -38,7 +38,7 @@ final class ChatWorkspaceTest extends TestCase
 
     public function testUpdateWorkspacesSettings(): void
     {
-        $response = $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $response = $this->client->chatWorkspace('myWorkspace')->updateSettings($this->workspaceSettings);
         self::assertSame($this->workspaceSettings['source'], $response->getSource());
         self::assertSame($this->workspaceSettings['orgId'], $response->getOrgId());
         self::assertSame($this->workspaceSettings['projectId'], $response->getProjectId());
@@ -54,14 +54,14 @@ final class ChatWorkspaceTest extends TestCase
     {
         self::expectException(ApiException::class);
         self::expectExceptionCode(404);
-        $this->client->chats->workspace('non-existent-workspace')->getSettings();
+        $this->client->chatWorkspace('non-existent-workspace')->getSettings();
     }
 
     public function testGetWorkspaceSettings(): void
     {
-        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $this->client->chatWorkspace('myWorkspace')->updateSettings($this->workspaceSettings);
 
-        $response = $this->client->chats->workspace('myWorkspace')->getSettings();
+        $response = $this->client->chatWorkspace('myWorkspace')->getSettings();
         self::assertSame($this->workspaceSettings['source'], $response->getSource());
         self::assertSame($this->workspaceSettings['orgId'], $response->getOrgId());
         self::assertSame($this->workspaceSettings['projectId'], $response->getProjectId());
@@ -79,8 +79,8 @@ final class ChatWorkspaceTest extends TestCase
 
     public function testListWorkspaces(): void
     {
-        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
-        $response = $this->client->chats->listWorkspaces();
+        $this->client->chatWorkspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $response = $this->client->getChatWorkspaces();
         self::assertSame([
             ['uid' => 'myWorkspace'],
         ], $response->getResults());
@@ -88,9 +88,9 @@ final class ChatWorkspaceTest extends TestCase
 
     public function testResetWorkspaceSettings(): void
     {
-        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
-        $this->client->chats->workspace('myWorkspace')->resetSettings();
-        $settingsResponse = $this->client->chats->workspace('myWorkspace')->getSettings();
+        $this->client->chatWorkspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $this->client->chatWorkspace('myWorkspace')->resetSettings();
+        $settingsResponse = $this->client->chatWorkspace('myWorkspace')->getSettings();
         self::assertSame('openAi', $settingsResponse->getSource()); // Source is reset to openAi for some reason
         self::assertNull($settingsResponse->getOrgId());
         self::assertNull($settingsResponse->getProjectId());
@@ -105,7 +105,7 @@ final class ChatWorkspaceTest extends TestCase
         self::assertNotEmpty($settingsResponse->getPrompts()->getSearchIndexUidParam());
 
         // Workspace still appears when listing workspaces
-        $listResponse = $this->client->chats->listWorkspaces();
+        $listResponse = $this->client->getChatWorkspaces();
         self::assertSame([
             ['uid' => 'myWorkspace'],
         ], $listResponse->getResults());
@@ -113,9 +113,9 @@ final class ChatWorkspaceTest extends TestCase
 
     public function testCompletionStreaming(): void
     {
-        $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
+        $this->client->chatWorkspace('myWorkspace')->updateSettings($this->workspaceSettings);
 
-        $stream = $this->client->chats->workspace('myWorkspace')->streamCompletion([
+        $stream = $this->client->chatWorkspace('myWorkspace')->streamCompletion([
             'model' => 'gpt-4o-mini',
             'messages' => [
                 [

--- a/tests/Endpoints/ChatWorkspaceTest.php
+++ b/tests/Endpoints/ChatWorkspaceTest.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
-use Meilisearch\Client as MeilisearchClient;
 use Meilisearch\Http\Client;
 use Tests\TestCase;
 
 final class ChatWorkspaceTest extends TestCase
 {
     private array $workspaceSettings = [
-      "source" => "openAi",
-      "orgId" => "some-org-id",
-      "projectId" => "some-project-id",
-      "apiVersion" => "some-api-version",
-      "deploymentId" => "some-deployment-id",
-      "baseUrl" => "https://baseurl.com",
-      "apiKey" => "sk-abc...",
-      "prompts" => [
-        "system" => "You are a helpful assistant that answers questions based on the provided context.",
-      ],
+        'source' => 'openAi',
+        'orgId' => 'some-org-id',
+        'projectId' => 'some-project-id',
+        'apiVersion' => 'some-api-version',
+        'deploymentId' => 'some-deployment-id',
+        'baseUrl' => 'https://baseurl.com',
+        'apiKey' => 'sk-abc...',
+        'prompts' => [
+            'system' => 'You are a helpful assistant that answers questions based on the provided context.',
+        ],
     ];
 
     protected function setUp(): void
@@ -66,7 +65,7 @@ final class ChatWorkspaceTest extends TestCase
         $this->client->chats->workspace('myWorkspace')->updateSettings($this->workspaceSettings);
         $response = $this->client->chats->listWorkspaces();
         self::assertSame([
-          ['uid' => 'myWorkspace'],
+            ['uid' => 'myWorkspace'],
         ], $response->getResults());
     }
 
@@ -85,7 +84,7 @@ final class ChatWorkspaceTest extends TestCase
 
         $listResponse = $this->client->chats->listWorkspaces();
         self::assertSame([
-          ['uid' => 'myWorkspace'],
+            ['uid' => 'myWorkspace'],
         ], $listResponse->getResults());
     }
 
@@ -117,14 +116,14 @@ final class ChatWorkspaceTest extends TestCase
                     continue;
                 }
                 $receivedData .= $chunk;
-                $chunkCount++;
+                ++$chunkCount;
             }
 
             if ($chunkCount >= $maxChunks) {
                 self::fail('Test exceeded maximum chunk limit of '.$maxChunks);
             }
 
-            self::assertGreaterThan(0, strlen($receivedData));
+            self::assertGreaterThan(0, \strlen($receivedData));
         } finally {
             // Ensure we release network resources
             $stream->close();

--- a/tests/Settings/ChatTest.php
+++ b/tests/Settings/ChatTest.php
@@ -13,11 +13,11 @@ final class ChatTest extends TestCase
     private Indexes $index;
 
     private const DEFAULT_CHAT_SETTINGS = [
-      'description' => '',
-      'documentTemplate' => '{% for field in fields %}{% if field.is_searchable and field.value != nil %}{{ field.name }}: {{ field.value }}
+        'description' => '',
+        'documentTemplate' => '{% for field in fields %}{% if field.is_searchable and field.value != nil %}{{ field.name }}: {{ field.value }}
 {% endif %}{% endfor %}',
-      'documentTemplateMaxBytes' => 400,
-      'searchParameters' => []
+        'documentTemplateMaxBytes' => 400,
+        'searchParameters' => [],
     ];
 
     protected function setUp(): void
@@ -32,33 +32,33 @@ final class ChatTest extends TestCase
 
     public function testGetChatDefaultSettings(): void
     {
-      $settings = $this->index->getChat();
-      self::assertSame(self::DEFAULT_CHAT_SETTINGS['description'], $settings['description']);
-      self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplate'], $settings['documentTemplate']);
-      self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
-      self::assertSame(self::DEFAULT_CHAT_SETTINGS['searchParameters'], $settings['searchParameters']);
+        $settings = $this->index->getChat();
+        self::assertSame(self::DEFAULT_CHAT_SETTINGS['description'], $settings['description']);
+        self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplate'], $settings['documentTemplate']);
+        self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
+        self::assertSame(self::DEFAULT_CHAT_SETTINGS['searchParameters'], $settings['searchParameters']);
     }
 
     public function testUpdateChatSettings(): void
     {
-      $newSettings = [
-        'description' => 'New description',
-        'documentTemplate' => 'New document template',
-        'documentTemplateMaxBytes' => 500,
-        'searchParameters' => [
-          'limit' => 10,
-        ],
-      ];
+        $newSettings = [
+            'description' => 'New description',
+            'documentTemplate' => 'New document template',
+            'documentTemplateMaxBytes' => 500,
+            'searchParameters' => [
+                'limit' => 10,
+            ],
+        ];
 
-      $promise = $this->index->updateChat($newSettings);
+        $promise = $this->index->updateChat($newSettings);
 
-      $this->assertIsValidPromise($promise);
-      $this->index->waitForTask($promise['taskUid']);
+        $this->assertIsValidPromise($promise);
+        $this->index->waitForTask($promise['taskUid']);
 
-      $settings = $this->index->getChat();
-      self::assertSame($newSettings['description'], $settings['description']);
-      self::assertSame($newSettings['documentTemplate'], $settings['documentTemplate']);
-      self::assertSame($newSettings['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
-      self::assertSame($newSettings['searchParameters'], $settings['searchParameters']);
+        $settings = $this->index->getChat();
+        self::assertSame($newSettings['description'], $settings['description']);
+        self::assertSame($newSettings['documentTemplate'], $settings['documentTemplate']);
+        self::assertSame($newSettings['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
+        self::assertSame($newSettings['searchParameters'], $settings['searchParameters']);
     }
 }

--- a/tests/Settings/ChatTest.php
+++ b/tests/Settings/ChatTest.php
@@ -24,9 +24,13 @@ final class ChatTest extends TestCase
     {
         parent::setUp();
 
-        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
-        $http->patch('/experimental-features', ['chatCompletions' => true]);
+        $apiKey = getenv('MEILISEARCH_API_KEY');
+        if (!$apiKey) {
+            throw new \Exception('Missing `MEILISEARCH_API_KEY` environment variable');
+        }
 
+        $http = new Client($this->host, $apiKey);
+        $http->patch('/experimental-features', ['chatCompletions' => true]);
         $this->index = $this->createEmptyIndex($this->safeIndexName());
     }
 

--- a/tests/Settings/ChatTest.php
+++ b/tests/Settings/ChatTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Settings;
+
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class ChatTest extends TestCase
+{
+    private Indexes $index;
+
+    private const DEFAULT_CHAT_SETTINGS = [
+      'description' => '',
+      'documentTemplate' => '{% for field in fields %}{% if field.is_searchable and field.value != nil %}{{ field.name }}: {{ field.value }}
+{% endif %}{% endfor %}',
+      'documentTemplateMaxBytes' => 400,
+      'searchParameters' => []
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['chatCompletions' => true]);
+
+        $this->index = $this->createEmptyIndex($this->safeIndexName());
+    }
+
+    public function testGetChatDefaultSettings(): void
+    {
+      $settings = $this->index->getChat();
+      self::assertSame(self::DEFAULT_CHAT_SETTINGS['description'], $settings['description']);
+      self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplate'], $settings['documentTemplate']);
+      self::assertSame(self::DEFAULT_CHAT_SETTINGS['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
+      self::assertSame(self::DEFAULT_CHAT_SETTINGS['searchParameters'], $settings['searchParameters']);
+    }
+
+    public function testUpdateChatSettings(): void
+    {
+      $newSettings = [
+        'description' => 'New description',
+        'documentTemplate' => 'New document template',
+        'documentTemplateMaxBytes' => 500,
+        'searchParameters' => [
+          'limit' => 10,
+        ],
+      ];
+
+      $promise = $this->index->updateChat($newSettings);
+
+      $this->assertIsValidPromise($promise);
+      $this->index->waitForTask($promise['taskUid']);
+
+      $settings = $this->index->getChat();
+      self::assertSame($newSettings['description'], $settings['description']);
+      self::assertSame($newSettings['documentTemplate'], $settings['documentTemplate']);
+      self::assertSame($newSettings['documentTemplateMaxBytes'], $settings['documentTemplateMaxBytes']);
+      self::assertSame($newSettings['searchParameters'], $settings['searchParameters']);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #765 

## What does this PR do?

Add methods to interact with chat workspaces endpoints:
- updating workspace settings (`PATCH /chats/{workspace}/settings`)
- getting a workspace settings (`GET /chats/{workspace}/settings`)
- listing workspaces (`GET /chats`)
- deleting a workspace (`DELETE /chats/{workspace_uid}/settings`
- creating a chat completion (`POST chats/{workspace}/chat/completions`)

Add methods to interact with index chat settings:
- get an index chat settings `GET /indexes/{index_uid}/settings/chat`
- update an index chat settings `PUT /indexes/{index_uid}/settings/chat`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat workspaces: list, select, manage workspace settings, and stream chat completions; client exposes chats at the top level.

- **Settings**
  - Per-workspace structured prompt and settings management (get/update/reset) with API key masking.
  - Expanded index-level chat configuration (retrieve/update).
  - Embedders management: get, update, reset.

- **Tests**
  - End-to-end and integration tests covering workspace lifecycle, settings, resets, and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->