### PR TITLE
fix: wrong type for `retrieveVectors`

### DIFF
--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -123,7 +123,7 @@ class DocumentsQuery
      *     limit?: non-negative-int,
      *     fields?: non-empty-list<string>|non-empty-string,
      *     filter?: list<non-empty-string|list<non-empty-string>>,
-     *     retrieveVectors?: 'true'|'false',
+     *     retrieveVectors?: bool,
      *     ids?: string
      * }
      */

--- a/src/Contracts/DocumentsQuery.php
+++ b/src/Contracts/DocumentsQuery.php
@@ -134,7 +134,7 @@ class DocumentsQuery
             'limit' => $this->limit,
             'fields' => $this->getFields(),
             'filter' => $this->filter,
-            'retrieveVectors' => (null !== $this->retrieveVectors ? ($this->retrieveVectors ? 'true' : 'false') : null),
+            'retrieveVectors' => $this->retrieveVectors,
             'ids' => ($this->ids ?? []) !== [] ? implode(',', $this->ids) : null,
         ], static function ($item) { return null !== $item; });
     }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -161,6 +161,12 @@ class Client implements Http
 
     private function buildQueryString(array $queryParams = []): string
     {
+        foreach ($queryParams as $key => $value) {
+            if (\is_bool($value)) {
+                $queryParams[$key] = $value ? 'true' : 'false';
+            }
+        }
+
         return \count($queryParams) > 0 ? '?'.http_build_query($queryParams) : '';
     }
 

--- a/tests/Contracts/DocumentsQueryTest.php
+++ b/tests/Contracts/DocumentsQueryTest.php
@@ -37,6 +37,13 @@ final class DocumentsQueryTest extends TestCase
         self::assertSame(['offset' => 5], $data->toArray());
     }
 
+    public function testSetRetrieveVectors(): void
+    {
+        $data = (new DocumentsQuery())->setRetrieveVectors(true);
+
+        self::assertSame(['retrieveVectors' => true], $data->toArray());
+    }
+
     /**
      * @dataProvider idsProvider
      */


### PR DESCRIPTION
Setting `retrieveVectors` to `true` using `DocumentsQuery` currently lead to the following error when using the `POST` verb to retrieve documents:

```
[Meilisearch\Exceptions\ApiException (400)]
  Invalid value type at `.retrieveVectors`: expected a boolean, but found a string: `"true"`
```

It should only be casted as string when using `GET /documents` (which is deprecated for some reason).

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ability to enable vector retrieval via a flag in document queries.

- Bug Fixes
  - Serialized query payloads now represent the vector retrieval flag as boolean or null, matching docs and improving interoperability.
  - Boolean query parameters are now encoded consistently in request URLs to ensure correct transmission.

- Tests
  - Added coverage validating the vector retrieval flag is set and serialized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->