### PR TITLE
Fix PHP-CS-Fixer deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: linter-check
-    env:
-      PHP_CS_FIXER_IGNORE_ENV: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ $finder = PhpCsFixer\Finder::create()
 
 return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'declare_strict_types' => true,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Fixes PHP-CS-Fixer deprecation by using new config option instead of deprecated environment variable

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and continuous integration configurations to improve build and code quality processes.
  * Removed a CI environment variable from the workflow configuration.
  * Adjusted the code formatter configuration to allow unsupported PHP versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->