### PR TITLE
Add support for `showPerformanceDetails` option 

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -274,9 +274,6 @@ class SearchQuery
     /**
      * @return $this
      */
-    /**
-     * @return $this
-     */
     public function setShowPerformanceDetails(?bool $showPerformanceDetails): self
     {
         $this->showPerformanceDetails = $showPerformanceDetails;

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -102,6 +102,8 @@ class SearchQuery
 
     private ?bool $showRankingScoreDetails = null;
 
+    private ?bool $showPerformanceDetails = null;
+
     private ?float $rankingScoreThreshold = null;
 
     /**
@@ -265,6 +267,19 @@ class SearchQuery
     public function setShowRankingScoreDetails(?bool $showRankingScoreDetails): self
     {
         $this->showRankingScoreDetails = $showRankingScoreDetails;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    /**
+     * @return $this
+     */
+    public function setShowPerformanceDetails(?bool $showPerformanceDetails): self
+    {
+        $this->showPerformanceDetails = $showPerformanceDetails;
 
         return $this;
     }
@@ -455,6 +470,7 @@ class SearchQuery
      *     attributesToSearchOn?: non-empty-list<non-empty-string>,
      *     showRankingScore?: bool,
      *     showRankingScoreDetails?: bool,
+     *     showPerformanceDetails?: bool,
      *     rankingScoreThreshold?: float,
      *     distinct?: non-empty-string,
      *     federationOptions?: array<mixed>
@@ -487,6 +503,7 @@ class SearchQuery
             'attributesToSearchOn' => $this->attributesToSearchOn,
             'showRankingScore' => $this->showRankingScore,
             'showRankingScoreDetails' => $this->showRankingScoreDetails,
+            'showPerformanceDetails' => $this->showPerformanceDetails,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
             'federationOptions' => null !== $this->federationOptions ? $this->federationOptions->toArray() : null,

--- a/src/Contracts/SimilarDocumentsQuery.php
+++ b/src/Contracts/SimilarDocumentsQuery.php
@@ -35,6 +35,8 @@ class SimilarDocumentsQuery
 
     private ?bool $showRankingScoreDetails = null;
 
+    private ?bool $showPerformanceDetails = null;
+
     private ?bool $retrieveVectors = null;
 
     /**
@@ -127,6 +129,18 @@ class SimilarDocumentsQuery
     }
 
     /**
+     * @param bool|null $showPerformanceDetails boolean value to show performance details
+     *
+     * @return $this
+     */
+    public function setShowPerformanceDetails(?bool $showPerformanceDetails): self
+    {
+        $this->showPerformanceDetails = $showPerformanceDetails;
+
+        return $this;
+    }
+
+    /**
      * @param bool|null $retrieveVectors boolean value to show _vector details
      *
      * @return $this
@@ -158,6 +172,7 @@ class SimilarDocumentsQuery
      *     attributesToRetrieve?: list<non-empty-string>,
      *     showRankingScore?: bool,
      *     showRankingScoreDetails?: bool,
+     *     showPerformanceDetails?: bool,
      *     retrieveVectors?: bool,
      *     rankingScoreThreshold?: int|float
      * }
@@ -173,6 +188,7 @@ class SimilarDocumentsQuery
             'attributesToRetrieve' => $this->attributesToRetrieve,
             'showRankingScore' => $this->showRankingScore,
             'showRankingScoreDetails' => $this->showRankingScoreDetails,
+            'showPerformanceDetails' => $this->showPerformanceDetails,
             'retrieveVectors' => $this->retrieveVectors,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
         ], static function ($item) {return null !== $item; });

--- a/tests/Contracts/SearchQueryTest.php
+++ b/tests/Contracts/SearchQueryTest.php
@@ -216,6 +216,17 @@ final class SearchQueryTest extends TestCase
         self::assertSame(['showRankingScoreDetails' => $value], $data->toArray());
     }
 
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testSetShowPerformanceDetails(?bool $value): void
+    {
+        $data = (new SearchQuery())->setShowPerformanceDetails($value);
+
+        self::assertSame(['showPerformanceDetails' => $value], $data->toArray());
+    }
+
     public function testSetRankingScoreThreshold(): void
     {
         $data = (new SearchQuery())->setRankingScoreThreshold(0.123);

--- a/tests/Contracts/SimilarDocumentsQueryTest.php
+++ b/tests/Contracts/SimilarDocumentsQueryTest.php
@@ -80,6 +80,17 @@ final class SimilarDocumentsQueryTest extends TestCase
      * @testWith [false]
      *           [true]
      */
+    public function testSetShowPerformanceDetails(bool $showPerformanceDetails): void
+    {
+        $data = (new SimilarDocumentsQuery('test', 'default'))->setShowPerformanceDetails($showPerformanceDetails);
+
+        self::assertSame(['id' => 'test', 'embedder' => 'default', 'showPerformanceDetails' => $showPerformanceDetails], $data->toArray());
+    }
+
+    /**
+     * @testWith [false]
+     *           [true]
+     */
     public function testSetRetrieveVectors(bool $retrieveVectors): void
     {
         $data = (new SimilarDocumentsQuery('test', 'default'))->setRetrieveVectors($retrieveVectors);


### PR DESCRIPTION
## Description

Resolves #866

Adds the `showPerformanceDetails` option introduced in [Meilisearch v1.35.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.35.0) to search endpoints.

## Changes

- Added `showPerformanceDetails` property and setter to `SearchQuery` (used by search and multi-search)
- Added `showPerformanceDetails` property and setter to `SimilarDocumentsQuery`
- Added unit tests for both classes
- The response `performanceDetails` object is returned as raw data (no accessors/types), as specified in the issue

## Usage

```php
// Single search
$index->search('query', ['showPerformanceDetails' => true]);

// Multi-search
$query = (new SearchQuery())
    ->setIndexUid('movies')
    ->setQuery('batman')
    ->setShowPerformanceDetails(true);
$client->multiSearch([$query]);

// Similar documents
$query = (new SimilarDocumentsQuery(1, 'default'))
    ->setShowPerformanceDetails(true);
$index->searchSimilarDocuments($query);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and similar documents queries now support an optional performance-details flag to include performance metrics with results (configurable per request).

* **Tests**
  * Added tests to cover the new performance-details configuration for both search and similar-documents queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->