### PR TITLE
Make network API compatible with Meilisearch v1.37

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.36.0
+    image: getmeili/meilisearch-enterprise:v1.37.0
     ports:
       - "7700"
     environment:

--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -52,7 +52,7 @@ class NetworkResults extends Data
         $this->leader = $params['leader'] ?? null;
         $this->version = $params['version'] ?? null;
         $this->remotes = $params['remotes'] ?? [];
-        $this->shards = $this->normalizeShards($params['shards'] ?? []);
+        $this->shards = $params['shards'] ?? [];
     }
 
     /**
@@ -93,34 +93,5 @@ class NetworkResults extends Data
     public function getShards(): array
     {
         return $this->shards;
-    }
-
-    /**
-     * @param array<non-empty-string, array{remotes: list<non-empty-string>}> $shards
-     *
-     * @return array<non-empty-string, Shard>
-     */
-    private function normalizeShards(array $shards): array
-    {
-        $normalized = [];
-
-        foreach ($shards as $name => $definition) {
-            if (!\is_array($definition)) {
-                continue;
-            }
-
-            $remotes = $definition['remotes'] ?? [];
-
-            if (!\is_array($remotes)) {
-                $remotes = [];
-            }
-
-            /** @var list<non-empty-string> $remoteList */
-            $remoteList = array_values(array_filter($remotes, static fn ($remote): bool => \is_string($remote) && $remote !== ''));
-
-            $normalized[$name] = ['remotes' => $remoteList];
-        }
-
-        return $normalized;
     }
 }

--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -6,7 +6,7 @@ namespace Meilisearch\Contracts;
 
 /**
  * @phpstan-type RemoteConfig array{url: non-empty-string, searchApiKey: non-empty-string, writeApiKey: non-empty-string}
- * @phpstan-type Shard array{remotes: list<non-empty-string>}
+ * @phpstan-type ShardConfig array{remotes: list<non-empty-string>}
  */
 class NetworkResults extends Data
 {
@@ -31,7 +31,7 @@ class NetworkResults extends Data
     private array $remotes;
 
     /**
-     * @var array<non-empty-string, Shard> a mapping of shard names to their remote owners
+     * @var array<non-empty-string, ShardConfig> a mapping of shard names to their remote owners
      */
     private array $shards;
 
@@ -41,7 +41,7 @@ class NetworkResults extends Data
      *     leader?: non-empty-string|null,
      *     version?: non-empty-string|null,
      *     remotes?: array<non-empty-string, RemoteConfig|null>,
-     *     shards?: array<non-empty-string, array{remotes: list<non-empty-string>}>
+     *     shards?: array<non-empty-string, ShardConfig>
      * } $params
      */
     public function __construct(array $params)
@@ -88,7 +88,7 @@ class NetworkResults extends Data
     }
 
     /**
-     * @return array<non-empty-string, Shard>
+     * @return array<non-empty-string, ShardConfig>
      */
     public function getShards(): array
     {

--- a/src/Contracts/NetworkResults.php
+++ b/src/Contracts/NetworkResults.php
@@ -6,6 +6,7 @@ namespace Meilisearch\Contracts;
 
 /**
  * @phpstan-type RemoteConfig array{url: non-empty-string, searchApiKey: non-empty-string, writeApiKey: non-empty-string}
+ * @phpstan-type Shard array{remotes: list<non-empty-string>}
  */
 class NetworkResults extends Data
 {
@@ -30,11 +31,17 @@ class NetworkResults extends Data
     private array $remotes;
 
     /**
+     * @var array<non-empty-string, Shard> a mapping of shard names to their remote owners
+     */
+    private array $shards;
+
+    /**
      * @param array{
      *     self?: non-empty-string|null,
      *     leader?: non-empty-string|null,
      *     version?: non-empty-string|null,
-     *     remotes?: array<non-empty-string, RemoteConfig|null>
+     *     remotes?: array<non-empty-string, RemoteConfig|null>,
+     *     shards?: array<non-empty-string, array{remotes: list<non-empty-string>}>
      * } $params
      */
     public function __construct(array $params)
@@ -45,6 +52,7 @@ class NetworkResults extends Data
         $this->leader = $params['leader'] ?? null;
         $this->version = $params['version'] ?? null;
         $this->remotes = $params['remotes'] ?? [];
+        $this->shards = $this->normalizeShards($params['shards'] ?? []);
     }
 
     /**
@@ -77,5 +85,42 @@ class NetworkResults extends Data
     public function getRemotes(): array
     {
         return $this->remotes;
+    }
+
+    /**
+     * @return array<non-empty-string, Shard>
+     */
+    public function getShards(): array
+    {
+        return $this->shards;
+    }
+
+    /**
+     * @param array<non-empty-string, array{remotes: list<non-empty-string>}> $shards
+     *
+     * @return array<non-empty-string, Shard>
+     */
+    private function normalizeShards(array $shards): array
+    {
+        $normalized = [];
+
+        foreach ($shards as $name => $definition) {
+            if (!\is_array($definition)) {
+                continue;
+            }
+
+            $remotes = $definition['remotes'] ?? [];
+
+            if (!\is_array($remotes)) {
+                $remotes = [];
+            }
+
+            /** @var list<non-empty-string> $remoteList */
+            $remoteList = array_values(array_filter($remotes, static fn ($remote): bool => \is_string($remote) && $remote !== ''));
+
+            $normalized[$name] = ['remotes' => $remoteList];
+        }
+
+        return $normalized;
     }
 }

