### PR TITLE
Add method to get task documents

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -108,6 +108,8 @@ get_all_tasks_1: |-
   $client->getTasks();
 get_task_1: |-
   $client->getTask(1);
+get_task_documents_1: |-
+  $client->getTaskDocuments(1);
 get_one_key_1: |-
   $client->getKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d');
 get_all_keys_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -112,6 +112,8 @@ get_all_tasks_1: |-
   $client->getTasks();
 get_task_1: |-
   $client->getTask(1);
+get_task_documents_1: |-
+  $client->getTaskDocuments(1);
 get_one_key_1: |-
   $client->getKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d');
 get_all_keys_1: |-

--- a/src/Contracts/Http.php
+++ b/src/Contracts/Http.php
@@ -48,4 +48,9 @@ interface Http
      * @throws \JsonException
      */
     public function postStream(string $path, mixed $body = null, array $query = []): StreamInterface;
+
+    /**
+     * @throws ApiException
+     */
+    public function getStream(string $path, array $query = []): StreamInterface;
 }

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -20,6 +20,11 @@ trait HandlesTasks
         return $this->tasks->get($uid);
     }
 
+    public function getTaskDocuments(int $uid): array
+    {
+        return $this->tasks->getDocuments($uid);
+    }
+
     public function getTasks(?TasksQuery $options = null): TasksResults
     {
         $response = $this->tasks->all($options?->toArray() ?? []);

--- a/src/Endpoints/Delegates/HandlesTasks.php
+++ b/src/Endpoints/Delegates/HandlesTasks.php
@@ -10,6 +10,7 @@ use Meilisearch\Contracts\Task;
 use Meilisearch\Contracts\TasksQuery;
 use Meilisearch\Contracts\TasksResults;
 use Meilisearch\Endpoints\Tasks;
+use Psr\Http\Message\StreamInterface;
 
 trait HandlesTasks
 {
@@ -20,7 +21,7 @@ trait HandlesTasks
         return $this->tasks->get($uid);
     }
 
-    public function getTaskDocuments(int $uid): array
+    public function getTaskDocuments(int $uid): StreamInterface
     {
         return $this->tasks->getDocuments($uid);
     }

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -22,6 +22,11 @@ class Tasks extends Endpoint
         return Task::fromArray($this->http->get(self::PATH.'/'.$taskUid), partial(self::waitTask(...), $this->http));
     }
 
+    public function getDocuments(int $taskUid): array
+    {
+        return $this->http->get(self::PATH.'/'.$taskUid.'/documents');
+    }
+
     public function all(array $query = []): array
     {
         $data = $this->http->get(self::PATH.'/', $query);

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -10,6 +10,7 @@ use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\Http;
 use Meilisearch\Contracts\Task;
 use Meilisearch\Exceptions\TimeOutException;
+use Psr\Http\Message\StreamInterface;
 
 use function Meilisearch\partial;
 
@@ -22,9 +23,9 @@ class Tasks extends Endpoint
         return Task::fromArray($this->http->get(self::PATH.'/'.$taskUid), partial(self::waitTask(...), $this->http));
     }
 
-    public function getDocuments(int $taskUid): array
+    public function getDocuments(int $taskUid): StreamInterface
     {
-        return $this->http->get(self::PATH.'/'.$taskUid.'/documents');
+        return $this->http->getStream(self::PATH.'/'.$taskUid.'/documents');
     }
 
     public function all(array $query = []): array

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -10,6 +10,7 @@ use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\Http;
 use Meilisearch\Contracts\Task;
 use Meilisearch\Exceptions\TimeOutException;
+use Psr\Http\Message\StreamInterface;
 
 use function Meilisearch\partial;
 
@@ -40,9 +41,9 @@ class Tasks extends Endpoint
         return Task::fromArray($this->http->get(self::PATH.'/'.$taskUid), partial(self::waitTask(...), $this->http));
     }
 
-    public function getDocuments(int $taskUid): array
+    public function getDocuments(int $taskUid): StreamInterface
     {
-        return $this->http->get(self::PATH.'/'.$taskUid.'/documents');
+        return $this->http->getStream(self::PATH.'/'.$taskUid.'/documents');
     }
 
     /**

--- a/src/Endpoints/Tasks.php
+++ b/src/Endpoints/Tasks.php
@@ -40,6 +40,11 @@ class Tasks extends Endpoint
         return Task::fromArray($this->http->get(self::PATH.'/'.$taskUid), partial(self::waitTask(...), $this->http));
     }
 
+    public function getDocuments(int $taskUid): array
+    {
+        return $this->http->get(self::PATH.'/'.$taskUid.'/documents');
+    }
+
     /**
      * @return TasksResponse
      */

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -154,6 +154,16 @@ class Client implements Http
         return $this->executeStream($request, ['Content-type' => 'application/json']);
     }
 
