### PR TITLE
Wrap data with `Task` before passing to `TasksResults`

### DIFF
--- a/src/Contracts/TasksResults.php
+++ b/src/Contracts/TasksResults.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class TasksResults extends Data
+final class TasksResults extends Data
 {
     /**
      * @var non-negative-int
@@ -26,14 +26,23 @@ class TasksResults extends Data
      */
     private int $total;
 
+    /**
+     * @param array{
+     *     results: array<int, Task>,
+     *     from: non-negative-int|null,
+     *     limit: non-negative-int,
+     *     next: non-negative-int|null,
+     *     total: non-negative-int
+     * } $params
+     */
     public function __construct(array $params)
     {
-        parent::__construct(isset($params['results']) ? array_map(static fn (array $data) => Task::fromArray($data), $params['results']) : []);
+        parent::__construct($params['results']);
 
         $this->from = $params['from'] ?? 0;
-        $this->limit = $params['limit'] ?? 0;
+        $this->limit = $params['limit'];
         $this->next = $params['next'] ?? 0;
-        $this->total = $params['total'] ?? 0;
+        $this->total = $params['total'];
     }
 
     /**
@@ -76,6 +85,15 @@ class TasksResults extends Data
         return $this->total;
     }
 
+    /**
+     * @return array{
+     *     results: array<int, Task>,
+     *     from: non-negative-int,
+     *     limit: non-negative-int,
+     *     next: non-negative-int,
+     *     total: non-negative-int
+     * }
+     */
     public function toArray(): array
     {
         return [
@@ -85,10 +103,5 @@ class TasksResults extends Data
             'from' => $this->from,
             'total' => $this->total,
         ];
-    }
-
-    public function count(): int
-    {
-        return \count($this->data);
     }
 }

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -22,9 +22,7 @@ trait HandlesTasks
 
     public function getTasks(?TasksQuery $options = null): TasksResults
     {
-        $query = isset($options) ? $options->toArray() : [];
-
-        $response = $this->tasks->all($query);
+        $response = $this->tasks->all($options?->toArray() ?? []);
 
         return new TasksResults($response);
     }

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -178,6 +178,7 @@ class Indexes extends Endpoint
         }
 
         $response = $this->http->get('/tasks', $options->toArray());
+        $response['results'] = array_map(fn (array $task) => Task::fromArray($task, partial(Tasks::waitTask(...), $this->http)), $response['results']);
 
         return new TasksResults($response);
     }

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -22,10 +22,12 @@ class Tasks extends Endpoint
         return Task::fromArray($this->http->get(self::PATH.'/'.$taskUid), partial(self::waitTask(...), $this->http));
     }
 
-    // @todo: must return array<Task>
     public function all(array $query = []): array
     {
-        return $this->http->get(self::PATH.'/', $query);
+        $data = $this->http->get(self::PATH.'/', $query);
+        $data['results'] = array_map(fn (array $task) => Task::fromArray($task, partial(self::waitTask(...), $this->http)), $data['results']);
+
+        return $data;
     }
 
     public function cancelTasks(?CancelTasksQuery $options): Task


### PR DESCRIPTION
# Pull Request

## Related issue
Part of #842

## What does this PR do?
- Wraps tasks arrays with `Task` before passing to `TasksResults`

## Migration guide

### `TasksResults` Constructor

```php
use Meilisearch\Contracts\Task;
use Meilisearch\Contracts\TasksResults;

// Before: Passing raw response data directly
$response = [
    'results' => [
        ['uid' => 1, 'status' => 'succeeded'],
        ['uid' => 2, 'status' => 'processing'],
    ],
    // other parameters
];
$tasksResults = new TasksResults($response);

// After: Data must be mapped to Task objects first
$response = [
    'results' => [
        Task::fromArray(['uid' => 1, 'status' => 'succeeded']),
        Task::fromArray(['uid' => 2, 'status' => 'processing']),
    ],
    // ...
];

$tasksResults = new TasksResults($response);
```

### `Tasks::all()` Return Value

```php
$tasks = $client->tasks->all();

// Before: $tasks['results'] was an array of arrays
// After: $tasks['results'] is now an array of Meilisearch\Contracts\Task objects
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the public count() method from task-results.
  * Task-results payload now requires limit and total fields.
  * Exported task-results array shape and field order updated; "next" behavior clarified.

* **Improvements**
  * Task result entries are now typed Task objects instead of raw arrays.
  * Task-fetching and option handling streamlined for clearer, more readable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->