### PR TITLE
feat(stats): add query params for Meilisearch v1.44 showInternalDatabaseSizes and sizeFormat

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -283,9 +283,9 @@ update_sortable_attributes_1: |-
 reset_sortable_attributes_1: |-
   $client->index('books')->resetSortableAttributes();
 get_index_stats_1: |-
-  $client->index('movies')->stats();
+  $client->index('movies')->stats(['showInternalDatabaseSizes' => true, 'sizeFormat' => 'human']);
 get_indexes_stats_1: |-
-  $client->stats();
+  $client->stats(['showInternalDatabaseSizes' => true, 'sizeFormat' => 'human']);
 get_health_1: |-
   $client->health();
 get_version_1: |-

--- a/src/Contracts/IndexStats.php
+++ b/src/Contracts/IndexStats.php
@@ -8,20 +8,22 @@ final class IndexStats
 {
     /**
      * @param non-negative-int                          $numberOfDocuments
-     * @param non-negative-int                          $rawDocumentDbSize
-     * @param non-negative-int                          $avgDocumentSize
+     * @param int|string                                $rawDocumentDbSize         Bytes or human-readable string
+     * @param int|string                                $avgDocumentSize           Bytes or human-readable string
      * @param non-negative-int                          $numberOfEmbeddings
      * @param non-negative-int                          $numberOfEmbeddedDocuments
      * @param array<non-empty-string, non-negative-int> $fieldDistribution
+     * @param array<non-empty-string, int|string>|null  $internalDatabaseSizes     Present when showInternalDatabaseSizes=true; keys subject to change
      */
     public function __construct(
         private readonly int $numberOfDocuments,
-        private readonly int $rawDocumentDbSize,
-        private readonly int $avgDocumentSize,
+        private readonly int|string $rawDocumentDbSize,
+        private readonly int|string $avgDocumentSize,
         private readonly bool $isIndexing,
         private readonly int $numberOfEmbeddings,
         private readonly int $numberOfEmbeddedDocuments,
         private readonly array $fieldDistribution,
+        private readonly ?array $internalDatabaseSizes = null,
     ) {
     }
 
@@ -34,17 +36,25 @@ final class IndexStats
     }
 
     /**
-     * @return non-negative-int
+     * Returns the raw document DB size.
+     * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
+     * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
+     *
+     * @return int|string
      */
-    public function getRawDocumentDbSize(): int
+    public function getRawDocumentDbSize(): int|string
     {
         return $this->rawDocumentDbSize;
     }
 
     /**
-     * @return non-negative-int
+     * Returns the average document size.
+     * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
+     * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
+     *
+     * @return int|string
      */
-    public function getAvgDocumentSize(): int
+    public function getAvgDocumentSize(): int|string
     {
         return $this->avgDocumentSize;
     }
@@ -79,14 +89,26 @@ final class IndexStats
     }
 
     /**
+     * Returns the internal database sizes map when requested via `showInternalDatabaseSizes=true`.
+     * Returns null if the parameter was not set. Keys are subject to change.
+     *
+     * @return array<non-empty-string, int|string>|null
+     */
+    public function getInternalDatabaseSizes(): ?array
+    {
+        return $this->internalDatabaseSizes;
+    }
+
+    /**
      * @param array{
      *     numberOfDocuments: non-negative-int,
-     *     rawDocumentDbSize: non-negative-int,
-     *     avgDocumentSize: non-negative-int,
+     *     rawDocumentDbSize: int|string,
+     *     avgDocumentSize: int|string,
      *     isIndexing: bool,
      *     numberOfEmbeddings: non-negative-int,
      *     numberOfEmbeddedDocuments: non-negative-int,
-     *     fieldDistribution: array<non-empty-string, non-negative-int>
+     *     fieldDistribution: array<non-empty-string, non-negative-int>,
+     *     internalDatabaseSizes?: array<non-empty-string, int|string>|null
      * } $data
      */
     public static function fromArray(array $data): self
