### PR TITLE
allow symfony/http-client 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "symfony/http-client": "^5.4|^6.0|^7.0"
+        "symfony/http-client": "^5.4|^6.0|^7.0|^8.0"
     },
     "scripts": {
         "lint": [


### PR DESCRIPTION
Symfony 8 is in RC2 and will be out very soon.

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded development dependency version constraints for the Symfony HTTP Client to include v8.0, enabling compatibility with newer framework releases. No runtime behavior or error-handling changes were made. This change only affects allowed versions during development/CI and does not alter application functionality; package resolution may now select newer client releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->