+    public function getStream(string $path, array $query = []): StreamInterface
+    {
+        $request = $this->requestFactory->createRequest(
+            'GET',
+            $this->baseUrl.$path.$this->buildQueryString($query)
+        );
+
+        return $this->executeStream($request);
+    }
+
     /**
      * @param array<string, string|string[]> $headers
      *

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -55,6 +55,7 @@ final class TasksTest extends TestCase
         $http->patch('/experimental-features', ['getTaskDocumentsRoute' => true]);
 
         $task = $this->index->updateDocuments(self::DOCUMENTS);
+        $task->wait();
 
         $stream = $this->client->getTaskDocuments($task->getTaskUid());
 
@@ -63,7 +64,6 @@ final class TasksTest extends TestCase
         self::assertNotEmpty($lines, 'Stream should contain at least one NDJSON line');
 
         $documents = array_map(fn (string $line) => json_decode($line, true, 512, \JSON_THROW_ON_ERROR), $lines);
-        self::assertNotEmpty($documents);
         self::assertArrayHasKey('id', $documents[0], 'Each document should have an id field');
     }
 

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -48,6 +48,15 @@ final class TasksTest extends TestCase
         self::assertInstanceOf(DocumentAdditionOrUpdateDetails::class, $task->getDetails());
     }
 
+    public function testGetTaskDocumentsClient(): void
+    {
+        [$seedTask, $completedTask] = $this->seedIndex();
+
+        $documents = $this->client->getTaskDocuments($completedTask->getTaskUid());
+
+        self::assertIsArray($documents);
+    }
+
     public function testGetAllTasksClient(): void
     {
         $tasks = $this->client->getTasks();

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -50,11 +50,10 @@ final class TasksTest extends TestCase
 
     public function testGetTaskDocumentsClient(): void
     {
-        [$seedTask, $completedTask] = $this->seedIndex();
+        [, $completedTask] = $this->seedIndex();
 
         $documents = $this->client->getTaskDocuments($completedTask->getTaskUid());
 
-        self::assertIsArray($documents);
         self::assertNotEmpty($documents);
     }
 

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -13,6 +13,7 @@ use Meilisearch\Contracts\TaskStatus;
 use Meilisearch\Contracts\TaskType;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Exceptions\ApiException;
+use Meilisearch\Http\Client;
 use Tests\TestCase;
 
 final class TasksTest extends TestCase
@@ -50,6 +51,9 @@ final class TasksTest extends TestCase
 
     public function testGetTaskDocumentsClient(): void
     {
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['getTaskDocumentsRoute' => true]);
+
         [, $completedTask] = $this->seedIndex();
 
         $documents = $this->client->getTaskDocuments($completedTask->getTaskUid());

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -55,6 +55,7 @@ final class TasksTest extends TestCase
         $documents = $this->client->getTaskDocuments($completedTask->getTaskUid());
 
         self::assertIsArray($documents);
+        self::assertNotEmpty($documents);
     }
 
     public function testGetAllTasksClient(): void

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -14,7 +14,6 @@ use Meilisearch\Contracts\TaskType;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Exceptions\ApiException;
 use Meilisearch\Http\Client;
-use Psr\Http\Message\StreamInterface;
 use Tests\TestCase;
 
 final class TasksTest extends TestCase
@@ -59,9 +58,13 @@ final class TasksTest extends TestCase
 
         $stream = $this->client->getTaskDocuments($task->getTaskUid());
 
-        self::assertInstanceOf(StreamInterface::class, $stream);
-        $content = (string) $stream;
-        self::assertNotEmpty($content);
+        // Parse NDJSON: each line is a separate JSON document
+        $lines = array_filter(explode("\n", (string) $stream), fn (string $line) => '' !== trim($line));
+        self::assertNotEmpty($lines, 'Stream should contain at least one NDJSON line');
+
+        $documents = array_map(fn (string $line) => json_decode($line, true, 512, \JSON_THROW_ON_ERROR), $lines);
+        self::assertNotEmpty($documents);
+        self::assertArrayHasKey('id', $documents[0], 'Each document should have an id field');
     }
 
     public function testGetAllTasksClient(): void

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -14,6 +14,7 @@ use Meilisearch\Contracts\TaskType;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Exceptions\ApiException;
 use Meilisearch\Http\Client;
+use Psr\Http\Message\StreamInterface;
 use Tests\TestCase;
 
 final class TasksTest extends TestCase
@@ -56,9 +57,11 @@ final class TasksTest extends TestCase
 
         $task = $this->index->updateDocuments(self::DOCUMENTS);
 
-        $documents = $this->client->getTaskDocuments($task->getTaskUid());
+        $stream = $this->client->getTaskDocuments($task->getTaskUid());
 
-        self::assertNotEmpty($documents);
+        self::assertInstanceOf(StreamInterface::class, $stream);
+        $content = (string) $stream;
+        self::assertNotEmpty($content);
     }
 
     public function testGetAllTasksClient(): void

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -54,9 +54,9 @@ final class TasksTest extends TestCase
         $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
         $http->patch('/experimental-features', ['getTaskDocumentsRoute' => true]);
 
-        [, $completedTask] = $this->seedIndex();
+        $task = $this->index->updateDocuments(self::DOCUMENTS);
 
-        $documents = $this->client->getTaskDocuments($completedTask->getTaskUid());
+        $documents = $this->client->getTaskDocuments($task->getTaskUid());
 
         self::assertNotEmpty($documents);
     }

--- a/tests/Endpoints/TasksTest.php
+++ b/tests/Endpoints/TasksTest.php
@@ -54,17 +54,74 @@ final class TasksTest extends TestCase
         $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
         $http->patch('/experimental-features', ['getTaskDocumentsRoute' => true]);
 
+        // The task documents route only exposes documents while the task is
+        // still enqueued or processing. Enqueue a large batch first so the task
+        // we inspect stays queued behind it instead of completing immediately.
+        $this->index->updateDocuments(array_map(
+            static fn (int $id): array => ['id' => $id],
+            range(1_000_000, 1_010_000)
+        ));
         $task = $this->index->updateDocuments(self::DOCUMENTS);
-        $task->wait();
 
-        $stream = $this->client->getTaskDocuments($task->getTaskUid());
+        $stream = (string) $this->client->getTaskDocuments($task->getTaskUid());
 
-        // Parse NDJSON: each line is a separate JSON document
-        $lines = array_filter(explode("\n", (string) $stream), fn (string $line) => '' !== trim($line));
-        self::assertNotEmpty($lines, 'Stream should contain at least one NDJSON line');
+        // Meilisearch streams the documents as consecutive JSON objects. Despite
+        // the application/x-ndjson content type they are not newline-delimited,
+        // so decode them as a sequence of concatenated JSON values.
+        $documents = self::decodeJsonObjectStream($stream);
 
-        $documents = array_map(fn (string $line) => json_decode($line, true, 512, \JSON_THROW_ON_ERROR), $lines);
+        self::assertCount(\count(self::DOCUMENTS), $documents);
         self::assertArrayHasKey('id', $documents[0], 'Each document should have an id field');
+    }
+
+    /**
+     * Decodes a stream of concatenated JSON objects (e.g. {"id":1}{"id":2}) into
+     * a list of associative arrays, tracking string/escape state so object
+     * boundaries inside string values are ignored.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private static function decodeJsonObjectStream(string $payload): array
+    {
+        $documents = [];
+        $depth = 0;
+        $start = null;
+        $inString = false;
+        $escaped = false;
+        $length = \strlen($payload);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $payload[$i];
+
+            if ($inString) {
+                if ($escaped) {
+                    $escaped = false;
+                } elseif ('\\' === $char) {
+                    $escaped = true;
+                } elseif ('"' === $char) {
+                    $inString = false;
+                }
+
+                continue;
+            }
+
+            if ('"' === $char) {
+                $inString = true;
+            } elseif ('{' === $char) {
+                if (0 === $depth) {
+                    $start = $i;
+                }
+                ++$depth;
+            } elseif ('}' === $char) {
+                --$depth;
+                if (0 === $depth && null !== $start) {
+                    $documents[] = json_decode(substr($payload, $start, $i - $start + 1), true, 512, \JSON_THROW_ON_ERROR);
+                    $start = null;
+                }
+            }
+        }
+
+        return $documents;
     }
 
     public function testGetAllTasksClient(): void


### PR DESCRIPTION
## Summary

Adds `getTaskDocuments()` for the `GET /tasks/{task_id}/documents` endpoint introduced in Meilisearch v1.13.

## Changes

- `src/Endpoints/Tasks.php`: Added `getDocuments(int $taskUid)` that calls `GET /tasks/{id}/documents`
- `src/Endpoints/Delegates/HandlesTasks.php`: Added `getTaskDocuments(int $uid)` delegate method
- `.code-samples.meilisearch.yaml`: Added `get_task_documents_1` code sample

## Testing

- Follows the existing pattern from `getTask()` / `get()`
- Code sample matches the format from the [Meilisearch documentation](https://www.meilisearch.com/docs/reference/api/async-task-management/get-tasks-documents)

Fixes #890

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve documents associated with a specific task ID via a new endpoint method, returning the task’s document payload.

* **Documentation**
  * Added a code sample showing how to fetch documents for a given task.

* **Tests**
  * Added an integration test that enables the experimental route, seeds a completed task, and verifies fetching task documents returns a non-empty array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->