--- a/src/Endpoints/Delegates/HandlesNetwork.php
+++ b/src/Endpoints/Delegates/HandlesNetwork.php
@@ -10,6 +10,7 @@ use Meilisearch\Endpoints\Network;
 
 /**
  * @phpstan-import-type RemoteConfig from NetworkResults
+ * @phpstan-import-type ShardConfig from \Meilisearch\Endpoints\Network
  */
 trait HandlesNetwork
 {
@@ -27,7 +28,9 @@ trait HandlesNetwork
      *
      * @param array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, RemoteConfig>
+     *     leader: non-empty-string,
+     *     remotes: array<non-empty-string, RemoteConfig>,
+     *     shards: array<non-empty-string, ShardConfig>,
      * } $options
      */
     public function initializeNetwork(array $options): Task
@@ -54,5 +57,23 @@ trait HandlesNetwork
     public function removeRemote(string $name): Task
     {
         return $this->network->removeRemote($name);
+    }
+
+    /**
+     * @param non-empty-string      $shardName
+     * @param list<non-empty-string> $remoteNames
+     */
+    public function addRemotesToShard(string $shardName, array $remoteNames): Task
+    {
+        return $this->network->addRemotesToShard($shardName, $remoteNames);
+    }
+
+    /**
+     * @param non-empty-string      $shardName
+     * @param list<non-empty-string> $remoteNames
+     */
+    public function removeRemotesFromShard(string $shardName, array $remoteNames): Task
+    {
+        return $this->network->removeRemotesFromShard($shardName, $remoteNames);
     }
 }

--- a/src/Endpoints/Delegates/HandlesNetwork.php
+++ b/src/Endpoints/Delegates/HandlesNetwork.php
@@ -60,7 +60,7 @@ trait HandlesNetwork
     }
 
     /**
-     * @param non-empty-string      $shardName
+     * @param non-empty-string       $shardName
      * @param list<non-empty-string> $remoteNames
      */
     public function addRemotesToShard(string $shardName, array $remoteNames): Task
@@ -69,7 +69,7 @@ trait HandlesNetwork
     }
 
     /**
-     * @param non-empty-string      $shardName
+     * @param non-empty-string       $shardName
      * @param list<non-empty-string> $remoteNames
      */
     public function removeRemotesFromShard(string $shardName, array $remoteNames): Task

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints;
 
-use InvalidArgumentException;
 use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\NetworkResults;
 use Meilisearch\Contracts\Task;
@@ -13,6 +12,7 @@ use function Meilisearch\partial;
 
 /**
  * @phpstan-import-type RemoteConfig from NetworkResults
+ *
  * @phpstan-type ShardConfig array{
  *   remotes?: list<non-empty-string>,
  *   addRemotes?: list<non-empty-string>,
@@ -98,7 +98,7 @@ class Network extends Endpoint
     }
 
     /**
-     * @param non-empty-string   $shardName
+     * @param non-empty-string       $shardName
      * @param list<non-empty-string> $remoteNames
      */
     public function addRemotesToShard(string $shardName, array $remoteNames): Task
@@ -116,7 +116,7 @@ class Network extends Endpoint
     }
 
     /**
-     * @param non-empty-string   $shardName
+     * @param non-empty-string       $shardName
      * @param list<non-empty-string> $remoteNames
      */
     public function removeRemotesFromShard(string $shardName, array $remoteNames): Task
@@ -148,42 +148,42 @@ class Network extends Endpoint
         $remotes = $options['remotes'] ?? null;
         $shards = $options['shards'] ?? null;
 
