### PR TITLE
Make network tests compatible with v1.19

### DIFF
--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+/**
+ * @phpstan-type RemoteConfig array{url: non-empty-string, searchApiKey: non-empty-string, writeApiKey: non-empty-string}
+ */
 class NetworkResults extends Data
 {
     /**
@@ -12,14 +15,14 @@ class NetworkResults extends Data
     private string $self;
 
     /**
-     * @var array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}> a mapping of remote node IDs to their connection details
+     * @var array<non-empty-string, RemoteConfig> a mapping of remote node IDs to their connection details
      */
     private array $remotes;
 
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     *     remotes?: array<non-empty-string, RemoteConfig>
      * } $params
      */
     public function __construct(array $params)
@@ -39,7 +42,7 @@ class NetworkResults extends Data
     }
 
     /**
-     * @return array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     * @return array<non-empty-string, RemoteConfig>
      */
     public function getRemotes(): array
     {

--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -12,14 +12,14 @@ class NetworkResults extends Data
     private string $self;
 
     /**
-     * @var array<non-empty-string, array{url: non-empty-string, searchApiKey: string}> a mapping of remote node IDs to their connection details
+     * @var array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}> a mapping of remote node IDs to their connection details
      */
     private array $remotes;
 
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      * } $params
      */
     public function __construct(array $params)
@@ -39,7 +39,7 @@ class NetworkResults extends Data
     }
 
     /**
-     * @return array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     * @return array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      */
     public function getRemotes(): array
     {

--- a/src/Endpoints/Delegates/HandlesNetwork.php
+++ b/src/Endpoints/Delegates/HandlesNetwork.php
@@ -7,6 +7,9 @@ namespace Meilisearch\Endpoints\Delegates;
 use Meilisearch\Contracts\NetworkResults;
 use Meilisearch\Endpoints\Network;
 
+/**
+ * @phpstan-import-type RemoteConfig from NetworkResults
+ */
 trait HandlesNetwork
 {
     protected Network $network;
@@ -21,7 +24,7 @@ trait HandlesNetwork
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     *     remotes?: array<non-empty-string, RemoteConfig>
      * } $network
      */
     public function updateNetwork(array $network): NetworkResults

--- a/src/Endpoints/Delegates/HandlesNetwork.php
+++ b/src/Endpoints/Delegates/HandlesNetwork.php
@@ -21,7 +21,7 @@ trait HandlesNetwork
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      * } $network
      */
     public function updateNetwork(array $network): NetworkResults

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Meilisearch\Endpoints;
 
 use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\NetworkResults;
 
+/**
+ * @phpstan-import-type RemoteConfig from NetworkResults
+ */
 class Network extends Endpoint
 {
     protected const PATH = '/network';
@@ -13,7 +17,7 @@ class Network extends Endpoint
     /**
      * @return array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     *     remotes: array<non-empty-string, RemoteConfig>
      * }
      */
     public function get(): array
@@ -24,12 +28,12 @@ class Network extends Endpoint
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     *     remotes?: array<non-empty-string, RemoteConfig>
      * } $body
      *
      * @return array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
+     *     remotes: array<non-empty-string, RemoteConfig>
      * }
      */
     public function update(array $body): array

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -13,7 +13,7 @@ class Network extends Endpoint
     /**
      * @return array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      * }
      */
     public function get(): array
@@ -24,12 +24,12 @@ class Network extends Endpoint
     /**
      * @param array{
      *     self?: non-empty-string,
-     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     *     remotes?: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      * } $body
      *
      * @return array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string}>
+     *     remotes: array<non-empty-string, array{url: non-empty-string, searchApiKey: string, writeApiKey: string}>
      * }
      */
     public function update(array $body): array

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -37,18 +37,30 @@ final class NetworksTest extends TestCase
 
         $updateResp = $this->client->updateNetwork($networks);
         self::assertSame($networks['self'], $updateResp->getSelf());
