### PR TITLE
tests: increase PHP memory limit to 512M in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
+RUN echo "memory_limit = 512M" > /usr/local/etc/php/conf.d/memory-limit.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer


### PR DESCRIPTION
Hello there,

When running `docker-compose run --rm package bash -c "composer install && composer test && composer lint && composer phpstan"`  I got memory_limit errors during the phpstan step (Mac M4).

I suggest to raise the default limit from 128M to 512M to avoid these errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Composer is now preinstalled in the container, enabling dependency management directly within the image.

* **Chores**
  * PHP memory limit set to 512M to improve application stability under heavier workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->