### PR TITLE
Backport distinct field to MultiSearchFederation (v1.x)

### DIFF
--- a/src/Contracts/MultiSearchFederation.php
+++ b/src/Contracts/MultiSearchFederation.php
@@ -27,6 +27,11 @@ class MultiSearchFederation
     private ?array $mergeFacets = null;
 
     /**
+     * @var non-empty-string|null
+     */
+    private ?string $distinct = null;
+
+    /**
      * @param non-negative-int $limit
      *
      * @return $this
@@ -75,11 +80,24 @@ class MultiSearchFederation
     }
 
     /**
+     * @param non-empty-string $distinct
+     *
+     * @return $this
+     */
+    public function setDistinct(string $distinct): self
+    {
+        $this->distinct = $distinct;
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     limit?: non-negative-int,
      *     offset?: non-negative-int,
      *     facetsByIndex?: array<non-empty-string, list<non-empty-string>>,
      *     mergeFacets?: array{maxValuesPerFacet: positive-int},
+     *     distinct?: non-empty-string,
      * }
      */
     public function toArray(): array
@@ -89,6 +107,7 @@ class MultiSearchFederation
             'offset' => $this->offset,
             'facetsByIndex' => $this->facetsByIndex,
             'mergeFacets' => $this->mergeFacets,
+            'distinct' => $this->distinct,
         ], static function ($item) { return null !== $item; });
     }
 }


### PR DESCRIPTION
## Summary

Backports the `distinct` field from `main` to the `v1.x` branch, enabling deduplication by attribute in federated multi-index search (available since Meilisearch v1.12).

Closes #894

## Changes

- Added `distinct` property with `setDistinct()` setter to `MultiSearchFederation`
- Updated `toArray()` return type annotation and output to include `distinct`

## Usage

```php
$federation = (new MultiSearchFederation())
    ->setLimit(10)
    ->setDistinct('title');
```