### PR TITLE
Add merge_group trigger to workflows for merge queue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,8 @@ on:
       - main
       - feature/**
       - v1.x
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   yaml-lint:


### PR DESCRIPTION
## why

We want tests to be triggered when PRs targeting `v1.x` are sent to the merge queue.

## how 

This PR adds the merge_group trigger to the tests workflow to ensure GitHub Merge Queue can run required checks when using the merge queue with the `v1.x` branch.

Reference: [GitHub Actions merge_group event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow configuration to execute tests when merge checks are requested, improving merge validation reliability and ensuring comprehensive test coverage during the merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->