### PR TITLE
Remove unused code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -18,10 +18,6 @@ facet_search_3: |-
         ->setFacetQuery('c')
         ->setFacetName('genres')
   );
-search_parameter_guide_show_ranking_score_details_1: |-
-  $client->index('movies')->search('dragon', [
-    'showRankingScoreDetails' => true
-  ]);
 get_documents_post_1: |-
   $client->index('books')->getDocuments(
     (new DocumentsQuery())
@@ -296,12 +292,6 @@ get_version_1: |-
   $client->version();
 distinct_attribute_guide_1: |-
   $client->index('jackets')->updateDistinctAttribute('product_id');
-field_properties_guide_searchable_1: |-
-  $client->index('movies')->updateSearchableAttributes([
-    'title',
-    'overview',
-    'genres'
-  ]);
 field_properties_guide_displayed_1: |-
   $client->index('movies')->updateDisplayedAttributes([
     'title',


### PR DESCRIPTION
Removes unused code samples from `.code-samples.meilisearch.yaml` that are neither referenced in the docs nor in the local config:
- `field_properties_guide_searchable_1`
- `search_parameter_guide_show_ranking_score_details_1`

Flagged by the CI: https://github.com/meilisearch/documentation/actions/runs/24176332506/job/70558505454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated code examples from documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->