### PR TITLE
Add dynamic search rules

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -591,3 +591,24 @@ update_network_1: |-
       ]
     ]
   ]);
+list_dynamic_search_rules_1: |-
+  $client->getDynamicSearchRules();
+get_dynamic_search_rule_1: |-
+  $client->getDynamicSearchRule('RULE_UID');
+patch_dynamic_search_rule_1: |-
+  $client->updateDynamicSearchRule('RULE_UID', [
+    'actions' => [
+      [
+        'selector' => [
+          'indexUid' => 'movies',
+          'id' => '299537'
+        ],
+        'action' => [
+          'type' => 'pin',
+          'position' => 0
+        ]
+      ]
+    ]
+  ]);
+delete_dynamic_search_rule_1: |-
+  $client->deleteDynamicSearchRule('RULE_UID');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Workflow
+
+- Lint when the task is finished.
+
+## Commands
+
+Use Docker Compose to run commands:
+- Tests: `docker compose run --rm package bash -c "composer install && composer test"`
+- Lint: `docker compose run --rm package bash -c "composer lint && composer phpstan"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.37.0
+    image: getmeili/meilisearch-enterprise:v1.42.0
     ports:
       - "7700"
     environment:

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use Meilisearch\Endpoints\ChatWorkspaces;
 use Meilisearch\Endpoints\Delegates\HandlesBatches;
 use Meilisearch\Endpoints\Delegates\HandlesChatWorkspaces;
 use Meilisearch\Endpoints\Delegates\HandlesDumps;
+use Meilisearch\Endpoints\Delegates\HandlesDynamicSearchRules;
 use Meilisearch\Endpoints\Delegates\HandlesIndex;
 use Meilisearch\Endpoints\Delegates\HandlesKeys;
 use Meilisearch\Endpoints\Delegates\HandlesMultiSearch;
@@ -17,6 +18,7 @@ use Meilisearch\Endpoints\Delegates\HandlesSnapshots;
 use Meilisearch\Endpoints\Delegates\HandlesSystem;
 use Meilisearch\Endpoints\Delegates\HandlesTasks;
 use Meilisearch\Endpoints\Dumps;
+use Meilisearch\Endpoints\DynamicSearchRules;
 use Meilisearch\Endpoints\Health;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Endpoints\Keys;
@@ -43,6 +45,7 @@ class Client
     use HandlesMultiSearch;
     use HandlesBatches;
     use HandlesNetwork;
+    use HandlesDynamicSearchRules;
 
     /**
      * @param array<int, string> $clientAgents
@@ -68,5 +71,6 @@ class Client
         $this->snapshots = new Snapshots($this->http);
         $this->tenantToken = new TenantToken($this->http, $apiKey);
         $this->network = new Network($this->http);
+        $this->dynamicSearchRules = new DynamicSearchRules($this->http);
     }
 }

--- a/src/Contracts/AGENTS.md
+++ b/src/Contracts/AGENTS.md
@@ -1,5 +1,4 @@
 # Contract Typing
 
 - Use precise PHPStan array shapes over `array<string, mixed>`
-- Import shared aliases with `@phpstan-import-type` instead of duplicating shapes
 - Type `toArray()` with the most accurate known shape

--- a/src/Contracts/AGENTS.md
+++ b/src/Contracts/AGENTS.md
@@ -1,0 +1,5 @@
+# Contract Typing
+
+- Use precise PHPStan array shapes over `array<string, mixed>`
+- Import shared aliases with `@phpstan-import-type` instead of duplicating shapes
+- Type `toArray()` with the most accurate known shape

--- a/src/Contracts/DynamicSearchRule.php
+++ b/src/Contracts/DynamicSearchRule.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+final class DynamicSearchRule
+{
+    /**
+     * @param non-empty-string                $uid
+     * @param list<array<string, mixed>>      $actions
+     * @param non-negative-int|null           $priority
+     * @param list<array<string, mixed>>|null $conditions
+     * @param array<string, mixed>            $raw
+     */
+    public function __construct(
+        private readonly string $uid,
+        private readonly array $actions,
+        private readonly ?string $description = null,
+        private readonly ?int $priority = null,
+        private readonly ?bool $active = null,
+        private readonly ?array $conditions = null,
+        private readonly array $raw = [],
+    ) {
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function getActions(): array
+    {
+        return $this->actions;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getPriority(): ?int
+    {
+        return $this->priority;
+    }
+
+    public function isActive(): ?bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * @return list<array<string, mixed>>|null
+     */
+    public function getConditions(): ?array
+    {
+        return $this->conditions;
+    }
+
+    /**
+     * Return the original dynamic search rule.
+     *
+     * @return array<string, mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @return array{
+     *     uid: non-empty-string,
+     *     description?: string|null,
+     *     priority?: non-negative-int|null,
+     *     active?: bool,
+     *     conditions?: list<array<string, mixed>>,
+     *     actions: list<array<string, mixed>>
+     * }
+     */
+    public function toArray(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @param array{
+     *     uid: non-empty-string,
+     *     description?: string|null,
+     *     priority?: non-negative-int|null,
+     *     active?: bool,
+     *     conditions?: list<array<string, mixed>>,
+     *     actions: list<array<string, mixed>>
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            uid: $data['uid'],
+            actions: $data['actions'],
+            description: $data['description'] ?? null,
+            priority: $data['priority'] ?? null,
+            active: $data['active'] ?? null,
+            conditions: $data['conditions'] ?? null,
+            raw: $data,
+        );
+    }
+}

--- a/src/Contracts/DynamicSearchRule.php
+++ b/src/Contracts/DynamicSearchRule.php
@@ -4,14 +4,47 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+/**
+ * @phpstan-type SearchRuleSelector array{
+ *     indexUid?: non-empty-string|null,
+ *     id?: non-empty-string|null
+ * }
+ * @phpstan-type SearchRulePinAction array{
+ *     type: 'pin',
+ *     position: int
+ * }
+ * @phpstan-type SearchRuleAction array{
+ *     selector: SearchRuleSelector,
+ *     action: SearchRulePinAction
+ * }
+ * @phpstan-type SearchRuleQueryCondition array{
+ *     scope: 'query',
+ *     isEmpty?: bool|null,
+ *     contains?: non-empty-string|null
+ * }
+ * @phpstan-type SearchRuleTimeCondition array{
+ *     scope: 'time',
+ *     start?: non-empty-string|null,
+ *     end?: non-empty-string|null
+ * }
+ * @phpstan-type SearchRuleCondition SearchRuleQueryCondition|SearchRuleTimeCondition
+ * @phpstan-type RawDynamicSearchRule array{
+ *     uid: non-empty-string,
+ *     description?: string|null,
+ *     priority?: non-negative-int|null,
+ *     active?: bool,
+ *     conditions?: list<SearchRuleCondition>,
+ *     actions: list<SearchRuleAction>
+ * }
+ */
 final class DynamicSearchRule
 {
     /**
-     * @param non-empty-string                $uid
-     * @param list<array<string, mixed>>      $actions
-     * @param non-negative-int|null           $priority
-     * @param list<array<string, mixed>>|null $conditions
-     * @param array<string, mixed>            $raw
+     * @param non-empty-string               $uid
+     * @param list<SearchRuleAction>         $actions
+     * @param non-negative-int|null          $priority
+     * @param list<SearchRuleCondition>|null $conditions
+     * @param array<string, mixed>           $raw
      */
     public function __construct(
         private readonly string $uid,
@@ -30,7 +63,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @return list<array<string, mixed>>
+     * @return list<SearchRuleAction>
      */
     public function getActions(): array
     {
@@ -53,7 +86,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @return list<array<string, mixed>>|null
+     * @return list<SearchRuleCondition>|null
      */
     public function getConditions(): ?array
     {
@@ -71,14 +104,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @return array{
-     *     uid: non-empty-string,
-     *     description?: string|null,
-     *     priority?: non-negative-int|null,
-     *     active?: bool,
-     *     conditions?: list<array<string, mixed>>,
-     *     actions: list<array<string, mixed>>
-     * }
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {
@@ -86,14 +112,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @param array{
-     *     uid: non-empty-string,
-     *     description?: string|null,
-     *     priority?: non-negative-int|null,
-     *     active?: bool,
-     *     conditions?: list<array<string, mixed>>,
-     *     actions: list<array<string, mixed>>
-     * } $data
+     * @param RawDynamicSearchRule $data
      */
     public static function fromArray(array $data): self
     {

--- a/src/Contracts/DynamicSearchRule.php
+++ b/src/Contracts/DynamicSearchRule.php
@@ -40,21 +40,41 @@ namespace Meilisearch\Contracts;
 final class DynamicSearchRule
 {
     /**
-     * @param non-empty-string               $uid
-     * @param list<SearchRuleAction>         $actions
-     * @param non-negative-int|null          $priority
-     * @param list<SearchRuleCondition>|null $conditions
-     * @param array<string, mixed>           $raw
+     * @var non-empty-string
+     */
+    private readonly string $uid;
+
+    /**
+     * @var list<SearchRuleAction>
+     */
+    private readonly array $actions;
+
+    private readonly ?string $description;
+
+    /**
+     * @var non-negative-int|null
+     */
+    private readonly ?int $priority;
+
+    private readonly ?bool $active;
+
+    /**
+     * @var list<SearchRuleCondition>|null
+     */
+    private readonly ?array $conditions;
+
+    /**
+     * @param RawDynamicSearchRule $raw
      */
     public function __construct(
-        private readonly string $uid,
-        private readonly array $actions,
-        private readonly ?string $description = null,
-        private readonly ?int $priority = null,
-        private readonly ?bool $active = null,
-        private readonly ?array $conditions = null,
-        private readonly array $raw = [],
+        private readonly array $raw,
     ) {
+        $this->uid = $raw['uid'];
+        $this->actions = $raw['actions'];
+        $this->description = $raw['description'] ?? null;
+        $this->priority = $raw['priority'] ?? null;
+        $this->active = $raw['active'] ?? null;
+        $this->conditions = $raw['conditions'] ?? null;
     }
 
     public function getUid(): string
@@ -96,7 +116,7 @@ final class DynamicSearchRule
     /**
      * Return the original dynamic search rule.
      *
-     * @return array<string, mixed>
+     * @return RawDynamicSearchRule
      */
     public function getRaw(): array
     {
@@ -104,7 +124,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @return array<string, mixed>
+     * @return RawDynamicSearchRule
      */
     public function toArray(): array
     {
@@ -116,14 +136,6 @@ final class DynamicSearchRule
      */
     public static function fromArray(array $data): self
     {
-        return new self(
-            uid: $data['uid'],
-            actions: $data['actions'],
-            description: $data['description'] ?? null,
-            priority: $data['priority'] ?? null,
-            active: $data['active'] ?? null,
-            conditions: $data['conditions'] ?? null,
-            raw: $data,
-        );
+        return new self($data);
     }
 }

--- a/src/Contracts/DynamicSearchRulesFilter.php
+++ b/src/Contracts/DynamicSearchRulesFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class DynamicSearchRulesFilter
+{
+    /**
+     * @var list<non-empty-string>|null
+     */
+    private ?array $attributePatterns = null;
+
+    private ?bool $active = null;
+
+    /**
+     * @param list<non-empty-string> $patterns
+     *
+     * @return $this
+     */
+    public function setAttributePatterns(array $patterns): self
+    {
+        $this->attributePatterns = $patterns;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    /**
+     * @return array{
+     *     attributePatterns?: list<non-empty-string>,
+     *     active?: bool
+     * }
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'attributePatterns' => $this->attributePatterns,
+            'active' => $this->active,
+        ], static function ($item) { return null !== $item; });
+    }
+}

--- a/src/Contracts/DynamicSearchRulesFilter.php
+++ b/src/Contracts/DynamicSearchRulesFilter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class DynamicSearchRulesFilter
+final class DynamicSearchRulesFilter
 {
     /**
      * @var list<non-empty-string>|null

--- a/src/Contracts/DynamicSearchRulesQuery.php
+++ b/src/Contracts/DynamicSearchRulesQuery.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class DynamicSearchRulesQuery
+{
+    /**
+     * @var non-negative-int|null
+     */
+    private ?int $offset = null;
+
+    /**
+     * @var non-negative-int|null
+     */
+    private ?int $limit = null;
+
+    private ?DynamicSearchRulesFilter $filter = null;
+
+    /**
+     * @param non-negative-int $offset
+     *
+     * @return $this
+     */
+    public function setOffset(int $offset): self
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    /**
+     * @param non-negative-int $limit
+     *
+     * @return $this
+     */
+    public function setLimit(int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFilter(DynamicSearchRulesFilter $filter): self
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    /**
+     * @return array{
+     *     offset?: non-negative-int,
+     *     limit?: non-negative-int,
+     *     filter?: array{
+     *         attributePatterns?: list<non-empty-string>,
+     *         active?: bool
+     *     }
+     * }
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'filter' => null !== $this->filter ? $this->filter->toArray() : null,
+        ], static function ($item) { return null !== $item; });
+    }
+}

--- a/src/Contracts/DynamicSearchRulesQuery.php
+++ b/src/Contracts/DynamicSearchRulesQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class DynamicSearchRulesQuery
+final class DynamicSearchRulesQuery
 {
     /**
      * @var non-negative-int|null

--- a/src/Contracts/DynamicSearchRulesResults.php
+++ b/src/Contracts/DynamicSearchRulesResults.php
@@ -39,7 +39,7 @@ final class DynamicSearchRulesResults extends Data
     }
 
     /**
-     * @return array<int, DynamicSearchRule>
+     * @return list<DynamicSearchRule>
      */
     public function getResults(): array
     {
@@ -72,7 +72,7 @@ final class DynamicSearchRulesResults extends Data
 
     /**
      * @return array{
-     *     results: array<int, DynamicSearchRule>,
+     *     results: list<DynamicSearchRule>,
      *     offset: non-negative-int,
      *     limit: non-negative-int,
      *     total: non-negative-int

--- a/src/Contracts/DynamicSearchRulesResults.php
+++ b/src/Contracts/DynamicSearchRulesResults.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+final class DynamicSearchRulesResults extends Data
+{
+    /**
+     * @var non-negative-int
+     */
+    private int $offset;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $limit;
+
+    /**
+     * @var non-negative-int
+     */
+    private int $total;
+
+    /**
+     * @param array{
+     *     results: array<int, DynamicSearchRule>,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     total: non-negative-int
+     * } $params
+     */
+    public function __construct(array $params)
+    {
+        parent::__construct($params['results']);
+
+        $this->offset = $params['offset'];
+        $this->limit = $params['limit'];
+        $this->total = $params['total'];
+    }
+
+    /**
+     * @return array<int, DynamicSearchRule>
+     */
+    public function getResults(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return non-negative-int
+     */
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    /**
+     * @return non-negative-int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    /**
+     * @return non-negative-int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return array{
+     *     results: array<int, DynamicSearchRule>,
+     *     offset: non-negative-int,
+     *     limit: non-negative-int,
+     *     total: non-negative-int
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'results' => $this->data,
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'total' => $this->total,
+        ];
+    }
+}

--- a/src/Contracts/DynamicSearchRulesResults.php
+++ b/src/Contracts/DynamicSearchRulesResults.php
@@ -23,7 +23,7 @@ final class DynamicSearchRulesResults extends Data
 
     /**
      * @param array{
-     *     results: array<int, DynamicSearchRule>,
+     *     results: list<DynamicSearchRule>,
      *     offset: non-negative-int,
      *     limit: non-negative-int,
      *     total: non-negative-int

--- a/src/Contracts/UpdateDynamicSearchRuleQuery.php
+++ b/src/Contracts/UpdateDynamicSearchRuleQuery.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
+/**
+ * @phpstan-import-type SearchRuleAction from DynamicSearchRule
+ * @phpstan-import-type SearchRuleCondition from DynamicSearchRule
+ */
 final class UpdateDynamicSearchRuleQuery
 {
     private bool $hasDescription = false;
@@ -22,12 +26,12 @@ final class UpdateDynamicSearchRuleQuery
     private ?bool $active = null;
 
     /**
-     * @var list<array<string, mixed>>|null
+     * @var list<SearchRuleCondition>|null
      */
     private ?array $conditions = null;
 
     /**
-     * @var list<array<string, mixed>>|null
+     * @var list<SearchRuleAction>|null
      */
     private ?array $actions = null;
 
@@ -74,11 +78,11 @@ final class UpdateDynamicSearchRuleQuery
     }
 
     /**
-     * @param list<array<string, mixed>> $conditions
+     * @param list<SearchRuleCondition>|null $conditions
      *
      * @return $this
      */
-    public function setConditions(array $conditions): self
+    public function setConditions(?array $conditions): self
     {
         $this->conditions = $conditions;
         $this->hasConditions = true;
@@ -87,11 +91,11 @@ final class UpdateDynamicSearchRuleQuery
     }
 
     /**
-     * @param list<array<string, mixed>> $actions
+     * @param list<SearchRuleAction>|null $actions
      *
      * @return $this
      */
-    public function setActions(array $actions): self
+    public function setActions(?array $actions): self
     {
         $this->actions = $actions;
         $this->hasActions = true;
@@ -104,8 +108,8 @@ final class UpdateDynamicSearchRuleQuery
      *     description?: string|null,
      *     priority?: non-negative-int|null,
      *     active?: bool,
-     *     conditions?: list<array<string, mixed>>,
-     *     actions?: list<array<string, mixed>>
+     *     conditions?: list<SearchRuleCondition>|null,
+     *     actions?: list<SearchRuleAction>|null
      * }
      */
     public function toArray(): array

--- a/src/Contracts/UpdateDynamicSearchRuleQuery.php
+++ b/src/Contracts/UpdateDynamicSearchRuleQuery.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+final class UpdateDynamicSearchRuleQuery
+{
+    private bool $hasDescription = false;
+    private bool $hasPriority = false;
+    private bool $hasActive = false;
+    private bool $hasConditions = false;
+    private bool $hasActions = false;
+
+    private ?string $description = null;
+
+    /**
+     * @var non-negative-int|null
+     */
+    private ?int $priority = null;
+
+    private ?bool $active = null;
+
+    /**
+     * @var list<array<string, mixed>>|null
+     */
+    private ?array $conditions = null;
+
+    /**
+     * @var list<array<string, mixed>>|null
+     */
+    private ?array $actions = null;
+
+    /**
+     * @param non-empty-string $uid
+     */
+    public function __construct(public readonly string $uid)
+    {
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        $this->hasDescription = true;
+
+        return $this;
+    }
+
+    /**
+     * @param non-negative-int|null $priority
+     *
+     * @return $this
+     */
+    public function setPriority(?int $priority): self
+    {
+        $this->priority = $priority;
+        $this->hasPriority = true;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
+        $this->hasActive = true;
+
+        return $this;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $conditions
+     *
+     * @return $this
+     */
+    public function setConditions(array $conditions): self
+    {
+        $this->conditions = $conditions;
+        $this->hasConditions = true;
+
+        return $this;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $actions
+     *
+     * @return $this
+     */
+    public function setActions(array $actions): self
+    {
+        $this->actions = $actions;
+        $this->hasActions = true;
+
+        return $this;
+    }
+
+    /**
+     * @return array{
+     *     description?: string|null,
+     *     priority?: non-negative-int|null,
+     *     active?: bool,
+     *     conditions?: list<array<string, mixed>>,
+     *     actions?: list<array<string, mixed>>
+     * }
+     */
+    public function toArray(): array
+    {
+        $payload = [];
+
+        if ($this->hasDescription) {
+            $payload['description'] = $this->description;
+        }
+
+        if ($this->hasPriority) {
+            $payload['priority'] = $this->priority;
+        }
+
+        if ($this->hasActive) {
+            $payload['active'] = $this->active;
+        }
+
+        if ($this->hasConditions) {
+            $payload['conditions'] = $this->conditions;
+        }
+
+        if ($this->hasActions) {
+            $payload['actions'] = $this->actions;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Endpoints/AGENTS.md
+++ b/src/Endpoints/AGENTS.md
@@ -1,5 +1,4 @@
 # Endpoint Typing
 
-- Define endpoint-only response aliases locally; import contract aliases with `@phpstan-import-type`
 - Map raw API arrays into contract objects (`src/Contracts`) at the endpoint boundary
 - Do not weaken known payloads to `array<string, mixed>` unless the API data is intentionally arbitrary

--- a/src/Endpoints/AGENTS.md
+++ b/src/Endpoints/AGENTS.md
@@ -1,0 +1,5 @@
+# Endpoint Typing
+
+- Define endpoint-only response aliases locally; import contract aliases with `@phpstan-import-type`
+- Map raw API arrays into contract objects (`src/Contracts`) at the endpoint boundary
+- Do not weaken known payloads to `array<string, mixed>` unless the API data is intentionally arbitrary

--- a/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
+++ b/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
@@ -4,47 +4,32 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints\Delegates;
 
+use Meilisearch\Contracts\DynamicSearchRule;
+use Meilisearch\Contracts\DynamicSearchRulesQuery;
+use Meilisearch\Contracts\DynamicSearchRulesResults;
+use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 use Meilisearch\Endpoints\DynamicSearchRules;
 
-/**
- * @phpstan-import-type DynamicSearchRuleUpdatePayload from DynamicSearchRules
- * @phpstan-import-type DynamicSearchRulesQuery from DynamicSearchRules
- * @phpstan-import-type RawDynamicSearchRule from DynamicSearchRules
- * @phpstan-import-type RawDynamicSearchRules from DynamicSearchRules
- */
 trait HandlesDynamicSearchRules
 {
     protected DynamicSearchRules $dynamicSearchRules;
 
-    /**
-     * @param DynamicSearchRulesQuery $options
-     *
-     * @return RawDynamicSearchRules
-     */
-    public function getDynamicSearchRules(array $options = []): array
+    public function getDynamicSearchRules(?DynamicSearchRulesQuery $options = null): DynamicSearchRulesResults
     {
         return $this->dynamicSearchRules->all($options);
     }
 
     /**
      * @param non-empty-string $uid
-     *
-     * @return RawDynamicSearchRule
      */
-    public function getDynamicSearchRule(string $uid): array
+    public function getDynamicSearchRule(string $uid): DynamicSearchRule
     {
         return $this->dynamicSearchRules->get($uid);
     }
 
-    /**
-     * @param non-empty-string               $uid
-     * @param DynamicSearchRuleUpdatePayload $payload
-     *
-     * @return RawDynamicSearchRule
-     */
-    public function updateDynamicSearchRule(string $uid, array $payload): array
+    public function updateDynamicSearchRule(UpdateDynamicSearchRuleQuery $request): DynamicSearchRule
     {
-        return $this->dynamicSearchRules->update($uid, $payload);
+        return $this->dynamicSearchRules->update($request);
     }
 
     /**

--- a/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
+++ b/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints\Delegates;
+
+use Meilisearch\Endpoints\DynamicSearchRules;
+
+/**
+ * @phpstan-import-type DynamicSearchRuleUpdatePayload from DynamicSearchRules
+ * @phpstan-import-type DynamicSearchRulesQuery from DynamicSearchRules
+ * @phpstan-import-type RawDynamicSearchRule from DynamicSearchRules
+ * @phpstan-import-type RawDynamicSearchRules from DynamicSearchRules
+ */
+trait HandlesDynamicSearchRules
+{
+    protected DynamicSearchRules $dynamicSearchRules;
+
+    /**
+     * @param DynamicSearchRulesQuery $options
+     *
+     * @return RawDynamicSearchRules
+     */
+    public function getDynamicSearchRules(array $options = []): array
+    {
+        return $this->dynamicSearchRules->all($options);
+    }
+
+    /**
+     * @param non-empty-string $uid
+     *
+     * @return RawDynamicSearchRule
+     */
+    public function getDynamicSearchRule(string $uid): array
+    {
+        return $this->dynamicSearchRules->get($uid);
+    }
+
+    /**
+     * @param non-empty-string               $uid
+     * @param DynamicSearchRuleUpdatePayload $payload
+     *
+     * @return RawDynamicSearchRule
+     */
+    public function updateDynamicSearchRule(string $uid, array $payload): array
+    {
+        return $this->dynamicSearchRules->update($uid, $payload);
+    }
+
+    /**
+     * @param non-empty-string $uid
+     */
+    public function deleteDynamicSearchRule(string $uid): ?array
+    {
+        return $this->dynamicSearchRules->delete($uid);
+    }
+}

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -11,14 +11,8 @@ use Meilisearch\Contracts\Endpoint;
 use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 
 /**
- * @phpstan-type RawDynamicSearchRule array{
- *     uid: non-empty-string,
- *     description?: string|null,
- *     priority?: non-negative-int|null,
- *     active?: bool,
- *     conditions?: list<array<string, mixed>>,
- *     actions: list<array<string, mixed>>
- * }
+ * @phpstan-import-type RawDynamicSearchRule from DynamicSearchRule
+ *
  * @phpstan-type RawDynamicSearchRules array{
  *     results: list<RawDynamicSearchRule>,
  *     offset: non-negative-int,

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -20,7 +20,7 @@ use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
  *     total: non-negative-int
  * }
  */
-class DynamicSearchRules extends Endpoint
+final class DynamicSearchRules extends Endpoint
 {
     protected const PATH = '/dynamic-search-rules';
 

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -26,7 +26,7 @@ final class DynamicSearchRules extends Endpoint
 
     public function all(?DynamicSearchRulesQuery $options = null): DynamicSearchRulesResults
     {
-        $query = null !== $options ? $options->toArray() : [];
+        $query = $options?->toArray() ?? [];
 
         $response = $this->http->post(self::PATH, (object) $query);
         $response['results'] = array_map(static fn (array $data) => DynamicSearchRule::fromArray($data), $response['results']);

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Meilisearch\Endpoints;
 
+use Meilisearch\Contracts\DynamicSearchRule;
+use Meilisearch\Contracts\DynamicSearchRulesQuery;
+use Meilisearch\Contracts\DynamicSearchRulesResults;
 use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 
 /**
  * @phpstan-type RawDynamicSearchRule array{
@@ -21,52 +25,36 @@ use Meilisearch\Contracts\Endpoint;
  *     limit: non-negative-int,
  *     total: non-negative-int
  * }
- * @phpstan-type DynamicSearchRulesQuery array{
- *     offset?: non-negative-int,
- *     limit?: non-negative-int,
- *     filter?: array<string, mixed>|null
- * }
- * @phpstan-type DynamicSearchRuleUpdatePayload array{
- *     description?: string|null,
- *     priority?: non-negative-int|null,
- *     active?: bool,
- *     conditions?: list<array<string, mixed>>,
- *     actions?: list<array<string, mixed>>
- * }
  */
 class DynamicSearchRules extends Endpoint
 {
     protected const PATH = '/dynamic-search-rules';
 
-    /**
-     * @param DynamicSearchRulesQuery $options
-     *
-     * @return RawDynamicSearchRules
-     */
-    public function all(array $options = []): array
+    public function all(?DynamicSearchRulesQuery $options = null): DynamicSearchRulesResults
     {
-        return $this->http->post(self::PATH, (object) $options);
+        $query = null !== $options ? $options->toArray() : [];
+
+        $response = $this->http->post(self::PATH, (object) $query);
+        $response['results'] = array_map(static fn (array $data) => DynamicSearchRule::fromArray($data), $response['results']);
+
+        return new DynamicSearchRulesResults($response);
     }
 
     /**
      * @param non-empty-string $uid
-     *
-     * @return RawDynamicSearchRule
      */
-    public function get(string $uid): array
+    public function get(string $uid): DynamicSearchRule
     {
-        return $this->http->get(self::PATH.'/'.$uid);
+        $response = $this->http->get(self::PATH.'/'.$uid);
+
+        return DynamicSearchRule::fromArray($response);
     }
 
-    /**
-     * @param non-empty-string               $uid
-     * @param DynamicSearchRuleUpdatePayload $payload
-     *
-     * @return RawDynamicSearchRule
-     */
-    public function update(string $uid, array $payload): array
+    public function update(UpdateDynamicSearchRuleQuery $request): DynamicSearchRule
     {
-        return $this->http->patch(self::PATH.'/'.$uid, $payload);
+        $response = $this->http->patch(self::PATH.'/'.$request->uid, $request->toArray());
+
+        return DynamicSearchRule::fromArray($response);
     }
 
     /**

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Endpoints;
+
+use Meilisearch\Contracts\Endpoint;
+
+/**
+ * @phpstan-type RawDynamicSearchRule array{
+ *     uid: non-empty-string,
+ *     description?: string|null,
+ *     priority?: non-negative-int|null,
+ *     active?: bool,
+ *     conditions?: list<array<string, mixed>>,
+ *     actions: list<array<string, mixed>>
+ * }
+ * @phpstan-type RawDynamicSearchRules array{
+ *     results: list<RawDynamicSearchRule>,
+ *     offset: non-negative-int,
+ *     limit: non-negative-int,
+ *     total: non-negative-int
+ * }
+ * @phpstan-type DynamicSearchRulesQuery array{
+ *     offset?: non-negative-int,
+ *     limit?: non-negative-int,
+ *     filter?: array<string, mixed>|null
+ * }
+ * @phpstan-type DynamicSearchRuleUpdatePayload array{
+ *     description?: string|null,
+ *     priority?: non-negative-int|null,
+ *     active?: bool,
+ *     conditions?: list<array<string, mixed>>,
+ *     actions?: list<array<string, mixed>>
+ * }
+ */
+class DynamicSearchRules extends Endpoint
+{
+    protected const PATH = '/dynamic-search-rules';
+
+    /**
+     * @param DynamicSearchRulesQuery $options
+     *
+     * @return RawDynamicSearchRules
+     */
+    public function all(array $options = []): array
+    {
+        return $this->http->post(self::PATH, (object) $options);
+    }
+
+    /**
+     * @param non-empty-string $uid
+     *
+     * @return RawDynamicSearchRule
+     */
+    public function get(string $uid): array
+    {
+        return $this->http->get(self::PATH.'/'.$uid);
+    }
+
+    /**
+     * @param non-empty-string               $uid
+     * @param DynamicSearchRuleUpdatePayload $payload
+     *
+     * @return RawDynamicSearchRule
+     */
+    public function update(string $uid, array $payload): array
+    {
+        return $this->http->patch(self::PATH.'/'.$uid, $payload);
+    }
+
+    /**
+     * @param non-empty-string $uid
+     */
+    public function delete(string $uid): ?array
+    {
+        return $this->http->delete(self::PATH.'/'.$uid);
+    }
+}

--- a/tests/Contracts/DynamicSearchRuleTest.php
+++ b/tests/Contracts/DynamicSearchRuleTest.php
@@ -19,14 +19,20 @@ final class DynamicSearchRuleTest extends TestCase
             'conditions' => [
                 [
                     'scope' => 'query',
+                    'isEmpty' => false,
                     'contains' => 'movie',
+                ],
+                [
+                    'scope' => 'time',
+                    'start' => '2026-01-01T00:00:00Z',
+                    'end' => null,
                 ],
             ],
             'actions' => [
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => '1',
+                        'id' => null,
                     ],
                     'action' => [
                         'type' => 'pin',

--- a/tests/Contracts/DynamicSearchRuleTest.php
+++ b/tests/Contracts/DynamicSearchRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\DynamicSearchRule;
+use PHPUnit\Framework\TestCase;
+
+final class DynamicSearchRuleTest extends TestCase
+{
+    public function testFromArray(): void
+    {
+        $raw = [
+            'uid' => 'movie-rule',
+            'description' => 'Movie promotion',
+            'priority' => 1,
+            'active' => true,
+            'conditions' => [
+                [
+                    'scope' => 'query',
+                    'contains' => 'movie',
+                ],
+            ],
+            'actions' => [
+                [
+                    'selector' => [
+                        'indexUid' => 'movies',
+                        'id' => '1',
+                    ],
+                    'action' => [
+                        'type' => 'pin',
+                        'position' => 1,
+                    ],
+                ],
+            ],
+        ];
+
+        $rule = DynamicSearchRule::fromArray($raw);
+
+        self::assertSame('movie-rule', $rule->getUid());
+        self::assertSame('Movie promotion', $rule->getDescription());
+        self::assertSame(1, $rule->getPriority());
+        self::assertTrue($rule->isActive());
+        self::assertSame($raw['conditions'], $rule->getConditions());
+        self::assertSame($raw['actions'], $rule->getActions());
+        self::assertSame($raw, $rule->getRaw());
+        self::assertSame($raw, $rule->toArray());
+    }
+}

--- a/tests/Contracts/DynamicSearchRulesQueryTest.php
+++ b/tests/Contracts/DynamicSearchRulesQueryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\DynamicSearchRulesFilter;
+use Meilisearch\Contracts\DynamicSearchRulesQuery;
+use PHPUnit\Framework\TestCase;
+
+final class DynamicSearchRulesQueryTest extends TestCase
+{
+    public function testEmptyQuery(): void
+    {
+        $data = new DynamicSearchRulesQuery();
+
+        self::assertSame([], $data->toArray());
+    }
+
+    public function testSetOffsetAndLimit(): void
+    {
+        $data = (new DynamicSearchRulesQuery())
+            ->setOffset(5)
+            ->setLimit(10);
+
+        self::assertSame([
+            'offset' => 5,
+            'limit' => 10,
+        ], $data->toArray());
+    }
+
+    public function testSetFilter(): void
+    {
+        $data = (new DynamicSearchRulesQuery())
+            ->setFilter(
+                (new DynamicSearchRulesFilter())
+                    ->setAttributePatterns(['movie-rule', 'promo*'])
+                    ->setActive(true)
+            );
+
+        self::assertSame([
+            'filter' => [
+                'attributePatterns' => ['movie-rule', 'promo*'],
+                'active' => true,
+            ],
+        ], $data->toArray());
+    }
+}

--- a/tests/Contracts/DynamicSearchRulesResultsTest.php
+++ b/tests/Contracts/DynamicSearchRulesResultsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\DynamicSearchRule;
+use Meilisearch\Contracts\DynamicSearchRulesResults;
+use PHPUnit\Framework\TestCase;
+
+final class DynamicSearchRulesResultsTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $firstRule = DynamicSearchRule::fromArray([
+            'uid' => 'movie-rule',
+            'actions' => [
+                [
+                    'selector' => ['indexUid' => 'movies', 'id' => '1'],
+                    'action' => ['type' => 'pin', 'position' => 1],
+                ],
+            ],
+        ]);
+        $secondRule = DynamicSearchRule::fromArray([
+            'uid' => 'book-rule',
+            'actions' => [
+                [
+                    'selector' => ['indexUid' => 'books', 'id' => '2'],
+                    'action' => ['type' => 'pin', 'position' => 2],
+                ],
+            ],
+        ]);
+
+        $results = new DynamicSearchRulesResults([
+            'results' => [$firstRule, $secondRule],
+            'offset' => 1,
+            'limit' => 2,
+            'total' => 5,
+        ]);
+
+        self::assertCount(2, $results);
+        self::assertSame(1, $results->getOffset());
+        self::assertSame(2, $results->getLimit());
+        self::assertSame(5, $results->getTotal());
+        self::assertSame('movie-rule', $results->getResults()[0]->getUid());
+        self::assertSame('book-rule', $results[1]->getUid());
+
+        $array = $results->toArray();
+        self::assertSame(1, $array['offset']);
+        self::assertSame(2, $array['limit']);
+        self::assertSame(5, $array['total']);
+        self::assertCount(2, $array['results']);
+    }
+}

--- a/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
+++ b/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateDynamicSearchRuleQueryTest extends TestCase
+{
+    public function testActionOnlyPayload(): void
+    {
+        $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
+            ->setActions([
+                [
+                    'selector' => [
+                        'indexUid' => 'movies',
+                        'id' => '1',
+                    ],
+                    'action' => [
+                        'type' => 'pin',
+                        'position' => 1,
+                    ],
+                ],
+            ]);
+
+        self::assertSame('movie-rule', $data->uid);
+        self::assertSame([
+            'actions' => [
+                [
+                    'selector' => [
+                        'indexUid' => 'movies',
+                        'id' => '1',
+                    ],
+                    'action' => [
+                        'type' => 'pin',
+                        'position' => 1,
+                    ],
+                ],
+            ],
+        ], $data->toArray());
+    }
+
+    public function testNullableFieldsCanBeExplicitlySetToNull(): void
+    {
+        $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
+            ->setDescription(null)
+            ->setPriority(null);
+
+        self::assertSame([
+            'description' => null,
+            'priority' => null,
+        ], $data->toArray());
+    }
+
+    public function testFullPayload(): void
+    {
+        $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
+            ->setDescription('Movie promotion')
+            ->setPriority(2)
+            ->setActive(true)
+            ->setConditions([
+                [
+                    'scope' => 'query',
+                    'contains' => 'movie',
+                ],
+            ])
+            ->setActions([
+                [
+                    'selector' => [
+                        'indexUid' => 'movies',
+                        'id' => '1',
+                    ],
+                    'action' => [
+                        'type' => 'pin',
+                        'position' => 1,
+                    ],
+                ],
+            ]);
+
+        self::assertSame([
+            'description' => 'Movie promotion',
+            'priority' => 2,
+            'active' => true,
+            'conditions' => [
+                [
+                    'scope' => 'query',
+                    'contains' => 'movie',
+                ],
+            ],
+            'actions' => [
+                [
+                    'selector' => [
+                        'indexUid' => 'movies',
+                        'id' => '1',
+                    ],
+                    'action' => [
+                        'type' => 'pin',
+                        'position' => 1,
+                    ],
+                ],
+            ],
+        ], $data->toArray());
+    }
+}

--- a/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
+++ b/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
@@ -54,6 +54,18 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
         ], $data->toArray());
     }
 
+    public function testNullableActionsAndConditionsCanBeExplicitlySetToNull(): void
+    {
+        $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
+            ->setConditions(null)
+            ->setActions(null);
+
+        self::assertSame([
+            'conditions' => null,
+            'actions' => null,
+        ], $data->toArray());
+    }
+
     public function testFullPayload(): void
     {
         $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
@@ -63,14 +75,20 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
             ->setConditions([
                 [
                     'scope' => 'query',
+                    'isEmpty' => false,
                     'contains' => 'movie',
+                ],
+                [
+                    'scope' => 'time',
+                    'start' => '2026-01-01T00:00:00Z',
+                    'end' => null,
                 ],
             ])
             ->setActions([
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => '1',
+                        'id' => null,
                     ],
                     'action' => [
                         'type' => 'pin',
@@ -86,14 +104,20 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
             'conditions' => [
                 [
                     'scope' => 'query',
+                    'isEmpty' => false,
                     'contains' => 'movie',
+                ],
+                [
+                    'scope' => 'time',
+                    'start' => '2026-01-01T00:00:00Z',
+                    'end' => null,
                 ],
             ],
             'actions' => [
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => '1',
+                        'id' => null,
                     ],
                     'action' => [
                         'type' => 'pin',

--- a/tests/Endpoints/DynamicSearchRulesTest.php
+++ b/tests/Endpoints/DynamicSearchRulesTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Endpoints;
 
+use Meilisearch\Contracts\DynamicSearchRulesFilter;
+use Meilisearch\Contracts\DynamicSearchRulesQuery;
+use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 use Meilisearch\Http\Client;
 use Tests\TestCase;
 
-final class SearchRulesTest extends TestCase
+final class DynamicSearchRulesTest extends TestCase
 {
     private const SEARCH_RULE_UID = 'movie-rule';
     private const SEARCH_RULE_PATCH = [
@@ -37,8 +40,8 @@ final class SearchRulesTest extends TestCase
     {
         $response = $this->client->getDynamicSearchRules();
 
-        foreach ($response['results'] as $rule) {
-            $this->client->deleteDynamicSearchRule($rule['uid']);
+        foreach ($response as $rule) {
+            $this->client->deleteDynamicSearchRule($rule->getUid());
         }
 
         parent::tearDown();
@@ -47,49 +50,46 @@ final class SearchRulesTest extends TestCase
     public function testCanListDynamicSearchRules(): void
     {
         $this->client->updateDynamicSearchRule(
-            self::SEARCH_RULE_UID,
-            self::SEARCH_RULE_PATCH
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
         );
 
-        $response = $this->client->getDynamicSearchRules([
-            'offset' => 0,
-            'limit' => 20,
-            'filter' => ['attributePatterns' => [self::SEARCH_RULE_UID]],
-        ]);
+        $response = $this->client->getDynamicSearchRules(
+            (new DynamicSearchRulesQuery())
+                ->setOffset(0)
+                ->setLimit(20)
+                ->setFilter((new DynamicSearchRulesFilter())->setAttributePatterns([self::SEARCH_RULE_UID]))
+        );
 
-        self::assertCount(1, $response['results']);
-        self::assertSame(self::SEARCH_RULE_UID, $response['results'][0]['uid']);
+        self::assertCount(1, $response);
+        self::assertSame(self::SEARCH_RULE_UID, $response->getResults()[0]->getUid());
     }
 
     public function testCanCreateOrUpdateDynamicSearchRule(): void
     {
         $response = $this->client->updateDynamicSearchRule(
-            self::SEARCH_RULE_UID,
-            self::SEARCH_RULE_PATCH
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
         );
 
-        self::assertSame(self::SEARCH_RULE_UID, $response['uid']);
-        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response['actions']);
+        self::assertSame(self::SEARCH_RULE_UID, $response->getUid());
+        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response->getActions());
     }
 
     public function testCanFetchDynamicSearchRule(): void
     {
         $this->client->updateDynamicSearchRule(
-            self::SEARCH_RULE_UID,
-            self::SEARCH_RULE_PATCH
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
         );
 
         $response = $this->client->getDynamicSearchRule(self::SEARCH_RULE_UID);
 
-        self::assertSame(self::SEARCH_RULE_UID, $response['uid']);
-        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response['actions']);
+        self::assertSame(self::SEARCH_RULE_UID, $response->getUid());
+        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response->getActions());
     }
 
     public function testCanDeleteDynamicSearchRule(): void
     {
         $this->client->updateDynamicSearchRule(
-            self::SEARCH_RULE_UID,
-            self::SEARCH_RULE_PATCH
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
         );
 
         $response = $this->client->deleteDynamicSearchRule(self::SEARCH_RULE_UID);

--- a/tests/Endpoints/SearchRulesTest.php
+++ b/tests/Endpoints/SearchRulesTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Endpoints;
+
+use Meilisearch\Http\Client;
+use Tests\TestCase;
+
+final class SearchRulesTest extends TestCase
+{
+    private const SEARCH_RULE_UID = 'movie-rule';
+    private const SEARCH_RULE_PATCH = [
+        'actions' => [
+            [
+                'selector' => [
+                    'indexUid' => 'movies',
+                    'id' => '1',
+                ],
+                'action' => [
+                    'type' => 'pin',
+                    'position' => 1,
+                ],
+            ],
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $http = new Client($this->host, getenv('MEILISEARCH_API_KEY'));
+        $http->patch('/experimental-features', ['dynamicSearchRules' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        $response = $this->client->getDynamicSearchRules();
+
+        foreach ($response['results'] as $rule) {
+            $this->client->deleteDynamicSearchRule($rule['uid']);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testCanListDynamicSearchRules(): void
+    {
+        $this->client->updateDynamicSearchRule(
+            self::SEARCH_RULE_UID,
+            self::SEARCH_RULE_PATCH
+        );
+
+        $response = $this->client->getDynamicSearchRules([
+            'offset' => 0,
+            'limit' => 20,
+            'filter' => ['attributePatterns' => [self::SEARCH_RULE_UID]],
+        ]);
+
+        self::assertCount(1, $response['results']);
+        self::assertSame(self::SEARCH_RULE_UID, $response['results'][0]['uid']);
+    }
+
+    public function testCanCreateOrUpdateDynamicSearchRule(): void
+    {
+        $response = $this->client->updateDynamicSearchRule(
+            self::SEARCH_RULE_UID,
+            self::SEARCH_RULE_PATCH
+        );
+
+        self::assertSame(self::SEARCH_RULE_UID, $response['uid']);
+        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response['actions']);
+    }
+
+    public function testCanFetchDynamicSearchRule(): void
+    {
+        $this->client->updateDynamicSearchRule(
+            self::SEARCH_RULE_UID,
+            self::SEARCH_RULE_PATCH
+        );
+
+        $response = $this->client->getDynamicSearchRule(self::SEARCH_RULE_UID);
+
+        self::assertSame(self::SEARCH_RULE_UID, $response['uid']);
+        self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response['actions']);
+    }
+
+    public function testCanDeleteDynamicSearchRule(): void
+    {
+        $this->client->updateDynamicSearchRule(
+            self::SEARCH_RULE_UID,
+            self::SEARCH_RULE_PATCH
+        );
+
+        $response = $this->client->deleteDynamicSearchRule(self::SEARCH_RULE_UID);
+
+        self::assertNull($response);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #904 

## What does this PR do?
- Bump docker-compose.yml meilisearch version to v1.42
- Add methods to interact with the dynamic search rules API: get, createOrUpdate, list, and delete
- Add relevant code samples
- Added `AGENTS.md`

## AI disclosure
Cursor with `gpt-5.5-medium`, and `gpt-5.3-codex-medium`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic search rules: list, fetch, update (patch) and delete with filtering, pagination, and client access.

* **Documentation**
  * Added workflow guidance, endpoint/contract typing guidance, Docker Compose commands, and PHP code samples for dynamic search rules and lint/test commands.

* **Tests**
  * Added unit and endpoint tests for contracts, queries, results, updates, and lifecycle behaviors.

* **Chores**
  * Updated Meilisearch service image to v1.42.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->