### PR TITLE
Add type hints to `DocumentsResults`

### DIFF
--- a/src/Contracts/DocumentsResults.php
+++ b/src/Contracts/DocumentsResults.php
@@ -4,44 +4,80 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class DocumentsResults extends Data
+final class DocumentsResults extends Data
 {
+    /**
+     * @var non-negative-int
+     */
     private int $offset;
+
+    /**
+     * @var non-negative-int
+     */
     private int $limit;
+
+    /**
+     * @var non-negative-int
+     */
     private int $total;
 
+    /**
+     * @param array{
+     *     results: array<int, array<string, mixed>>,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     total: non-negative-int
+     * } $params
+     */
     public function __construct(array $params)
     {
-        parent::__construct($params['results'] ?? []);
+        parent::__construct($params['results']);
 
         $this->offset = $params['offset'];
         $this->limit = $params['limit'];
-        $this->total = $params['total'] ?? 0;
+        $this->total = $params['total'];
     }
 
     /**
-     * @return array<int, array>
+     * @return array<int, array<string, mixed>>
      */
     public function getResults(): array
     {
         return $this->data;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getTotal(): int
     {
         return $this->total;
     }
 
+    /**
+     * @return array{
+     *     results: array<int, array<string, mixed>>,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     total: non-negative-int
+     * }
+     */
     public function toArray(): array
     {
         return [
@@ -50,10 +86,5 @@ class DocumentsResults extends Data
             'limit' => $this->limit,
             'total' => $this->total,
         ];
-    }
-
-    public function count(): int
-    {
-        return \count($this->data);
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Partially-fixes #848

## What does this PR do?
- Adds typehints to `DocumentsResults`;
- Makes the class final

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for returned document results and stricter data shape for result payloads.
  * Added explicit accessors for pagination values (offset, limit, total).
  * Constructor now requires explicit pagination and results parameters—no fallback defaults.
  * Removed built-in count functionality; consumers should rely on the explicit total value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->