### PR TITLE
chore: handle unknown commit date in version

### DIFF
--- a/src/Contracts/Version.php
+++ b/src/Contracts/Version.php
@@ -12,7 +12,7 @@ final class Version
      */
     public function __construct(
         private readonly string $commitSha,
-        private readonly \DateTimeImmutable $commitDate,
+        private readonly ?\DateTimeImmutable $commitDate,
         private readonly string $pkgVersion,
     ) {
     }
@@ -25,7 +25,7 @@ final class Version
         return $this->commitSha;
     }
 
-    public function getCommitDate(): \DateTimeImmutable
+    public function getCommitDate(): ?\DateTimeImmutable
     {
         return $this->commitDate;
     }
@@ -44,9 +44,14 @@ final class Version
      */
     public static function fromArray(array $data): Version
     {
+        $commitDate = null;
+        if ('unknown' !== $data['commitDate']) {
+            $commitDate = new \DateTimeImmutable($data['commitDate']);
+        }
+
         return new self(
             $data['commitSha'],
-            new \DateTimeImmutable($data['commitDate']),
+            $commitDate,
             $data['pkgVersion'],
         );
     }

--- a/tests/Contracts/VersionTest.php
+++ b/tests/Contracts/VersionTest.php
@@ -34,4 +34,17 @@ final class VersionTest extends TestCase
         self::assertEquals(new \DateTimeImmutable('2025-11-15 10:03:15.000000'), $version->getCommitDate());
         self::assertSame('1.26.0', $version->getPkgVersion());
     }
+
+    public function testFromArrayWithUnknownCommitDate(): void
+    {
+        $version = Version::fromArray([
+            'commitSha' => 'ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e',
+            'commitDate' => 'unknown',
+            'pkgVersion' => '1.26.0',
+        ]);
+
+        self::assertSame('ea70a7d1c90b4d87c1c3319e9bf280dc790f7f5e', $version->getCommitSha());
+        self::assertNull($version->getCommitDate());
+        self::assertSame('1.26.0', $version->getPkgVersion());
+    }
 }


### PR DESCRIPTION
# Pull Request

This PR improves the handling of the `commitDate` field from Meilisearch's `/version` endpoint.

It appears `commitDate` can be the string "unknown" instead of a timestamp, which can cause parsing errors. This change adds robustness by handling "unknown", null, or other unparsable values, ensuring the application remains stable.

This fixes failing tests that can be seen here: https://github.com/meilisearch/meilisearch-php/actions/runs/19986589382/job/57321426973?pr=835

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The commit date field now gracefully handles cases where the date is unavailable or invalid, returning null instead of causing errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->