+
         foreach ($networks['remotes'] as $key => $remote) {
-            self::assertSame($remote['url'], $updateResp->getRemotes()[$key]['url']);
-            self::assertSame($remote['searchApiKey'], $updateResp->getRemotes()[$key]['searchApiKey']);
-            self::assertSame($remote['writeApiKey'], $updateResp->getRemotes()[$key]['writeApiKey']);
+            $respRemotes = $updateResp->getRemotes();
+            self::assertArrayHasKey($key, $respRemotes);
+            self::assertArrayHasKey('url', $respRemotes[$key]);
+            self::assertArrayHasKey('searchApiKey', $respRemotes[$key]);
+            self::assertArrayHasKey('writeApiKey', $respRemotes[$key]);
+            self::assertSame($remote['url'], $respRemotes[$key]['url']);
+            self::assertSame($remote['searchApiKey'], $respRemotes[$key]['searchApiKey']);
+            self::assertSame($remote['writeApiKey'], $respRemotes[$key]['writeApiKey']);
         }
 
         $getResp = $this->client->getNetwork();
         self::assertSame($networks['self'], $getResp->getSelf());
+        self::assertArrayHasKey($networks['self'], $getResp->getRemotes(), '"self" must be a key of remotes');
         foreach ($networks['remotes'] as $key => $remote) {
-            self::assertSame($remote['url'], $getResp->getRemotes()[$key]['url']);
-            self::assertSame($remote['searchApiKey'], $getResp->getRemotes()[$key]['searchApiKey']);
-            self::assertSame($remote['writeApiKey'], $getResp->getRemotes()[$key]['writeApiKey']);
+            $respRemotes = $getResp->getRemotes();
+            self::assertArrayHasKey($key, $respRemotes);
+            self::assertArrayHasKey('url', $respRemotes[$key]);
+            self::assertArrayHasKey('searchApiKey', $respRemotes[$key]);
+            self::assertArrayHasKey('writeApiKey', $respRemotes[$key]);
+            self::assertSame($remote['url'], $respRemotes[$key]['url']);
+            self::assertSame($remote['searchApiKey'], $respRemotes[$key]['searchApiKey']);
+            self::assertSame($remote['writeApiKey'], $respRemotes[$key]['writeApiKey']);
         }
     }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -25,20 +25,30 @@ final class NetworksTest extends TestCase
                 'ms-00' => [
                     'url' => 'http://INSTANCE_URL',
                     'searchApiKey' => 'INSTANCE_API_KEY',
+                    'writeApiKey' => 'INSTANCE_WRITE_API_KEY',
                 ],
                 'ms-01' => [
                     'url' => 'http://ANOTHER_INSTANCE_URL',
                     'searchApiKey' => 'ANOTHER_INSTANCE_API_KEY',
+                    'writeApiKey' => 'ANOTHER_INSTANCE_WRITE_API_KEY',
                 ],
             ],
         ];
 
-        $response = $this->client->updateNetwork($networks);
-        self::assertSame($networks['self'], $response->getSelf());
-        self::assertSame($networks['remotes'], $response->getRemotes());
+        $updateResp = $this->client->updateNetwork($networks);
+        self::assertSame($networks['self'], $updateResp->getSelf());
+        foreach ($networks['remotes'] as $key =>$remote) {
+            self::assertSame($remote['url'], $updateResp->getRemotes()[$key]['url']);
+            self::assertSame($remote['searchApiKey'], $updateResp->getRemotes()[$key]['searchApiKey']);
+            self::assertSame($remote['writeApiKey'], $updateResp->getRemotes()[$key]['writeApiKey']);
+        }
 
