### PR TITLE
Add types to exceptions

### DIFF
--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -6,27 +6,26 @@ namespace Meilisearch\Exceptions;
 
 use Psr\Http\Message\ResponseInterface;
 
-class ApiException extends \Exception implements \Stringable, ExceptionInterface
+final class ApiException extends \Exception implements \Stringable, ExceptionInterface
 {
-    public $httpStatus = 0;
-    public $message;
-    public ?string $errorCode;
-    public ?string $errorType;
-    public ?string $errorLink;
-    public mixed $httpBody;
+    public readonly int $httpStatus;
+    public readonly ?string $errorCode;
+    public readonly ?string $errorType;
+    public readonly ?string $errorLink;
 
     public const HINT_MESSAGE = "Hint: It might not be working because maybe you're not up to date with the Meilisearch version that `%s` call requires.";
 
-    public function __construct(ResponseInterface $response, mixed $httpBody, ?\Throwable $previous = null)
-    {
-        $this->httpBody = $httpBody;
+    public function __construct(
+        public readonly ResponseInterface $response,
+        public readonly mixed $httpBody,
+        ?\Throwable $previous = null,
+    ) {
         $this->httpStatus = $response->getStatusCode();
-        $this->message = $this->getMessageFromHttpBody() ?? $response->getReasonPhrase();
         $this->errorCode = $this->getErrorCodeFromHttpBody();
         $this->errorLink = $this->getErrorLinkFromHttpBody();
         $this->errorType = $this->getErrorTypeFromHttpBody();
 
-        parent::__construct($this->message, $this->httpStatus, $previous);
+        parent::__construct($this->getMessageFromHttpBody() ?? $response->getReasonPhrase(), $this->httpStatus, $previous);
     }
 
     public function __toString(): string
@@ -90,6 +89,6 @@ class ApiException extends \Exception implements \Stringable, ExceptionInterface
 
     public static function rethrowWithHint(\Throwable $e, string $methodName): \Exception
     {
-        return new \Exception(\sprintf(self::HINT_MESSAGE, $methodName), 0, $e);
+        return new \RuntimeException(\sprintf(self::HINT_MESSAGE, $methodName), 0, $e);
     }
 }

--- a/src/Exceptions/CommunicationException.php
+++ b/src/Exceptions/CommunicationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Exceptions;
 
-class CommunicationException extends \Exception implements \Stringable, ExceptionInterface
+final class CommunicationException extends \Exception implements \Stringable, ExceptionInterface
 {
     public function __toString(): string
     {

--- a/src/Exceptions/InvalidResponseBodyException.php
+++ b/src/Exceptions/InvalidResponseBodyException.php
@@ -6,19 +6,18 @@ namespace Meilisearch\Exceptions;
 
 use Psr\Http\Message\ResponseInterface;
 
-class InvalidResponseBodyException extends \Exception implements \Stringable, ExceptionInterface
+final class InvalidResponseBodyException extends \Exception implements \Stringable, ExceptionInterface
 {
-    public int $httpStatus = 0;
-    public mixed $httpBody;
-    public $message;
+    public readonly int $httpStatus;
 
-    public function __construct(ResponseInterface $response, $httpBody, $previous = null)
-    {
+    public function __construct(
+        public readonly ResponseInterface $response,
+        public readonly mixed $httpBody,
+        ?\Throwable $previous = null,
+    ) {
         $this->httpStatus = $response->getStatusCode();
-        $this->httpBody = $httpBody;
-        $this->message = $this->getMessageFromHttpBody() ?? $response->getReasonPhrase();
 
-        parent::__construct($this->message, $this->httpStatus, $previous);
+        parent::__construct($this->getMessageFromHttpBody() ?? $response->getReasonPhrase(), $this->httpStatus, $previous);
     }
 
     public function __toString(): string

--- a/src/Exceptions/TimeOutException.php
+++ b/src/Exceptions/TimeOutException.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace Meilisearch\Exceptions;
 
-class TimeOutException extends \Exception implements \Stringable, ExceptionInterface
+final class TimeOutException extends \Exception implements \Stringable, ExceptionInterface
 {
-    public $code;
-    public $message;
-
     public function __construct(?string $message = null, ?int $code = null, ?\Throwable $previous = null)
     {
-        $this->message = $message ?? 'Request timed out';
-        $this->code = $code ?? 408;
-
-        parent::__construct($this->message, $this->code, $previous);
+        parent::__construct($message ?? 'Request timed out', $code ?? 408, $previous);
     }
 
     public function __toString(): string

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -30,7 +30,7 @@ final class ApiExceptionTest extends TestCase
             throw new ApiException($response, $httpBodyExample);
         } catch (ApiException $apiException) {
             self::assertSame($statusCode, $apiException->httpStatus);
-            self::assertSame($httpBodyExample['message'], $apiException->message);
+            self::assertSame($httpBodyExample['message'], $apiException->getMessage());
             self::assertSame($httpBodyExample['code'], $apiException->errorCode);
             self::assertSame($httpBodyExample['type'], $apiException->errorType);
             self::assertSame($httpBodyExample['link'], $apiException->errorLink);
@@ -50,7 +50,7 @@ final class ApiExceptionTest extends TestCase
             throw new ApiException($response, null);
         } catch (ApiException $apiException) {
             self::assertSame($statusCode, $apiException->httpStatus);
-            self::assertSame($response->getReasonPhrase(), $apiException->message);
+            self::assertSame($response->getReasonPhrase(), $apiException->getMessage());
             self::assertNull($apiException->errorCode);
             self::assertNull($apiException->errorType);
             self::assertNull($apiException->errorLink);

--- a/tests/Exceptions/InvalidResponseBodyExceptionTest.php
+++ b/tests/Exceptions/InvalidResponseBodyExceptionTest.php
@@ -25,7 +25,7 @@ final class InvalidResponseBodyExceptionTest extends TestCase
             throw new InvalidResponseBodyException($response, $httpBodyExample);
         } catch (InvalidResponseBodyException $invalidResponseBodyException) {
             self::assertSame($statusCode, $invalidResponseBodyException->httpStatus);
-            self::assertSame('Gateway Timeout', $invalidResponseBodyException->message);
+            self::assertSame('Gateway Timeout', $invalidResponseBodyException->getMessage());
 
             $expectedExceptionToString = "Meilisearch InvalidResponseBodyException: Http Status: {$statusCode} - Message: Gateway Timeout";
             self::assertSame($expectedExceptionToString, (string) $invalidResponseBodyException);
@@ -42,7 +42,7 @@ final class InvalidResponseBodyExceptionTest extends TestCase
             throw new InvalidResponseBodyException($response, null);
         } catch (InvalidResponseBodyException $invalidResponseBodyException) {
             self::assertSame($statusCode, $invalidResponseBodyException->httpStatus);
-            self::assertSame($response->getReasonPhrase(), $invalidResponseBodyException->message);
+            self::assertSame($response->getReasonPhrase(), $invalidResponseBodyException->getMessage());
 
             $expectedExceptionToString = "Meilisearch InvalidResponseBodyException: Http Status: {$statusCode} - Message: {$response->getReasonPhrase()}";
             self::assertSame($expectedExceptionToString, (string) $invalidResponseBodyException);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #846

## What does this PR do?
- Adds types to exceptions;
- Adds soft BC Break in `InvalidResponseBodyException`, `TimeOutException` and `ApiException` - message property is protected in base exception class and shouldn't be changed, `getMessage` method should be used.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Exception classes are now marked as final to prevent further subclassing.
  * Exception properties converted to readonly to prevent external modification after instantiation.
  * Constructor property promotion applied to improve encapsulation.
  * Internal error message handling optimized.

* **Tests**
  * Updated test assertions to use standard exception message retrieval methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->