### PR TITLE
Remove custom date parsing

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -54,8 +54,8 @@ class Indexes extends Endpoint
             $this->http,
             $attributes['uid'],
             $attributes['primaryKey'],
-            static::parseDate($attributes['createdAt']),
-            static::parseDate($attributes['updatedAt']),
+            null !== $attributes['createdAt'] ? new \DateTimeImmutable($attributes['createdAt']) : null,
+            null !== $attributes['updatedAt'] ? new \DateTimeImmutable($attributes['updatedAt']) : null,
         );
     }
 
@@ -66,8 +66,8 @@ class Indexes extends Endpoint
     {
         $this->uid = $attributes['uid'];
         $this->primaryKey = $attributes['primaryKey'];
-        $this->createdAt = static::parseDate($attributes['createdAt']);
-        $this->updatedAt = static::parseDate($attributes['updatedAt']);
+        $this->createdAt = null !== $attributes['createdAt'] ? new \DateTimeImmutable($attributes['createdAt']) : null;
+        $this->updatedAt = null !== $attributes['updatedAt'] ? new \DateTimeImmutable($attributes['updatedAt']) : null;
 
         return $this;
     }
@@ -258,25 +258,5 @@ class Indexes extends Endpoint
     public function resetSettings(): Task
     {
         return Task::fromArray($this->http->delete(self::PATH.'/'.$this->uid.'/settings'), partial(Tasks::waitTask(...), $this->http));
-    }
-
-    /**
-     * @throws \Exception
-     */
-    public static function parseDate(?string $dateTime): ?\DateTimeInterface
-    {
-        if (null === $dateTime) {
-            return null;
-        }
-
-        try {
-            return new \DateTimeImmutable($dateTime);
-        } catch (\Exception $e) {
-            // Trim 9th+ digit from fractional seconds. Meilisearch server can send 9 digits; PHP supports up to 8
-            $trimPattern = '/(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,8})(?:\d{1,})?(Z|[\+-]\d{2}:\d{2})$/';
-            $trimmedDate = preg_replace($trimPattern, '$1$2', $dateTime);
-
-            return new \DateTimeImmutable($trimmedDate);
-        }
     }
 }

--- a/tests/Endpoints/IndexTest.php
+++ b/tests/Endpoints/IndexTest.php
@@ -261,31 +261,4 @@ final class IndexTest extends TestCase
         self::assertInstanceOf(TaskDeletionDetails::class, $details = $task->getDetails());
         self::assertSame('?uids=1%2C2', $details->originalFilter);
     }
-
-    public function testParseDate(): void
-    {
-        $date = '2021-01-01T01:23:45.123456Z';
-        $dateTime = Indexes::parseDate($date);
-        $formattedDate = '2021-01-01T01:23:45.123456+00:00';
-
-        self::assertInstanceOf(\DateTimeInterface::class, $dateTime);
-        self::assertSame($formattedDate, $dateTime->format('Y-m-d\TH:i:s.uP'));
-    }
-
-    public function testParseDateWithExtraFractionalSeconds(): void
-    {
-        $date = '2021-01-01T01:23:45.123456789Z';
-        $dateTime = Indexes::parseDate($date);
-        $formattedDate = '2021-01-01T01:23:45.123456+00:00';
-
-        self::assertInstanceOf(\DateTimeInterface::class, $dateTime);
-        self::assertSame($formattedDate, $dateTime->format('Y-m-d\TH:i:s.uP'));
-    }
-
-    public function testParseDateWhenNull(): void
-    {
-        $dateTime = Indexes::parseDate(null);
-
-        self::assertNull($dateTime);
-    }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-php/pull/823#discussion_r2548927346

## What does this PR do?
- Removes custom date parsing as of PHP 8.0.10 many fraction digits are supported passing to DateTime;
- Removes `Indexes::parseDate` so it's a breaking change (I don't understand why it was made as a public method);

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal date handling by inlining date construction logic and removing redundant parsing utilities. This change simplifies the codebase without affecting visible functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->