### PR TITLE
Add type hints to, and make query and results classes final

### DIFF
--- a/src/Contracts/SimilarDocumentsQuery.php
+++ b/src/Contracts/SimilarDocumentsQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class SimilarDocumentsQuery
+final class SimilarDocumentsQuery
 {
     /**
      * @var int|non-empty-string

--- a/src/Search/FacetSearchResult.php
+++ b/src/Search/FacetSearchResult.php
@@ -5,37 +5,73 @@ declare(strict_types=1);
 namespace Meilisearch\Search;
 
 /**
- * @implements \IteratorAggregate<array<int, array<string, mixed>>>
+ * @implements \IteratorAggregate<int, array<string, mixed>>
  */
-class FacetSearchResult implements \Countable, \IteratorAggregate
+final class FacetSearchResult implements \Countable, \IteratorAggregate
 {
     /**
      * @var array<int, array<string, mixed>>
      */
     private array $facetHits;
+
+    /**
+     * @var non-negative-int
+     */
     private int $processingTimeMs;
+
     private ?string $facetQuery;
 
+    /**
+     * @var array<string, mixed>
+     */
+    private array $raw;
+
+    /**
+     * @param array{
+     *     facetHits: array<int, array<string, mixed>>,
+     *     facetQuery: string|null,
+     *     processingTimeMs: non-negative-int
+     * } $body
+     */
     public function __construct(array $body)
     {
-        $this->facetHits = $body['facetHits'] ?? [];
+        $this->facetHits = $body['facetHits'];
         $this->facetQuery = $body['facetQuery'];
         $this->processingTimeMs = $body['processingTimeMs'];
+        $this->raw = $body;
     }
 
     /**
-     * @return array<int, array>
+     * @return array<int, array<string, mixed>>
      */
     public function getFacetHits(): array
     {
         return $this->facetHits;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getProcessingTimeMs(): int
     {
         return $this->processingTimeMs;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @return array{
+     *     facetHits: array<int, array<string, mixed>>,
+     *     facetQuery: string|null,
+     *     processingTimeMs: non-negative-int
+     * }
+     */
     public function toArray(): array
     {
         return [

--- a/src/Search/SearchResult.php
+++ b/src/Search/SearchResult.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Meilisearch\Search;
 
 /**
- * @implements \IteratorAggregate<array<int, array<string, mixed>>>
+ * @implements \IteratorAggregate<int, array<string, mixed>>
  */
-class SearchResult implements \Countable, \IteratorAggregate
+final class SearchResult implements \Countable, \IteratorAggregate
 {
     /**
      * @var array<int, array<string, mixed>>
@@ -18,19 +18,56 @@ class SearchResult implements \Countable, \IteratorAggregate
      * `estimatedTotalHits` is the attributes returned by the Meilisearch server
      * and its value will not be modified by the methods in this class.
      * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
+     *
+     * @var non-negative-int|null
      */
     private ?int $estimatedTotalHits = null;
+
+    /**
+     * @var non-negative-int
+     */
     private int $hitsCount;
+
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $offset = null;
+
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $limit = null;
+
+    /**
+     * @var non-negative-int
+     */
     private int $semanticHitCount;
 
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $hitsPerPage = null;
+
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $page = null;
+
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $totalPages = null;
+
+    /**
+     * @var non-negative-int|null
+     */
     private ?int $totalHits = null;
 
+    /**
+     * @var non-negative-int
+     */
     private int $processingTimeMs;
+
     private bool $numberedPagination;
 
     private string $query;
@@ -50,6 +87,23 @@ class SearchResult implements \Countable, \IteratorAggregate
      */
     private array $raw;
 
+    /**
+     * @param array{
+     *     hits: array<int, array<string, mixed>>,
+     *     processingTimeMs: non-negative-int,
+     *     query: string,
+     *     facetDistribution?: array<string, mixed>,
+     *     facetStats?: array<string, mixed>,
+     *     offset?: non-negative-int,
+     *     limit?: non-negative-int,
+     *     semanticHitCount?: non-negative-int,
+     *     page?: non-negative-int,
+     *     totalPages?: non-negative-int,
+     *     totalHits?: non-negative-int,
+     *     estimatedTotalHits?: non-negative-int,
+     *     hitsPerPage?: non-negative-int,
+     * } $body
+     */
     public function __construct(array $body)
     {
         if (isset($body['estimatedTotalHits'])) {
@@ -68,7 +122,7 @@ class SearchResult implements \Countable, \IteratorAggregate
         }
 
         $this->semanticHitCount = $body['semanticHitCount'] ?? 0;
-        $this->hits = $body['hits'] ?? [];
+        $this->hits = $body['hits'];
         $this->hitsCount = \count($body['hits']);
         $this->processingTimeMs = $body['processingTimeMs'];
         $this->query = $body['query'];
@@ -85,19 +139,27 @@ class SearchResult implements \Countable, \IteratorAggregate
      * - transformHits (callable)
      *
      * The method does NOT trigger a new search.
+     *
+     * @param array{
+     *     transformHits?: callable(array<int, array<string, mixed>>): array<int, array<string, mixed>>,
+     *     transformFacetDistribution?: callable(array<string, mixed>): array<string, mixed>
+     * } $options
      */
-    public function applyOptions($options): self
+    public function applyOptions(array $options): self
     {
-        if (\array_key_exists('transformHits', $options) && \is_callable($options['transformHits'])) {
+        if (\array_key_exists('transformHits', $options)) {
             $this->transformHits($options['transformHits']);
         }
-        if (\array_key_exists('transformFacetDistribution', $options) && \is_callable($options['transformFacetDistribution'])) {
+        if (\array_key_exists('transformFacetDistribution', $options)) {
             $this->transformFacetDistribution($options['transformFacetDistribution']);
         }
 
         return $this;
     }
 
+    /**
+     * @param callable(array<int, array<string, mixed>>): array<int, array<string, mixed>> $callback
+     */
     public function transformHits(callable $callback): self
     {
         $this->hits = $callback($this->hits);
@@ -106,6 +168,9 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this;
     }
 
+    /**
+     * @param callable(array<string, mixed>): array<string, mixed> $callback
+     */
     public function transformFacetDistribution(callable $callback): self
     {
         $this->facetDistribution = $callback($this->facetDistribution);
@@ -113,7 +178,14 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this;
     }
 
-    public function getHit(int $key, $default = null)
+    /**
+     * @template TDefault
+     *
+     * @param TDefault $default
+     *
+     * @return array<string, mixed>|TDefault
+     */
+    public function getHit(int $key, mixed $default = null): mixed
     {
         return $this->hits[$key] ?? $default;
     }
@@ -126,16 +198,25 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->hits;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getOffset(): ?int
     {
         return $this->offset;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getLimit(): ?int
     {
         return $this->limit;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getHitsCount(): int
     {
         return $this->hitsCount;
@@ -149,16 +230,25 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->semanticHitCount;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function count(): int
     {
         return $this->hitsCount;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getEstimatedTotalHits(): ?int
     {
         return $this->estimatedTotalHits;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getProcessingTimeMs(): int
     {
         return $this->processingTimeMs;
@@ -169,21 +259,33 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->query;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getHitsPerPage(): ?int
     {
         return $this->hitsPerPage;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getPage(): ?int
     {
         return $this->page;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getTotalPages(): ?int
     {
         return $this->totalPages;
     }
 
+    /**
+     * @return non-negative-int|null
+     */
     public function getTotalHits(): ?int
     {
         return $this->totalHits;
@@ -215,6 +317,23 @@ class SearchResult implements \Countable, \IteratorAggregate
         return $this->raw;
     }
 
+    /**
+     * @return array{
+     *     hits: array<int, array<string, mixed>>,
+     *     hitsCount: non-negative-int,
+     *     processingTimeMs: non-negative-int,
+     *     query: string,
+     *     facetDistribution: array<string, mixed>,
+     *     facetStats: array<string, mixed>,
+     *     offset?: non-negative-int,
+     *     limit?: non-negative-int,
+     *     estimatedTotalHits?: non-negative-int,
+     *     hitsPerPage?: non-negative-int,
+     *     page?: non-negative-int,
+     *     totalPages?: non-negative-int,
+     *     totalHits?: non-negative-int,
+     * }
+     */
     public function toArray(): array
     {
         $arr = [

--- a/src/Search/SimilarDocumentsSearchResult.php
+++ b/src/Search/SimilarDocumentsSearchResult.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Meilisearch\Search;
 
 /**
- * @implements \IteratorAggregate<array<int, array<string, mixed>>>
+ * @implements \IteratorAggregate<int, array<string, mixed>>
  */
-class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
+final class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
 {
     /**
      * @var array<int, array<string, mixed>>
@@ -20,12 +20,54 @@ class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
      * Please, use `hitsCount` if you want to know the real size of the `hits` array at any time.
      */
     private int $estimatedTotalHits;
-    private int $hitsCount;
-    private int $offset;
-    private int $limit;
-    private int $processingTimeMs;
-    private string $id;
 
+    /**
+     * @var non-negative-int
+     */
+    private int $hitsCount;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $offset;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $limit;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $processingTimeMs;
+
+    /**
+     * @var int|non-empty-string
+     */
+    private int|string $id;
+
+    /**
+     * @var array<string, string>|null
+     */
+    private ?array $performanceDetails;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $raw;
+
+    /**
+     * @param array{
+     *     id: int|non-empty-string,
+     *     hits: array<int, array<string, mixed>>,
+     *     hitsCount: non-negative-int,
+     *     processingTimeMs: non-negative-int,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     estimatedTotalHits: non-negative-int,
+     *     performanceDetails?: array<string, string>|null,
+     * } $body
+     */
     public function __construct(array $body)
     {
         $this->id = $body['id'];
@@ -35,14 +77,20 @@ class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
         $this->offset = $body['offset'];
         $this->limit = $body['limit'];
         $this->estimatedTotalHits = $body['estimatedTotalHits'];
+        $this->performanceDetails = $body['performanceDetails'] ?? null;
+        $this->raw = $body;
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @template TDefault
+     *
+     * @param TDefault $default
+     *
+     * @return array<string, mixed>|TDefault
      */
-    public function getHit(int $key): ?array
+    public function getHit(int $key, mixed $default = null): mixed
     {
-        return $this->hits[$key];
+        return $this->hits[$key] ?? $default;
     }
 
     /**
@@ -53,40 +101,83 @@ class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
         return $this->hits;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getEstimatedTotalHits(): int
     {
         return $this->estimatedTotalHits;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getProcessingTimeMs(): int
     {
         return $this->processingTimeMs;
     }
 
-    public function getId(): string
+    /**
+     * @return int|non-empty-string
+     */
+    public function getId(): int|string
     {
         return $this->id;
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function getHitsCount(): int
     {
         return $this->hitsCount;
     }
 
     /**
+     * @return array<string, string>|null
+     */
+    public function getPerformanceDetails(): ?array
+    {
+        return $this->performanceDetails;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
      * Converts the SimilarDocumentsSearchResult to an array representation.
      *
-     * @return array<string, mixed>
+     * @return array{
+     *     id: int|non-empty-string,
+     *     hits: array<int, array<string, mixed>>,
+     *     hitsCount: non-negative-int,
+     *     processingTimeMs: non-negative-int,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     estimatedTotalHits: non-negative-int,
+     *     performanceDetails?: array<string, string>|null,
+     * }
      */
     public function toArray(): array
     {
@@ -98,6 +189,7 @@ class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
             'offset' => $this->offset,
             'limit' => $this->limit,
             'estimatedTotalHits' => $this->estimatedTotalHits,
+            'performanceDetails' => $this->performanceDetails,
         ];
     }
 
@@ -106,6 +198,9 @@ class SimilarDocumentsSearchResult implements \Countable, \IteratorAggregate
         return new \ArrayIterator($this->hits);
     }
 
+    /**
+     * @return non-negative-int
+     */
     public function count(): int
     {
         return $this->hitsCount;

--- a/tests/Endpoints/SearchNestedFieldsTest.php
+++ b/tests/Endpoints/SearchNestedFieldsTest.php
@@ -23,7 +23,6 @@ final class SearchNestedFieldsTest extends TestCase
     {
         $response = $this->index->search('An awesome');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(1, $response->getHits());
 
         $response = $this->index->search('An awesome', [], [
@@ -39,7 +38,6 @@ final class SearchNestedFieldsTest extends TestCase
     {
         $response = $this->index->search('book');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(6, $response->getHits());
 
         $response = $this->index->search('book', [], [
@@ -71,7 +69,6 @@ final class SearchNestedFieldsTest extends TestCase
 
         $response = $this->index->search('An awesome');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(1, $response->getHits());
 
         $response = $this->index->search('An awesome', [], [
@@ -89,7 +86,6 @@ final class SearchNestedFieldsTest extends TestCase
 
         $response = $this->index->search('An awesome');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(1, $response->getHits());
 
         $response = $this->index->search('An awesome', [
@@ -112,7 +108,6 @@ final class SearchNestedFieldsTest extends TestCase
 
         $response = $this->index->search('An awesome');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(1, $response->getHits());
 
         $response = $this->index->search('An awesome', [

--- a/tests/Endpoints/SearchTest.php
+++ b/tests/Endpoints/SearchTest.php
@@ -371,7 +371,6 @@ final class SearchTest extends TestCase
             'facets' => ['genre'],
         ]);
         self::assertSame(2, $response->getHitsCount());
-        self::assertArrayHasKey('facetDistribution', $response->toArray());
         self::assertArrayHasKey('genre', $response->getFacetDistribution());
         self::assertSame($response->getFacetDistribution()['genre']['fantasy'], 1);
         self::assertSame($response->getFacetDistribution()['genre']['adventure'], 1);

--- a/tests/Endpoints/TenantTokenTest.php
+++ b/tests/Endpoints/TenantTokenTest.php
@@ -51,7 +51,6 @@ final class TenantTokenTest extends TestCase
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(7, $response->getHits());
     }
 
@@ -63,7 +62,6 @@ final class TenantTokenTest extends TestCase
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(7, $response->getHits());
     }
 
@@ -78,7 +76,6 @@ final class TenantTokenTest extends TestCase
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index('tenantToken')->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
         self::assertCount(4, $response->getHits());
     }
 
@@ -89,11 +86,10 @@ final class TenantTokenTest extends TestCase
 
         $token = $this->privateClient->generateTenantToken($this->key->getUid(), [$this->indexName]);
         $tokenClient = new Client($this->host, $token);
-        $response = $tokenClient->index($this->indexName)->search('');
+        $tokenClient->index($this->indexName)->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
-        self::assertArrayHasKey('query', $response->toArray());
         $this->expectException(ApiException::class);
+
         $tokenClient->index($indexName)->search('');
     }
 
@@ -107,7 +103,7 @@ final class TenantTokenTest extends TestCase
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index($this->indexName)->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
+        self::assertSame([], $response->getHits());
     }
 
     public function testGenerateTenantTokenWithExpiresAt(): void
@@ -122,7 +118,7 @@ final class TenantTokenTest extends TestCase
         $tokenClient = new Client($this->host, $token);
         $response = $tokenClient->index($this->indexName)->search('');
 
-        self::assertArrayHasKey('hits', $response->toArray());
+        self::assertSame([], $response->getHits());
     }
 
     public function testGenerateTenantTokenWithSearchRulesEmptyArray(): void

--- a/tests/Search/SearchResultTest.php
+++ b/tests/Search/SearchResultTest.php
@@ -106,16 +106,6 @@ final class SearchResultTest extends TestCase
         self::assertEmpty($this->basicResult->getFacetDistribution());
         self::assertEmpty($this->basicResult->getFacetStats());
         self::assertCount(2, $this->basicResult);
-
-        self::assertArrayHasKey('hits', $this->basicResult->toArray());
-        self::assertArrayHasKey('offset', $this->basicResult->toArray());
-        self::assertArrayHasKey('limit', $this->basicResult->toArray());
-        self::assertArrayHasKey('estimatedTotalHits', $this->basicResult->toArray());
-        self::assertArrayHasKey('hitsCount', $this->basicResult->toArray());
-        self::assertArrayHasKey('processingTimeMs', $this->basicResult->toArray());
-        self::assertArrayHasKey('query', $this->basicResult->toArray());
-        self::assertArrayHasKey('facetDistribution', $this->basicResult->toArray());
-        self::assertArrayHasKey('facetStats', $this->basicResult->toArray());
     }
 
     public function testSearchResultCanBeFiltered(): void
@@ -188,17 +178,12 @@ final class SearchResultTest extends TestCase
         $keepAmericanSniperFunc = function (array $hits): array {
             return array_filter(
                 $hits,
-                function (array $hit): bool { return 'American Sniper' === $hit['title']; }
+                static function (array $hit): bool { return 'American Sniper' === $hit['title']; }
             );
         };
 
         $response = $this->basicResult->transformHits($keepAmericanSniperFunc);
 
-        self::assertArrayHasKey('hits', $response->toArray());
-        self::assertArrayHasKey('offset', $response->toArray());
-        self::assertArrayHasKey('limit', $response->toArray());
-        self::assertArrayHasKey('processingTimeMs', $response->toArray());
-        self::assertArrayHasKey('query', $response->toArray());
         self::assertSame('American Sniper', $response->getHit(1)['title']); // Not getHits(0) because array_filter() does not reorder the indexes after filtering.
         self::assertSame(976, $response->getEstimatedTotalHits());
         self::assertSame(1, $response->getHitsCount());
@@ -222,12 +207,6 @@ final class SearchResultTest extends TestCase
 
         $response = $this->resultWithFacets->transformFacetDistribution($facetsToUpperFunc);
 
-        self::assertArrayHasKey('hits', $response->toArray());
-        self::assertArrayHasKey('facetDistribution', $response->toArray());
-        self::assertArrayHasKey('offset', $response->toArray());
-        self::assertArrayHasKey('limit', $response->toArray());
-        self::assertArrayHasKey('processingTimeMs', $response->toArray());
-        self::assertArrayHasKey('query', $response->toArray());
         self::assertSame($response->getRaw()['hits'], $response->getHits());
         self::assertNotSame($response->getRaw()['facetDistribution'], $response->getFacetDistribution());
         self::assertCount(3, $response->getFacetDistribution()['genre']);


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #839

## What does this PR do?
- Adds types to `FacetSearchResult`;
- Adds types to `SearchResult`;
- Adds types to `SimilarDocumentsSearchResult`;
- Makes `SimilarDocumentsQuery` final;
- Makes `FacetSearchResult` final;
- Makes `SearchResult` final;
- Adds raw data to `SimilarDocumentsSearchResult` with `getRaw` method;
- Adds raw data to `FacetSearchResult` with `getRaw` method;
- Aligns `SimilarDocumentsSearchResult::getHit` method to allow defined default return value when hit by requested key does not exist; 
- Adds `performanceDetails` to `SimilarDocumentsSearchResult`

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public accessors for raw response payload and performance details; getHit now accepts a default value.

* **Improvements**
  * More precise types and documented shapes for search results and facets.
  * Stricter handling of responses: several fields are required rather than optional; pagination/metric fields documented as non-negative integers.

* **Tests**
  * Updated tests to use typed accessors and remove assertions tied to serialized response array shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->