-        if (!\is_array($remotes) || $remotes === []) {
-            throw new InvalidArgumentException('remotes must be a non-empty array of remote definitions.');
+        if (!\is_array($remotes) || [] === $remotes) {
+            throw new \InvalidArgumentException('remotes must be a non-empty array of remote definitions.');
         }
 
         $validatedRemotes = $this->validateRemotes($remotes);
 
-        if (!array_key_exists($options['self'], $validatedRemotes)) {
-            throw new InvalidArgumentException('self must be one of the defined remotes.');
+        if (!\array_key_exists($options['self'], $validatedRemotes)) {
+            throw new \InvalidArgumentException('self must be one of the defined remotes.');
         }
 
-        if (!array_key_exists($options['leader'], $validatedRemotes)) {
-            throw new InvalidArgumentException('leader must be one of the defined remotes.');
+        if (!\array_key_exists($options['leader'], $validatedRemotes)) {
+            throw new \InvalidArgumentException('leader must be one of the defined remotes.');
         }
 
-        if (!\is_array($shards) || $shards === []) {
-            throw new InvalidArgumentException('shards must be a non-empty array.');
+        if (!\is_array($shards) || [] === $shards) {
+            throw new \InvalidArgumentException('shards must be a non-empty array.');
         }
 
         foreach ($shards as $shardName => $definition) {
             $this->assertNonEmptyString($shardName, 'shard name');
 
             if (!\is_array($definition)) {
-                throw new InvalidArgumentException('shard definition must be an array with remotes.');
+                throw new \InvalidArgumentException('shard definition must be an array with remotes.');
             }
 
             $remotesList = $definition['remotes'] ?? null;
 
-            if (!\is_array($remotesList) || $remotesList === []) {
-                throw new InvalidArgumentException('each shard must define at least one remote.');
+            if (!\is_array($remotesList) || [] === $remotesList) {
+                throw new \InvalidArgumentException('each shard must define at least one remote.');
             }
 
             foreach ($remotesList as $remoteName) {
                 $this->assertNonEmptyString($remoteName, 'shard remote');
 
-                if (!array_key_exists($remoteName, $validatedRemotes)) {
-                    throw new InvalidArgumentException(sprintf('shard references unknown remote "%s".', $remoteName));
+                if (!\array_key_exists($remoteName, $validatedRemotes)) {
+                    throw new \InvalidArgumentException(\sprintf('shard references unknown remote "%s".', $remoteName));
                 }
             }
         }
@@ -202,16 +202,16 @@ class Network extends Endpoint
             $this->assertNonEmptyString($name, 'remote name');
 
             if (!\is_array($config)) {
-                throw new InvalidArgumentException('remote configuration must be an array.');
+                throw new \InvalidArgumentException('remote configuration must be an array.');
             }
 
             foreach (['url', 'searchApiKey', 'writeApiKey'] as $field) {
-                if (!\is_string($config[$field] ?? null) || $config[$field] === '') {
-                    throw new InvalidArgumentException(sprintf('remote "%s" is missing a valid %s.', $name, $field));
+                if (!\is_string($config[$field] ?? null) || '' === $config[$field]) {
+                    throw new \InvalidArgumentException(\sprintf('remote "%s" is missing a valid %s.', $name, $field));
                 }
             }
 
-            /** @var RemoteConfig $config */
+            /* @var RemoteConfig $config */
             $validated[$name] = $config;
         }
 
@@ -225,8 +225,8 @@ class Network extends Endpoint
      */
     private function assertRemoteNames(array $remoteNames): array
     {
-        if ($remoteNames === []) {
-            throw new InvalidArgumentException('remoteNames must be a non-empty list of strings.');
+        if ([] === $remoteNames) {
+            throw new \InvalidArgumentException('remoteNames must be a non-empty list of strings.');
         }
 
         $list = [];
@@ -241,8 +241,8 @@ class Network extends Endpoint
 
     private function assertNonEmptyString(mixed $value, string $field): void
     {
-        if (!\is_string($value) || $value === '') {
-            throw new InvalidArgumentException(sprintf('%s must be a non-empty string.', $field));
+        if (!\is_string($value) || '' === $value) {
+            throw new \InvalidArgumentException(\sprintf('%s must be a non-empty string.', $field));
         }
     }
 

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -190,7 +190,7 @@ class Network extends Endpoint
     }
 
     /**
-     * @param array<non-empty-string, RemoteConfig> $remotes
+     * @param array<non-empty-string, mixed> $remotes
      *
      * @return array<non-empty-string, RemoteConfig>
      */
@@ -206,7 +206,7 @@ class Network extends Endpoint
             }
 
             foreach (['url', 'searchApiKey', 'writeApiKey'] as $field) {
-                if (!\is_string($config[$field] ?? null) || '' === $config[$field]) {
+                if (!isset($config[$field]) || !\is_string($config[$field]) || '' === $config[$field]) {
                     throw new \InvalidArgumentException(\sprintf('remote "%s" is missing a valid %s.', $name, $field));
                 }
             }

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -47,8 +47,6 @@ class Network extends Endpoint
      */
     public function initialize(array $options): Task
     {
-        $this->validateInitializeOptions($options);
-
         $body = [
             'self' => $options['self'],
             'leader' => $options['leader'],
@@ -67,9 +65,6 @@ class Network extends Endpoint
      */
     public function addRemote(string $name, array $remote): Task
     {
-        $this->assertNonEmptyString($name, 'remote name');
-        $this->validateRemotes([$name => $remote]);
-
         $body = [
             'remotes' => [
                 $name => $remote,
@@ -86,8 +81,6 @@ class Network extends Endpoint
      */
     public function removeRemote(string $name): Task
     {
-        $this->assertNonEmptyString($name, 'remote name');
-
         $body = [
             'remotes' => [
                 $name => null,
@@ -103,12 +96,9 @@ class Network extends Endpoint
      */
     public function addRemotesToShard(string $shardName, array $remoteNames): Task
     {
-        $this->assertNonEmptyString($shardName, 'shardName');
-        $remoteList = $this->assertRemoteNames($remoteNames);
-
         $body = [
             'shards' => [
-                $shardName => ['addRemotes' => $remoteList],
+                $shardName => ['addRemotes' => $remoteNames],
             ],
         ];
 
@@ -121,129 +111,13 @@ class Network extends Endpoint
      */
     public function removeRemotesFromShard(string $shardName, array $remoteNames): Task
     {
-        $this->assertNonEmptyString($shardName, 'shardName');
-        $remoteList = $this->assertRemoteNames($remoteNames);
-
         $body = [
             'shards' => [
-                $shardName => ['removeRemotes' => $remoteList],
+                $shardName => ['removeRemotes' => $remoteNames],
             ],
         ];
 
         return $this->dispatchPatch($body);
-    }
-
-    /**
-     * @param array{
-     *     self: mixed,
-     *     leader: mixed,
-     *     remotes: mixed,
-     *     shards: mixed,
-     * } $options
-     */
-    private function validateInitializeOptions(array $options): void
-    {
-        $this->assertNonEmptyString($options['self'] ?? null, 'self');
-        $this->assertNonEmptyString($options['leader'] ?? null, 'leader');
-        $remotes = $options['remotes'] ?? null;
-        $shards = $options['shards'] ?? null;
-
-        if (!\is_array($remotes) || [] === $remotes) {
-            throw new \InvalidArgumentException('remotes must be a non-empty array of remote definitions.');
-        }
-
-        $validatedRemotes = $this->validateRemotes($remotes);
-
-        if (!\array_key_exists($options['self'], $validatedRemotes)) {
-            throw new \InvalidArgumentException('self must be one of the defined remotes.');
-        }
-
-        if (!\array_key_exists($options['leader'], $validatedRemotes)) {
-            throw new \InvalidArgumentException('leader must be one of the defined remotes.');
-        }
-
-        if (!\is_array($shards) || [] === $shards) {
-            throw new \InvalidArgumentException('shards must be a non-empty array.');
-        }
-
-        foreach ($shards as $shardName => $definition) {
-            $this->assertNonEmptyString($shardName, 'shard name');
-
-            if (!\is_array($definition)) {
-                throw new \InvalidArgumentException('shard definition must be an array with remotes.');
-            }
-
-            $remotesList = $definition['remotes'] ?? null;
-
-            if (!\is_array($remotesList) || [] === $remotesList) {
-                throw new \InvalidArgumentException('each shard must define at least one remote.');
-            }
-
-            foreach ($remotesList as $remoteName) {
-                $this->assertNonEmptyString($remoteName, 'shard remote');
-
-                if (!\array_key_exists($remoteName, $validatedRemotes)) {
-                    throw new \InvalidArgumentException(\sprintf('shard references unknown remote "%s".', $remoteName));
-                }
-            }
-        }
-    }
-
-    /**
-     * @param array<non-empty-string, mixed> $remotes
-     *
-     * @return array<non-empty-string, RemoteConfig>
-     */
-    private function validateRemotes(array $remotes): array
-    {
-        $validated = [];
-
-        foreach ($remotes as $name => $config) {
-            $this->assertNonEmptyString($name, 'remote name');
-
-            if (!\is_array($config)) {
-                throw new \InvalidArgumentException('remote configuration must be an array.');
-            }
-
-            foreach (['url', 'searchApiKey', 'writeApiKey'] as $field) {
-                if (!isset($config[$field]) || !\is_string($config[$field]) || '' === $config[$field]) {
-                    throw new \InvalidArgumentException(\sprintf('remote "%s" is missing a valid %s.', $name, $field));
-                }
-            }
-
-            /* @var RemoteConfig $config */
-            $validated[$name] = $config;
-        }
-
-        return $validated;
-    }
-
-    /**
-     * @param list<mixed> $remoteNames
-     *
-     * @return list<non-empty-string>
-     */
-    private function assertRemoteNames(array $remoteNames): array
-    {
-        if ([] === $remoteNames) {
-            throw new \InvalidArgumentException('remoteNames must be a non-empty list of strings.');
-        }
-
-        $list = [];
-
-        foreach ($remoteNames as $name) {
-            $this->assertNonEmptyString($name, 'remote name');
-            $list[] = $name;
-        }
-
-        return $list;
-    }
-
-    private function assertNonEmptyString(mixed $value, string $field): void
-    {
-        if (!\is_string($value) || '' === $value) {
-            throw new \InvalidArgumentException(\sprintf('%s must be a non-empty string.', $field));
-        }
     }
 
     /**

--- a/src/Endpoints/Network.php
+++ b/src/Endpoints/Network.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints;
 
+use InvalidArgumentException;
 use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\NetworkResults;
 use Meilisearch\Contracts\Task;
@@ -12,6 +13,11 @@ use function Meilisearch\partial;
 
 /**
  * @phpstan-import-type RemoteConfig from NetworkResults
+ * @phpstan-type ShardConfig array{
+ *   remotes?: list<non-empty-string>,
+ *   addRemotes?: list<non-empty-string>,
+ *   removeRemotes?: list<non-empty-string>
+ * }
  */
 class Network extends Endpoint
 {
@@ -22,7 +28,8 @@ class Network extends Endpoint
      *     self?: non-empty-string|null,
      *     leader?: non-empty-string|null,
      *     version?: non-empty-string|null,
-     *     remotes?: array<non-empty-string, RemoteConfig|null>
+     *     remotes?: array<non-empty-string, RemoteConfig|null>,
+     *     shards?: array<non-empty-string, array{remotes: list<non-empty-string>}>
      * }
      */
     public function get(): array
@@ -31,22 +38,25 @@ class Network extends Endpoint
     }
 
     /**
-     * Initialize a network with the current instance as leader.
-     *
      * @param array{
      *     self: non-empty-string,
-     *     remotes: array<non-empty-string, RemoteConfig>
+     *     leader: non-empty-string,
+     *     remotes: array<non-empty-string, RemoteConfig>,
+     *     shards: array<non-empty-string, ShardConfig>,
      * } $options
      */
     public function initialize(array $options): Task
     {
+        $this->validateInitializeOptions($options);
+
         $body = [
             'self' => $options['self'],
-            'leader' => $options['self'],
+            'leader' => $options['leader'],
             'remotes' => $options['remotes'],
+            'shards' => $options['shards'],
         ];
 
-        return Task::fromArray($this->http->patch(self::PATH, $body), partial(Tasks::waitTask(...), $this->http));
+        return $this->dispatchPatch($body);
     }
 
     /**
@@ -57,13 +67,16 @@ class Network extends Endpoint
      */
     public function addRemote(string $name, array $remote): Task
     {
+        $this->assertNonEmptyString($name, 'remote name');
+        $this->validateRemotes([$name => $remote]);
+
         $body = [
             'remotes' => [
                 $name => $remote,
             ],
         ];
 
-        return Task::fromArray($this->http->patch(self::PATH, $body), partial(Tasks::waitTask(...), $this->http));
+        return $this->dispatchPatch($body);
     }
 
     /**
@@ -73,12 +86,171 @@ class Network extends Endpoint
      */
     public function removeRemote(string $name): Task
     {
+        $this->assertNonEmptyString($name, 'remote name');
+
         $body = [
             'remotes' => [
                 $name => null,
             ],
         ];
 
+        return $this->dispatchPatch($body);
+    }
+
+    /**
+     * @param non-empty-string   $shardName
+     * @param list<non-empty-string> $remoteNames
+     */
+    public function addRemotesToShard(string $shardName, array $remoteNames): Task
+    {
+        $this->assertNonEmptyString($shardName, 'shardName');
+        $remoteList = $this->assertRemoteNames($remoteNames);
+
+        $body = [
+            'shards' => [
+                $shardName => ['addRemotes' => $remoteList],
+            ],
+        ];
+
+        return $this->dispatchPatch($body);
+    }
+
+    /**
+     * @param non-empty-string   $shardName
+     * @param list<non-empty-string> $remoteNames
+     */
+    public function removeRemotesFromShard(string $shardName, array $remoteNames): Task
+    {
+        $this->assertNonEmptyString($shardName, 'shardName');
+        $remoteList = $this->assertRemoteNames($remoteNames);
+
+        $body = [
+            'shards' => [
+                $shardName => ['removeRemotes' => $remoteList],
+            ],
+        ];
+
+        return $this->dispatchPatch($body);
+    }
+
+    /**
+     * @param array{
+     *     self: mixed,
+     *     leader: mixed,
+     *     remotes: mixed,
+     *     shards: mixed,
+     * } $options
+     */
+    private function validateInitializeOptions(array $options): void
+    {
+        $this->assertNonEmptyString($options['self'] ?? null, 'self');
+        $this->assertNonEmptyString($options['leader'] ?? null, 'leader');
+        $remotes = $options['remotes'] ?? null;
+        $shards = $options['shards'] ?? null;
+
+        if (!\is_array($remotes) || $remotes === []) {
+            throw new InvalidArgumentException('remotes must be a non-empty array of remote definitions.');
+        }
+
+        $validatedRemotes = $this->validateRemotes($remotes);
+
+        if (!array_key_exists($options['self'], $validatedRemotes)) {
+            throw new InvalidArgumentException('self must be one of the defined remotes.');
+        }
+
+        if (!array_key_exists($options['leader'], $validatedRemotes)) {
+            throw new InvalidArgumentException('leader must be one of the defined remotes.');
+        }
+
+        if (!\is_array($shards) || $shards === []) {
+            throw new InvalidArgumentException('shards must be a non-empty array.');
+        }
+
+        foreach ($shards as $shardName => $definition) {
+            $this->assertNonEmptyString($shardName, 'shard name');
+
+            if (!\is_array($definition)) {
+                throw new InvalidArgumentException('shard definition must be an array with remotes.');
+            }
+
+            $remotesList = $definition['remotes'] ?? null;
+
+            if (!\is_array($remotesList) || $remotesList === []) {
+                throw new InvalidArgumentException('each shard must define at least one remote.');
+            }
+
+            foreach ($remotesList as $remoteName) {
+                $this->assertNonEmptyString($remoteName, 'shard remote');
+
+                if (!array_key_exists($remoteName, $validatedRemotes)) {
+                    throw new InvalidArgumentException(sprintf('shard references unknown remote "%s".', $remoteName));
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array<non-empty-string, RemoteConfig> $remotes
+     *
+     * @return array<non-empty-string, RemoteConfig>
+     */
+    private function validateRemotes(array $remotes): array
+    {
+        $validated = [];
+
+        foreach ($remotes as $name => $config) {
+            $this->assertNonEmptyString($name, 'remote name');
+
+            if (!\is_array($config)) {
+                throw new InvalidArgumentException('remote configuration must be an array.');
+            }
+
+            foreach (['url', 'searchApiKey', 'writeApiKey'] as $field) {
+                if (!\is_string($config[$field] ?? null) || $config[$field] === '') {
+                    throw new InvalidArgumentException(sprintf('remote "%s" is missing a valid %s.', $name, $field));
+                }
+            }
+
+            /** @var RemoteConfig $config */
+            $validated[$name] = $config;
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @param list<mixed> $remoteNames
+     *
+     * @return list<non-empty-string>
+     */
+    private function assertRemoteNames(array $remoteNames): array
+    {
+        if ($remoteNames === []) {
+            throw new InvalidArgumentException('remoteNames must be a non-empty list of strings.');
+        }
+
+        $list = [];
+
+        foreach ($remoteNames as $name) {
+            $this->assertNonEmptyString($name, 'remote name');
+            $list[] = $name;
+        }
+
+        return $list;
+    }
+
+    private function assertNonEmptyString(mixed $value, string $field): void
+    {
+        if (!\is_string($value) || $value === '') {
+            throw new InvalidArgumentException(sprintf('%s must be a non-empty string.', $field));
+        }
+    }
+
+    /**
+     * @param array<mixed> $body
+     */
+    private function dispatchPatch(array $body): Task
+    {
         return Task::fromArray($this->http->patch(self::PATH, $body), partial(Tasks::waitTask(...), $this->http));
     }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -18,7 +18,7 @@ final class NetworksTest extends TestCase
         $http->patch('/experimental-features', ['network' => true]);
     }
 
-    public function testInitializeNetworkWithExplicitShards(): void
+    public function testInitializeNetwork(): void
     {
         $apiKey = getenv('MEILISEARCH_API_KEY');
         $instanceName = 'ms-00';

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -18,7 +18,7 @@ final class NetworksTest extends TestCase
         $http->patch('/experimental-features', ['network' => true]);
     }
 
-    public function testInitializeNetwork(): void
+    public function testInitializeNetworkRequiresLeader(): void
     {
         $apiKey = getenv('MEILISEARCH_API_KEY');
         $instanceName = 'ms-00';
@@ -31,6 +31,78 @@ final class NetworksTest extends TestCase
                     'searchApiKey' => $apiKey,
                     'writeApiKey' => $apiKey,
                 ],
+            ],
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->client->initializeNetwork($options);
+    }
+
+    public function testInitializeNetworkRejectsShardWithUnknownRemote(): void
+    {
+        $apiKey = getenv('MEILISEARCH_API_KEY');
+        $instanceName = 'ms-00';
+
+        $options = [
+            'self' => $instanceName,
+            'leader' => $instanceName,
+            'remotes' => [
+                $instanceName => [
+                    'url' => $this->host,
+                    'searchApiKey' => $apiKey,
+                    'writeApiKey' => $apiKey,
+                ],
+            ],
+            'shards' => [
+                's-a' => ['remotes' => ['unknown-remote']],
+            ],
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->client->initializeNetwork($options);
+    }
+
+    public function testInitializeNetworkRejectsEmptyShardRemotes(): void
+    {
+        $apiKey = getenv('MEILISEARCH_API_KEY');
+        $instanceName = 'ms-00';
+
+        $options = [
+            'self' => $instanceName,
+            'leader' => $instanceName,
+            'remotes' => [
+                $instanceName => [
+                    'url' => $this->host,
+                    'searchApiKey' => $apiKey,
+                    'writeApiKey' => $apiKey,
+                ],
+            ],
+            'shards' => [
+                's-a' => ['remotes' => []],
+            ],
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->client->initializeNetwork($options);
+    }
+
+    public function testInitializeNetworkWithExplicitShards(): void
+    {
+        $apiKey = getenv('MEILISEARCH_API_KEY');
+        $instanceName = 'ms-00';
+
+        $options = [
+            'self' => $instanceName,
+            'leader' => $instanceName,
+            'remotes' => [
+                $instanceName => [
+                    'url' => $this->host,
+                    'searchApiKey' => $apiKey,
+                    'writeApiKey' => $apiKey,
+                ],
+            ],
+            'shards' => [
+                's-a' => ['remotes' => [$instanceName]],
             ],
         ];
 
@@ -50,5 +122,46 @@ final class NetworksTest extends TestCase
         self::assertSame($this->host, $remotes[$instanceName]['url']);
         self::assertSame($apiKey, $remotes[$instanceName]['searchApiKey']);
         self::assertSame($apiKey, $remotes[$instanceName]['writeApiKey']);
+
+        $shards = $network->getShards();
+        self::assertArrayHasKey('s-a', $shards);
+        self::assertEqualsCanonicalizing([$instanceName], $shards['s-a']['remotes']);
+    }
+
+    public function testAddAndRemoveRemotesOnShard(): void
+    {
+        $apiKey = getenv('MEILISEARCH_API_KEY');
+        $leader = 'ms-00';
+
+        $options = [
+            'self' => $leader,
+            'leader' => $leader,
+            'remotes' => [
+                $leader => [
+                    'url' => $this->host,
+                    'searchApiKey' => $apiKey,
+                    'writeApiKey' => $apiKey,
+                ],
+            ],
+            'shards' => [
+                's-a' => ['remotes' => [$leader]],
+            ],
+        ];
+
+        $task = $this->client->initializeNetwork($options);
+        self::assertSame(TaskType::NetworkTopologyChange, $task->getType());
+        $task->wait();
+
+        $addTask = $this->client->addRemotesToShard('s-a', [$leader]);
+        self::assertSame(TaskType::NetworkTopologyChange, $addTask->getType());
+        $addTask->wait();
+
+        $afterAdd = $this->client->getNetwork();
+        $shardsAfterAdd = $afterAdd->getShards();
+        self::assertArrayHasKey('s-a', $shardsAfterAdd);
+        self::assertEqualsCanonicalizing([$leader], $shardsAfterAdd['s-a']['remotes']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->client->removeRemotesFromShard('s-a', []);
     }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -18,75 +18,6 @@ final class NetworksTest extends TestCase
         $http->patch('/experimental-features', ['network' => true]);
     }
 
-    public function testInitializeNetworkRequiresLeader(): void
-    {
-        $apiKey = getenv('MEILISEARCH_API_KEY');
-        $instanceName = 'ms-00';
-
-        $options = [
-            'self' => $instanceName,
-            'remotes' => [
-                $instanceName => [
-                    'url' => $this->host,
-                    'searchApiKey' => $apiKey,
-                    'writeApiKey' => $apiKey,
-                ],
-            ],
-        ];
-
-        $this->expectException(\InvalidArgumentException::class);
-        /* @phpstan-ignore-next-line intentional invalid input to test validation */
-        $this->client->initializeNetwork($options);
-    }
-
-    public function testInitializeNetworkRejectsShardWithUnknownRemote(): void
-    {
-        $apiKey = getenv('MEILISEARCH_API_KEY');
-        $instanceName = 'ms-00';
-
-        $options = [
-            'self' => $instanceName,
-            'leader' => $instanceName,
-            'remotes' => [
-                $instanceName => [
-                    'url' => $this->host,
-                    'searchApiKey' => $apiKey,
-                    'writeApiKey' => $apiKey,
-                ],
-            ],
-            'shards' => [
-                's-a' => ['remotes' => ['unknown-remote']],
-            ],
-        ];
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->client->initializeNetwork($options);
-    }
-
-    public function testInitializeNetworkRejectsEmptyShardRemotes(): void
-    {
-        $apiKey = getenv('MEILISEARCH_API_KEY');
-        $instanceName = 'ms-00';
-
-        $options = [
-            'self' => $instanceName,
-            'leader' => $instanceName,
-            'remotes' => [
-                $instanceName => [
-                    'url' => $this->host,
-                    'searchApiKey' => $apiKey,
-                    'writeApiKey' => $apiKey,
-                ],
-            ],
-            'shards' => [
-                's-a' => ['remotes' => []],
-            ],
-        ];
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->client->initializeNetwork($options);
-    }
-
     public function testInitializeNetworkWithExplicitShards(): void
     {
         $apiKey = getenv('MEILISEARCH_API_KEY');
@@ -161,8 +92,5 @@ final class NetworksTest extends TestCase
         $shardsAfterAdd = $afterAdd->getShards();
         self::assertArrayHasKey('s-a', $shardsAfterAdd);
         self::assertEqualsCanonicalizing([$leader], $shardsAfterAdd['s-a']['remotes']);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->client->removeRemotesFromShard('s-a', []);
     }
 }

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -35,6 +35,7 @@ final class NetworksTest extends TestCase
         ];
 
         $this->expectException(\InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line intentional invalid input to test validation */
         $this->client->initializeNetwork($options);
     }
 

--- a/tests/Endpoints/NetworksTest.php
+++ b/tests/Endpoints/NetworksTest.php
@@ -35,7 +35,7 @@ final class NetworksTest extends TestCase
         ];
 
         $this->expectException(\InvalidArgumentException::class);
-        /** @phpstan-ignore-next-line intentional invalid input to test validation */
+        /* @phpstan-ignore-next-line intentional invalid input to test validation */
         $this->client->initializeNetwork($options);
     }
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #886 

## What does this PR do?

- **Aligns the network API with Meilisearch v1.37**: 
  - Supports the new shard-based topology for `PATCH /network` 
  - Add methods to interact with shards: `addRemotesToShard(string $shardName, array $remoteNames)` and `removeRemotesFromShard(string $shardName, array $remoteNames)` 
- **Pins Meilisearch runtime to v1.37.0 for local runs**: `docker-compose.yml` uses `getmeili/meilisearch-enterprise:v1.37.0` 

## AI disclosure

Cursor with `gpt-5.1-high` and `gpt-5.1-codex-max` models

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shard management: add/remove remotes for shards and include shard configuration in network initialization.
* **Tests**
  * Added tests validating network initialization with leader and shards, and verifying add/remove remotes behavior on shards.
* **Chores**
  * Updated Meilisearch service image to v1.37.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->