### PR TITLE
Remove remaining custom datetime parsing

### DIFF
--- a/src/Endpoints/Keys.php
+++ b/src/Endpoints/Keys.php
@@ -53,13 +53,13 @@ class Keys extends Endpoint
             $attributes['indexes'],
         );
         if ($attributes['expiresAt']) {
-            $key->expiresAt = $this->createDate($attributes['expiresAt']);
+            $key->expiresAt = new \DateTimeImmutable($attributes['expiresAt']);
         }
         if ($attributes['createdAt']) {
-            $key->createdAt = $this->createDate($attributes['createdAt']);
+            $key->createdAt = new \DateTimeImmutable($attributes['createdAt']);
         }
         if ($attributes['updatedAt']) {
-            $key->updatedAt = $this->createDate($attributes['updatedAt']);
+            $key->updatedAt = new \DateTimeImmutable($attributes['updatedAt']);
         }
 
         return $key;
@@ -77,32 +77,16 @@ class Keys extends Endpoint
         $this->actions = $attributes['actions'];
         $this->indexes = $attributes['indexes'];
         if ($attributes['expiresAt']) {
-            $this->expiresAt = $this->createDate($attributes['expiresAt']);
+            $this->expiresAt = new \DateTimeImmutable($attributes['expiresAt']);
         }
         if ($attributes['createdAt']) {
-            $this->createdAt = $this->createDate($attributes['createdAt']);
+            $this->createdAt = new \DateTimeImmutable($attributes['createdAt']);
         }
         if ($attributes['updatedAt']) {
-            $this->updatedAt = $this->createDate($attributes['updatedAt']);
+            $this->updatedAt = new \DateTimeImmutable($attributes['updatedAt']);
         }
 
         return $this;
-    }
-
-    protected function createDate($attribute): ?\DateTimeInterface
-    {
-        if (!\is_string($attribute)) {
-            return null;
-        }
-
-        if (!str_contains($attribute, '.')) {
-            $date = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, $attribute);
-        } else {
-            $attribute = preg_replace('/(\.\d{6})\d+/', '$1', $attribute, 1);
-            $date = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uP', $attribute);
-        }
-
-        return false === $date ? null : $date;
     }
 
     public function getUid(): ?string


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>
Related to #826

## What does this PR do?
- Removes remaining custom datetime parsing;
- BC break because of `protected function createDate`;

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for better maintainability and consistency in the Keys endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->