### PR TITLE
feat: add missing params in SearchQuery

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -111,6 +111,13 @@ class SearchQuery
 
     private ?FederationOptions $federationOptions = null;
 
+    private ?bool $retrieveVectors = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $media = null;
+
     /**
      * @return $this
      */
@@ -429,6 +436,29 @@ class SearchQuery
         return $this;
     }
 
+    public function setRetrieveVectors(?bool $retrieveVectors): self
+    {
+        $this->retrieveVectors = $retrieveVectors;
+
+        return $this;
+    }
+
+    /**
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     * It's available from Meilisearch v1.16.
+     * To enable it properly and use multimodal search, it's required to activate it through the /experimental-features route.
+     *
+     *  More info: https://www.meilisearch.com/docs/reference/api/experimental-features
+     *
+     * @param array<string, mixed>|null $media
+     */
+    public function setMedia(?array $media): self
+    {
+        $this->media = $media;
+
+        return $this;
+    }
+
     /**
      * @return array{
      *     indexUid?: non-empty-string,
@@ -457,7 +487,9 @@ class SearchQuery
      *     showRankingScoreDetails?: bool,
      *     rankingScoreThreshold?: float,
      *     distinct?: non-empty-string,
-     *     federationOptions?: array<mixed>
+     *     federationOptions?: array<mixed>,
+     *     retrieveVectors?: bool,
+     *     media?: array<string, mixed>,
      * }
      */
     public function toArray(): array
@@ -490,6 +522,8 @@ class SearchQuery
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
             'federationOptions' => null !== $this->federationOptions ? $this->federationOptions->toArray() : null,
+            'retrieveVectors' => $this->retrieveVectors,
+            'media' => $this->media,
         ], static function ($item) { return null !== $item; });
     }
 }

--- a/tests/Contracts/SearchQueryTest.php
+++ b/tests/Contracts/SearchQueryTest.php
@@ -236,4 +236,23 @@ final class SearchQueryTest extends TestCase
 
         self::assertSame(['federationOptions' => ['weight' => 0.5]], $data->toArray());
     }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testSetRetrieveVectors(bool $retrieveVectors): void
+    {
+        $data = (new SearchQuery())->setRetrieveVectors($retrieveVectors);
+
+        self::assertSame(['retrieveVectors' => $retrieveVectors], $data->toArray());
+    }
+
+    public function testSetMedia(): void
+    {
+        $media = ['image' => ['mime' => 'image/jpeg', 'data' => 'data://foo:bar']];
+        $data = (new SearchQuery())->setMedia($media);
+
+        self::assertSame(['media' => $media], $data->toArray());
+    }
 }


### PR DESCRIPTION
Add missing params `retrieveVectors` and `media` in `SearchQuery`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search queries can now request vector retrieval and include media data, enabling richer result payloads and more flexible result formatting.
  * New options allow callers to toggle vector inclusion and supply structured media information with searches.

* **Tests**
  * Added tests confirming search outputs include the vector flag and supplied media structure, ensuring the new options appear in serialized query results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->