### PR TITLE
Add compact method to Index (v1.x backport)

### DIFF
--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -154,6 +154,13 @@ class Indexes extends Endpoint
         return $this->http->post('/swap-indexes', $indexes);
     }
 
+    // Compact
+
+    public function compact(): array
+    {
+        return $this->http->post(self::PATH.'/'.$this->uid.'/compact');
+    }
+
     // Tasks
 
     public function getTask($uid): array


### PR DESCRIPTION
## Summary

Backports the `compact()` method to the v1.x branch, adding support for the compact database API endpoint introduced in Meilisearch v1.23.

Closes #878

## Changes

Added `compact()` method to `Indexes` class that calls `POST /indexes/{uid}/compact`.

## Usage

```php
$client->index('movies')->compact();
```

This contribution was developed with AI assistance (Claude Code).