### PR TITLE
Add typed `Version` object

### DIFF
--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -13,7 +13,7 @@ interface Http
      * @throws ApiException
      * @throws \JsonException
      */
-    public function get(string $path, array $query = []);
+    public function get(string $path, array $query = []): mixed;
 
     /**
      * @param non-empty-string|null $contentType
@@ -21,7 +21,7 @@ interface Http
      * @throws ApiException
      * @throws \JsonException
      */
-    public function post(string $path, mixed $body = null, array $query = [], ?string $contentType = null);
+    public function post(string $path, mixed $body = null, array $query = [], ?string $contentType = null): mixed;
 
     /**
      * @param non-empty-string|null $contentType
@@ -29,19 +29,19 @@ interface Http
      * @throws ApiException
      * @throws \JsonException
      */
-    public function put(string $path, mixed $body = null, array $query = [], ?string $contentType = null);
+    public function put(string $path, mixed $body = null, array $query = [], ?string $contentType = null): mixed;
 
     /**
      * @throws ApiException
      * @throws \JsonException
      */
-    public function patch(string $path, mixed $body = null, array $query = []);
+    public function patch(string $path, mixed $body = null, array $query = []): mixed;
 
     /**
      * @throws ApiException
      * @throws \JsonException
      */
-    public function delete(string $path, array $query = []);
+    public function delete(string $path, array $query = []): mixed;
 
     /**
      * @throws ApiException

--- a/src/Contracts/Version.php
+++ b/src/Contracts/Version.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+final class Version
+{
+    /**
+     * @param non-empty-string $commitSha
+     * @param non-empty-string $pkgVersion
+     */
+    public function __construct(
+        private readonly string $commitSha,
+        private readonly \DateTimeImmutable $commitDate,
+        private readonly string $pkgVersion,
+    ) {
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getCommitSha(): string
+    {
+        return $this->commitSha;
+    }
+
+    public function getCommitDate(): \DateTimeImmutable
+    {
+        return $this->commitDate;
+    }
+
+    public function getPkgVersion(): string
+    {
+        return $this->pkgVersion;
+    }
+
+    /**
+     * @param array{
+     *     commitSha: non-empty-string,
+     *     commitDate: non-empty-string,
+     *     pkgVersion: non-empty-string
+     * } $data
+     */
+    public static function fromArray(array $data): Version
+    {
+        return new self(
+            $data['commitSha'],
+            new \DateTimeImmutable($data['commitDate']),
+            $data['pkgVersion'],
+        );
+    }
+}

--- a/src/Endpoints/Delegates/HandlesSystem.php
+++ b/src/Endpoints/Delegates/HandlesSystem.php
@@ -6,6 +6,7 @@ namespace Meilisearch\Endpoints\Delegates;
 
 use Meilisearch\Contracts\Stats as StatsContract;
 use Meilisearch\Contracts\Task;
+use Meilisearch\Contracts\Version as VersionContract;
 use Meilisearch\Endpoints\Health;
 use Meilisearch\Endpoints\Stats;
 use Meilisearch\Endpoints\TenantToken;
@@ -35,9 +36,15 @@ trait HandlesSystem
         return true;
     }
 
-    public function version(): array
+    public function version(): VersionContract
     {
-        return $this->version->show();
+        $version = $this->version->show();
+
+        if (!\is_array($version)) {
+            throw new LogicException('Version did not respond with valid data.');
+        }
+
+        return VersionContract::fromArray($version);
     }
 
     public function stats(): StatsContract

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -66,7 +66,7 @@ class Client implements Http
      * @throws ApiException
      * @throws CommunicationException
      */
-    public function get(string $path, array $query = [])
+    public function get(string $path, array $query = []): mixed
     {
         $request = $this->requestFactory->createRequest(
             'GET',
@@ -84,7 +84,7 @@ class Client implements Http
      * @throws CommunicationException
      * @throws \JsonException
      */
-    public function post(string $path, mixed $body = null, array $query = [], ?string $contentType = null)
+    public function post(string $path, mixed $body = null, array $query = [], ?string $contentType = null): mixed
     {
         if (null === $contentType) {
             $body = $this->json->serialize($body);
@@ -105,7 +105,7 @@ class Client implements Http
      * @throws CommunicationException
      * @throws \JsonException
      */
-    public function put(string $path, mixed $body = null, array $query = [], ?string $contentType = null)
+    public function put(string $path, mixed $body = null, array $query = [], ?string $contentType = null): mixed
     {
         if (null === $contentType) {
             $body = $this->json->serialize($body);
@@ -118,7 +118,7 @@ class Client implements Http
         return $this->execute($request, ['Content-type' => $contentType ?? 'application/json']);
     }
 
-    public function patch(string $path, mixed $body = null, array $query = [])
+    public function patch(string $path, mixed $body = null, array $query = []): mixed
     {
         $request = $this->requestFactory->createRequest(
             'PATCH',
@@ -128,7 +128,7 @@ class Client implements Http
         return $this->execute($request, ['Content-type' => 'application/json']);
     }
 
-    public function delete(string $path, array $query = [])
+    public function delete(string $path, array $query = []): mixed
     {
         $request = $this->requestFactory->createRequest(
             'DELETE',

--- a/tests/Contracts/VersionTest.php
+++ b/tests/Contracts/VersionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\Version;
+use PHPUnit\Framework\TestCase;
+
+final class VersionTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $version = new Version(
+            commitSha: 'ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e',
+            commitDate: $date = new \DateTimeImmutable('2025-11-15 10:03:15.000000'),
+            pkgVersion: '1.26.0',
+        );
+
+        self::assertSame('ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e', $version->getCommitSha());
+        self::assertSame($date, $version->getCommitDate());
+        self::assertSame('1.26.0', $version->getPkgVersion());
+    }
+
+    public function testFromArray(): void
+    {
+        $version = Version::fromArray([
+            'commitSha' => 'ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e',
+            'commitDate' => '2025-11-15T10:03:15.000000000Z',
+            'pkgVersion' => '1.26.0',
+        ]);
+
+        self::assertSame('ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e', $version->getCommitSha());
+        self::assertEquals(new \DateTimeImmutable('2025-11-15 10:03:15.000000'), $version->getCommitDate());
+        self::assertSame('1.26.0', $version->getPkgVersion());
+    }
+}

--- a/tests/Endpoints/ClientTest.php
+++ b/tests/Endpoints/ClientTest.php
@@ -203,9 +203,8 @@ final class ClientTest extends TestCase
     {
         $response = $this->client->version();
 
-        self::assertArrayHasKey('commitSha', $response);
-        self::assertArrayHasKey('commitDate', $response);
-        self::assertArrayHasKey('pkgVersion', $response);
+        self::assertMatchesRegularExpression('/^[0-9a-f]{40}$/i', $response->getCommitSha());
+        self::assertGreaterThanOrEqual(0, version_compare($response->getPkgVersion(), '1.26.0'));
     }
 
     public function testStats(): void


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #745

## What does this PR do?
- Returns version object instead of untyped array;
- Adds `mixed` return type to `Http` client/interface

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Version info now returns an object with accessor methods instead of an associative array — update callers that read version fields.

* **New Features**
  * Added a Version value object exposing commit SHA, commit date, and package version accessors.

* **Chores**
  * HTTP client and related contracts now declare explicit return types (no behavioral changes).

* **Tests**
  * Added tests for the Version value object and updated client tests to use accessors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->