### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -452,7 +452,7 @@ primary_field_guide_add_document_primary_key: |-
     ]
   ], 'reference_number');
 authorization_header_1: |-
-  $client = new Client('MEILISEARCH_URL', 'masterKey');
+  $client = new Client('MEILISEARCH_URL', 'MEILISEARCH_KEY');
   $client->getKeys();
 tenant_token_guide_generate_sdk_1: |-
   $apiKeyUid = '85c3c2f9-bdd6-41f1-abd8-11fcf80e0f76';

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -41,7 +41,7 @@
 ## 📖 Documentation
 
 
-To learn more about Meilisearch PHP, refer to the in-depth [Meilisearch PHP Documentation](https://php-sdk.meilisearch.com). To learn more about Meilisearch in general, refer to our [documentation](https://www.meilisearch.com/docs/learn/getting_started/quick_start) or our [API reference](https://www.meilisearch.com/docs/reference/api/overview).
+To learn more about Meilisearch PHP, refer to the in-depth [Meilisearch PHP Documentation](https://php-sdk.meilisearch.com). To learn more about Meilisearch in general, refer to our [documentation](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch) or our [API reference](https://www.meilisearch.com/docs/reference/api/authorization).
 
 ## 🔧 Installation
 
@@ -98,7 +98,7 @@ $documents = [
 $index->addDocuments($documents); // => { "uid": 0 }
 ```
 
-With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/tasks#status).
+With the `uid`, you can check the status (`enqueued`, `canceled`, `processing`, `succeeded` or `failed`) of your documents addition using the [task](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#status).
 
 #### Basic Search <!-- omit in toc -->
 
@@ -127,7 +127,7 @@ Array
 
 #### Custom Search <!-- omit in toc -->
 
-All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters) section of the documentation.
+All the supported options are described in the [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters) section of the documentation.
 
 💡 **More about the `search()` method in [the Wiki](https://github.com/meilisearch/meilisearch-php/wiki/Search).**
 
@@ -175,7 +175,7 @@ $index->updateFilterableAttributes([
 
 You only need to perform this operation once.
 
-Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/tasks#get-tasks)).
+Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [tasks](https://www.meilisearch.com/docs/reference/api/async-task-management/list-tasks#get-tasks)).
 
 Then, you can perform the search:
 
@@ -213,10 +213,10 @@ This package guarantees compatibility with [version v1.x of Meilisearch](https:/
 
 The following sections in our main documentation website may interest you:
 
-- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents) or read more about [documents](https://www.meilisearch.com/docs/learn/core_concepts/documents).
-- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search#search-parameters).
-- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/core_concepts/indexes).
-- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/learn/configuration/settings).
+- **Manipulate documents**: see the [API references](https://www.meilisearch.com/docs/reference/api/documents/list-documents-with-get) or read more about [documents](https://www.meilisearch.com/docs/learn/getting_started/documents).
+- **Search**: see the [API references](https://www.meilisearch.com/docs/reference/api/search/search-with-post) or follow our guide on [search parameters](https://www.meilisearch.com/docs/reference/api/search/search-with-post#search-parameters).
+- **Manage the indexes**: see the [API references](https://www.meilisearch.com/docs/reference/api/indexes/list-all-indexes) or read more about [indexes](https://www.meilisearch.com/docs/learn/getting_started/indexes).
+- **Configure the index settings**: see the [API references](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings) or follow our guide on [settings parameters](https://www.meilisearch.com/docs/learn/configuration/configuring_index_settings).
 
 ## 🧰 HTTP Client Compatibilities
 

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -258,7 +258,7 @@ class SearchQuery
      * It's available after Meilisearch v1.3.
      * To enable it properly and use ranking scoring details its required to opt-in through the /experimental-features route.
      *
-     * More info: https://www.meilisearch.com/docs/reference/api/experimental_features
+     * More info: https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features
      *
      * @param bool $showRankingScoreDetails whether the feature is enabled or not
      *
@@ -399,7 +399,7 @@ class SearchQuery
      * It's available from Meilisearch v1.3.
      * To enable it properly and use vector store capabilities it's required to activate it through the /experimental-features route.
      *
-     * More info: https://www.meilisearch.com/docs/reference/api/experimental_features
+     * More info: https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features
      *
      * @param non-empty-list<float|non-empty-list<float>> $vector a multi-level array floats
      *

--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -172,7 +172,7 @@ trait HandlesDocuments
      * It's available after Meilisearch v1.10.
      *
      * More info about the feature: https://github.com/orgs/meilisearch/discussions/762
-     * More info about experimental features in general: https://www.meilisearch.com/docs/reference/api/experimental_features
+     * More info about experimental features in general: https://www.meilisearch.com/docs/reference/api/experimental-features/list-experimental-features
      *
      * @param non-empty-string                                                                                       $function
      * @param array{filter?: non-empty-string|list<non-empty-string>|null, context?: array<non-empty-string, mixed>} $options

--- a/tests/Exceptions/ApiExceptionTest.php
+++ b/tests/Exceptions/ApiExceptionTest.php
@@ -16,7 +16,7 @@ final class ApiExceptionTest extends TestCase
             'message' => 'This is the message',
             'code' => 'this_is_the_error_code',
             'type' => 'this_is_the_error_type',
-            'link' => 'https://www.meilisearch.com/docs/errors',
+            'link' => 'https://www.meilisearch.com/docs/reference/errors/error_codes',
         ];
         $statusCode = 400;
 


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs