### PR TITLE
Add support for `distinct` in federated search requests

### DIFF
--- a/src/Contracts/MultiSearchFederation.php
+++ b/src/Contracts/MultiSearchFederation.php
@@ -27,6 +27,11 @@ class MultiSearchFederation
     private ?array $mergeFacets = null;
 
     /**
+     * @var non-empty-string|null
+     */
+    private ?string $distinct = null;
+
+    /**
      * @param non-negative-int $limit
      *
      * @return $this
@@ -75,11 +80,24 @@ class MultiSearchFederation
     }
 
     /**
+     * @param non-empty-string $distinct
+     *
+     * @return $this
+     */
+    public function setDistinct(string $distinct): self
+    {
+        $this->distinct = $distinct;
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     limit?: non-negative-int,
      *     offset?: non-negative-int,
      *     facetsByIndex?: array<non-empty-string, list<non-empty-string>>,
      *     mergeFacets?: array{maxValuesPerFacet: positive-int},
+     *     distinct?: non-empty-string,
      * }
      */
     public function toArray(): array
@@ -89,6 +107,7 @@ class MultiSearchFederation
             'offset' => $this->offset,
             'facetsByIndex' => $this->facetsByIndex,
             'mergeFacets' => $this->mergeFacets,
+            'distinct' => $this->distinct,
         ], static function ($item) { return null !== $item; });
     }
 }

--- a/tests/Endpoints/MultiSearchTest.php
+++ b/tests/Endpoints/MultiSearchTest.php
@@ -119,6 +119,28 @@ final class MultiSearchTest extends TestCase
         self::assertSame(1, $response['hits'][1]['_federation']['queriesPosition']);
     }
 
+    public function testFederationDistinct(): void
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('http://meilisearch/multi-search', $url);
+            self::assertSame('{"queries":[{"indexUid":"first"}],"federation":{"distinct":"id"}}', $options['body']);
+
+            return new MockResponse(
+                json_encode(['results' => []], \JSON_THROW_ON_ERROR),
+                ['response_headers' => ['content-type' => 'application/json']],
+            );
+        });
+
+        $client = new Client('http://meilisearch', 'apikey', new Psr18Client($httpClient));
+        $client->multiSearch(
+            [
+                (new SearchQuery())->setIndexUid('first'),
+            ],
+            (new MultiSearchFederation())->setDistinct('id'),
+        );
+    }
+
     public function testSupportedQueryParams(): void
     {
         $query = (new SearchQuery())


### PR DESCRIPTION
## Summary
Adds `distinct` field to `MultiSearchFederation` for Meilisearch v1.40.

## Why this matters
Meilisearch v1.40 introduced `distinct` in federated search. The PHP SDK was missing this field. Users couldn't deduplicate federated results by attribute.

## Changes
- Added `distinct` string property with setter to `MultiSearchFederation` in `src/Contracts/MultiSearchFederation.php`
- Updated `toArray()` and its PHPDoc to include `distinct`
- Added `testFederationDistinct` test in `tests/Endpoints/MultiSearchTest.php`

## Testing
- Test follows existing federated search test patterns

Closes #891

**AI disclosure:** This contribution was developed with AI assistance (Codex CLI for implementation, Claude Code for review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a distinct configuration option to multi-search federation queries, enabling enhanced control over result deduplication and filtering in federated searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->