-        $response = $this->client->getNetwork();
-        self::assertSame($networks['self'], $response->getSelf());
-        self::assertSame($networks['remotes'], $response->getRemotes());
+        $getResp = $this->client->getNetwork();
+        self::assertSame($networks['self'], $getResp->getSelf());
+        foreach ($networks['remotes'] as $key => $remote) {
+            self::assertSame($remote['url'], $getResp->getRemotes()[$key]['url']);
+            self::assertSame($remote['searchApiKey'], $getResp->getRemotes()[$key]['searchApiKey']);
+            self::assertSame($remote['writeApiKey'], $getResp->getRemotes()[$key]['writeApiKey']);
+        }
     }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -46,8 +46,8 @@ final class NetworksTest extends TestCase
     private function assertNetworkResponse(array $expected, NetworkResults $response): void
     {
         self::assertSame($expected['self'], $response->getSelf());
+        $respRemotes = $response->getRemotes();
         foreach ($expected['remotes'] as $key => $remote) {
-            $respRemotes = $response->getRemotes();
             self::assertArrayHasKey($key, $respRemotes);
             self::assertSame($remote['url'], $respRemotes[$key]['url']);
             self::assertSame($remote['searchApiKey'], $respRemotes[$key]['searchApiKey']);

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -37,7 +37,7 @@ final class NetworksTest extends TestCase
 
         $updateResp = $this->client->updateNetwork($networks);
         self::assertSame($networks['self'], $updateResp->getSelf());
-        foreach ($networks['remotes'] as $key =>$remote) {
+        foreach ($networks['remotes'] as $key => $remote) {
             self::assertSame($remote['url'], $updateResp->getRemotes()[$key]['url']);
             self::assertSame($remote['searchApiKey'], $updateResp->getRemotes()[$key]['searchApiKey']);
             self::assertSame($remote['writeApiKey'], $updateResp->getRemotes()[$key]['writeApiKey']);

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use Meilisearch\Contracts\NetworkResults;
 use Meilisearch\Http\Client;
 use Tests\TestCase;
 
@@ -36,28 +37,18 @@ final class NetworksTest extends TestCase
         ];
 
         $updateResp = $this->client->updateNetwork($networks);
-        self::assertSame($networks['self'], $updateResp->getSelf());
-
-        foreach ($networks['remotes'] as $key => $remote) {
-            $respRemotes = $updateResp->getRemotes();
-            self::assertArrayHasKey($key, $respRemotes);
-            self::assertArrayHasKey('url', $respRemotes[$key]);
-            self::assertArrayHasKey('searchApiKey', $respRemotes[$key]);
-            self::assertArrayHasKey('writeApiKey', $respRemotes[$key]);
-            self::assertSame($remote['url'], $respRemotes[$key]['url']);
-            self::assertSame($remote['searchApiKey'], $respRemotes[$key]['searchApiKey']);
-            self::assertSame($remote['writeApiKey'], $respRemotes[$key]['writeApiKey']);
-        }
+        $this->assertNetworkResponse($networks, $updateResp);
 
         $getResp = $this->client->getNetwork();
-        self::assertSame($networks['self'], $getResp->getSelf());
-        self::assertArrayHasKey($networks['self'], $getResp->getRemotes(), '"self" must be a key of remotes');
-        foreach ($networks['remotes'] as $key => $remote) {
-            $respRemotes = $getResp->getRemotes();
+        $this->assertNetworkResponse($networks, $getResp);
+    }
+
+    private function assertNetworkResponse(array $expected, NetworkResults $response): void
+    {
+        self::assertSame($expected['self'], $response->getSelf());
+        foreach ($expected['remotes'] as $key => $remote) {
+            $respRemotes = $response->getRemotes();
             self::assertArrayHasKey($key, $respRemotes);
-            self::assertArrayHasKey('url', $respRemotes[$key]);
-            self::assertArrayHasKey('searchApiKey', $respRemotes[$key]);
-            self::assertArrayHasKey('writeApiKey', $respRemotes[$key]);
             self::assertSame($remote['url'], $respRemotes[$key]['url']);
             self::assertSame($remote['searchApiKey'], $respRemotes[$key]['searchApiKey']);
             self::assertSame($remote['writeApiKey'], $respRemotes[$key]['writeApiKey']);


### PR DESCRIPTION
Fix Meilisearch SDKs tests after v1.19.0 and v1.19.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated remotes type annotations into a shared RemoteConfig alias and updated public docblocks to include a write API key.
* **Tests**
  * Network tests expanded to include and verify write API key per remote, using more granular assertions and a helper for per-remote checks.
* **Chores**
  * No runtime or user-facing behavior changes; only docblock/type and test updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->