### PR TITLE
Use `array_key_exists` instead of `isset` in `Task::offsetExists`

### DIFF
--- a/src/Contracts/Task.php
+++ b/src/Contracts/Task.php
@@ -146,7 +146,7 @@ final class Task implements \ArrayAccess
 
     public function offsetExists(mixed $offset): bool
     {
-        return isset($this->raw[$offset]);
+        return \array_key_exists($offset, $this->raw);
     }
 
     public function offsetUnset(mixed $offset): void


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Replaces `isset` with `array_key_exists` to respect null values

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
  - No but coderabbit suggested https://github.com/meilisearch/meilisearch-symfony/pull/432#discussion_r2762266553 
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of task fields that contain null so such fields are treated as present (not missing), preventing incorrect behavior when tasks have null-valued properties and ensuring more accurate task state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->