### PR TITLE
Update release drafter workflow to handle beta releases

### DIFF
--- a/.github/release-draft-template-v2-beta.yml
+++ b/.github/release-draft-template-v2-beta.yml
@@ -1,0 +1,40 @@
+name-template: "v$RESOLVED_VERSION 🚀"
+tag-template: "v$RESOLVED_VERSION"
+filter-by-commitish: true
+exclude-labels:
+  - "skip-changelog"
+version-resolver:
+  major:
+    labels:
+      - "breaking-change"
+  minor:
+    labels:
+      - "enhancement"
+  default: patch
+# Set initial version for v2.x beta releases
+version-template: "2.0.0"
+categories:
+  - title: "⚠️ Breaking changes"
+    label: "breaking-change"
+  - title: "🚀 Enhancements"
+    label: "enhancement"
+  - title: "🐛 Bug Fixes"
+    label: "bug"
+  - title: "🔒 Security"
+    label: "security"
+  - title: "⚙️ Maintenance/misc"
+    label:
+      - "dependencies"
+      - "maintenance"
+      - "documentation"
+template: |
+  $CHANGES
+
+  Thanks to $CONTRIBUTORS! 🎉
+
+  **See full changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+no-changes-template: "Changes are coming soon 😎"
+sort-direction: "ascending"
+replacers:
+  - search: "/(?:and )?@meili-bot,?/g"
+    replace: ""

--- a/.github/release-draft-template-v2-stable.yml
+++ b/.github/release-draft-template-v2-stable.yml
@@ -1,0 +1,40 @@
+name-template: "v$RESOLVED_VERSION 🚀"
+tag-template: "v$RESOLVED_VERSION"
+filter-by-commitish: true
+exclude-labels:
+  - "skip-changelog"
+version-resolver:
+  major:
+    labels:
+      - "breaking-change"
+  minor:
+    labels:
+      - "enhancement"
+  default: patch
+# Set initial version for v2.x releases
+version-template: "2.0.0"
+categories:
+  - title: "⚠️ Breaking changes"
+    label: "breaking-change"
+  - title: "🚀 Enhancements"
+    label: "enhancement"
+  - title: "🐛 Bug Fixes"
+    label: "bug"
+  - title: "🔒 Security"
+    label: "security"
+  - title: "⚙️ Maintenance/misc"
+    label:
+      - "dependencies"
+      - "maintenance"
+      - "documentation"
+template: |
+  $CHANGES
+
+  Thanks to $CONTRIBUTORS! 🎉
+
+  **See full changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+no-changes-template: "Changes are coming soon 😎"
+sort-direction: "ascending"
+replacers:
+  - search: "/(?:and )?@meili-bot,?/g"
+    replace: ""

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,12 +7,37 @@ on:
       - v1.x
 
 jobs:
-  update_release_draft:
+  update_release_draft_v1:
+    if: github.ref_name == 'v1.x'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         with:
-          config-name: ${{ github.ref_name == 'v1.x' && 'release-draft-template-v1.yml' || 'release-draft-template.yml' }}
-          commitish: ${{ github.ref_name }}
+          config-name: release-draft-template-v1.yml
+          commitish: v1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}
+
+  update_release_draft_v2_stable:
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-draft-template-v2-stable.yml
+          commitish: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}
+
+  update_release_draft_v2_beta:
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-draft-template-v2-beta.yml
+          commitish: main
+          prerelease: true
+          prerelease-identifier: beta
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_DRAFTER_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Issue
The current workflow doesn't handle changelog for `v2.0.0.beta.X` releases correctly, because it diffs against the latest stable release (`v1.x` branch).

## What does this PR do?
- Update release drafter workflows to handle v2.x stable and v2.x beta separately

## AI disclosure
Cursor with `gpt-5.1-high` and `codex-5.3-medium`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation infrastructure with new configuration templates designed specifically for v1.x, v2 stable, and v2 beta release tracks.
  * Enhanced release draft workflow to independently manage and automate release notes generation across different version branches, ensuring proper categorization and filtering of changelog entries for each release track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->