@@ -99,6 +121,7 @@ final class IndexStats
             $data['numberOfEmbeddings'],
             $data['numberOfEmbeddedDocuments'],
             $data['fieldDistribution'],
+            $data['internalDatabaseSizes'] ?? null,
         );
     }
 }

--- a/src/Contracts/IndexStats.php
+++ b/src/Contracts/IndexStats.php
@@ -39,8 +39,6 @@ final class IndexStats
      * Returns the raw document DB size.
      * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
      * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
-     *
-     * @return int|string
      */
     public function getRawDocumentDbSize(): int|string
     {
@@ -51,8 +49,6 @@ final class IndexStats
      * Returns the average document size.
      * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
      * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
-     *
-     * @return int|string
      */
     public function getAvgDocumentSize(): int|string
     {

--- a/src/Contracts/Stats.php
+++ b/src/Contracts/Stats.php
@@ -7,30 +7,38 @@ namespace Meilisearch\Contracts;
 final class Stats
 {
     /**
-     * @param non-negative-int                    $databaseSize
-     * @param non-negative-int                    $usedDatabaseSize
+     * @param int|string                          $databaseSize     Bytes when sizeFormat is 'raw', human-readable string when 'human'
+     * @param int|string                          $usedDatabaseSize Bytes when sizeFormat is 'raw', human-readable string when 'human'
      * @param array<non-empty-string, IndexStats> $indexes
      */
     public function __construct(
-        private readonly int $databaseSize,
-        private readonly int $usedDatabaseSize,
+        private readonly int|string $databaseSize,
+        private readonly int|string $usedDatabaseSize,
         private readonly ?\DateTimeImmutable $lastUpdate,
         private readonly array $indexes,
     ) {
     }
 
     /**
-     * @return non-negative-int
+     * Returns the total database size.
+     * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
+     * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
+     *
+     * @return int|string
      */
-    public function getDatabaseSize(): int
+    public function getDatabaseSize(): int|string
     {
         return $this->databaseSize;
     }
 
     /**
-     * @return non-negative-int
+     * Returns the used database size.
+     * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
+     * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
+     *
+     * @return int|string
      */
-    public function getUsedDatabaseSize(): int
+    public function getUsedDatabaseSize(): int|string
     {
         return $this->usedDatabaseSize;
     }
@@ -50,8 +58,8 @@ final class Stats
 
     /**
      * @param array{
-     *     databaseSize: non-negative-int,
-     *     usedDatabaseSize: non-negative-int,
+     *     databaseSize: int|string,
+     *     usedDatabaseSize: int|string,
      *     lastUpdate: non-empty-string|null,
      *     indexes: array<non-empty-string, mixed>
      * } $data

--- a/src/Contracts/Stats.php
+++ b/src/Contracts/Stats.php
@@ -23,8 +23,6 @@ final class Stats
      * Returns the total database size.
      * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
      * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
-     *
-     * @return int|string
      */
     public function getDatabaseSize(): int|string
     {
@@ -35,8 +33,6 @@ final class Stats
      * Returns the used database size.
      * Value is an integer (bytes) when `sizeFormat` is `'raw'` (default),
      * or a human-readable string such as `"2.3 MiB"` when `sizeFormat` is `'human'`.
-     *
-     * @return int|string
      */
     public function getUsedDatabaseSize(): int|string
     {

--- a/src/Endpoints/Delegates/HandlesSystem.php
+++ b/src/Endpoints/Delegates/HandlesSystem.php
@@ -47,9 +47,14 @@ trait HandlesSystem
         return VersionContract::fromArray($version);
     }
 
-    public function stats(): StatsContract
+    /**
+     * Get stats of all indexes.
+     *
+     * @param array{showInternalDatabaseSizes?: bool, sizeFormat?: 'raw'|'human'} $query
+     */
+    public function stats(array $query = []): StatsContract
     {
-        $stats = $this->stats->show();
+        $stats = $this->stats->show($query);
 
         if (!\is_array($stats)) {
             throw new LogicException('Stats did not respond with valid data.');

--- a/src/Endpoints/Indexes.php
+++ b/src/Endpoints/Indexes.php
@@ -243,9 +243,12 @@ class Indexes extends Endpoint
 
     // Stats
 
-    public function stats(): array
+    /**
+     * @param array{showInternalDatabaseSizes?: bool, sizeFormat?: 'raw'|'human'} $query
+     */
+    public function stats(array $query = []): array
     {
-        return $this->http->get(self::PATH.'/'.$this->uid.'/stats');
+        return $this->http->get(self::PATH.'/'.$this->uid.'/stats', $query);
     }
 
     // Settings - Global

--- a/src/Endpoints/Stats.php
+++ b/src/Endpoints/Stats.php
@@ -9,4 +9,9 @@ use Meilisearch\Contracts\Endpoint;
 class Stats extends Endpoint
 {
     protected const PATH = '/stats';
+
+    public function show(array $query = []): ?array
+    {
+        return $this->http->get(static::PATH, $query);
+    }
 }


### PR DESCRIPTION
Closes #915.

Adds support for the two new query parameters introduced in [Meilisearch v1.44.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.44.0) for the stats endpoints.

## Changes

**`src/Contracts/Stats.php`** — `databaseSize` and `usedDatabaseSize` widened from `int` to `int|string` to accommodate human-readable responses when `sizeFormat='human'`

**`src/Contracts/IndexStats.php`** — same widening for `rawDocumentDbSize` and `avgDocumentSize`; new optional `internalDatabaseSizes: ?array` field (present only when `showInternalDatabaseSizes=true`; keys subject to change per spec)

**`src/Endpoints/Stats.php`** — overrides `show()` to accept a `$query` array passed through to `http->get`

**`src/Endpoints/Delegates/HandlesSystem.php`** — `stats(array $query = [])` passes query to `Stats::show()`

**`src/Endpoints/Indexes.php`** — `stats(array $query = [])` passes query to `http->get`

**`.code-samples.meilisearch.yaml`** — updated `get_index_stats_1` and `get_indexes_stats_1`

All existing callers with no arguments continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds support for two new query parameters introduced in Meilisearch v1.44.0 to the stats endpoints: `showInternalDatabaseSizes` and `sizeFormat`.

### Key Changes

**Contracts Updated**
- src/Contracts/Stats.php: `databaseSize` and `usedDatabaseSize` widened from `int` to `int|string` to support both raw byte counts and human-readable strings.
- src/Contracts/IndexStats.php: `rawDocumentDbSize` and `avgDocumentSize` widened from `int` to `int|string`; added optional `internalDatabaseSizes: ?array` (map of internal DB names to sizes) and a `getInternalDatabaseSizes(): ?array` getter. `fromArray()` updated to accept the new field.

**Endpoints and Delegates Enhanced**
- src/Endpoints/Stats.php: added `show(array $query = []): ?array` to forward query parameters to the HTTP GET for `/stats`.
- src/Endpoints/Delegates/HandlesSystem.php: `stats()` signature changed to `stats(array $query = []): StatsContract` and forwards `$query` to `Stats::show()`.
- src/Endpoints/Indexes.php: `stats(array $query = []): array` now forwards the query array to the HTTP GET request for index stats.

**Documentation Samples**
- .code-samples.meilisearch.yaml: updated `get_index_stats_1` and `get_indexes_stats_1` to call `stats` with `showInternalDatabaseSizes: true` and `sizeFormat: 'human'`.

### Backward Compatibility

All additions are optional and default to prior behavior; callers that invoke `stats()` without arguments continue to work unchanged.

### Related Issues

Closes `#915`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->