### PR TITLE
feat: add personalize search parameter to SearchQuery

### DIFF
--- a/src/Contracts/PersonalizeOptions.php
+++ b/src/Contracts/PersonalizeOptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meilisearch\Contracts;
 
-class PersonalizeOptions
+final class PersonalizeOptions
 {
     /**
      * @var non-empty-string|null

--- a/src/Contracts/PersonalizeOptions.php
+++ b/src/Contracts/PersonalizeOptions.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meilisearch\Contracts;
+
+class PersonalizeOptions
+{
+    /**
+     * @var non-empty-string|null
+     */
+    private ?string $userContext = null;
+
+    /**
+     * @param non-empty-string $userContext
+     *
+     * @return $this
+     */
+    public function setUserContext(string $userContext): self
+    {
+        $this->userContext = $userContext;
+
+        return $this;
+    }
+
+    /**
+     * @return array{
+     *     userContext?: non-empty-string
+     * }
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'userContext' => $this->userContext,
+        ], static function ($item) { return null !== $item; });
+    }
+}

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -525,7 +525,7 @@ class SearchQuery
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
             'federationOptions' => null !== $this->federationOptions ? $this->federationOptions->toArray() : null,
-            'personalize' => null !== $this->personalize ? $this->personalize->toArray() : null,
+            'personalize' => $this->personalize?->toArray(),
         ], static function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -113,6 +113,8 @@ class SearchQuery
 
     private ?FederationOptions $federationOptions = null;
 
+    private ?PersonalizeOptions $personalize = null;
+
     /**
      * @return $this
      */
@@ -430,6 +432,22 @@ class SearchQuery
     }
 
     /**
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * Set personalization options
+     * (new PersonalizeOptions())
+     *     ->setUserContext('The user prefers ...');
+     *
+     * @return $this
+     */
+    public function setPersonalize(PersonalizeOptions $personalize): self
+    {
+        $this->personalize = $personalize;
+
+        return $this;
+    }
+
+    /**
      * @param non-empty-list<non-empty-string> $attributesToSearchOn
      *
      * @return $this
@@ -470,7 +488,8 @@ class SearchQuery
      *     showPerformanceDetails?: bool,
      *     rankingScoreThreshold?: float,
      *     distinct?: non-empty-string,
-     *     federationOptions?: array<mixed>
+     *     federationOptions?: array<mixed>,
+     *     personalize?: array<mixed>
      * }
      */
     public function toArray(): array
@@ -504,6 +523,7 @@ class SearchQuery
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'distinct' => $this->distinct,
             'federationOptions' => null !== $this->federationOptions ? $this->federationOptions->toArray() : null,
+            'personalize' => null !== $this->personalize ? $this->personalize->toArray() : null,
         ], static function ($item) { return null !== $item; });
     }
 }

--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -489,7 +489,9 @@ class SearchQuery
      *     rankingScoreThreshold?: float,
      *     distinct?: non-empty-string,
      *     federationOptions?: array<mixed>,
-     *     personalize?: array<mixed>
+     *     personalize?: array{
+     *         userContext?: non-empty-string
+     *     }
      * }
      */
     public function toArray(): array

--- a/tests/Contracts/PersonalizeOptionsTest.php
+++ b/tests/Contracts/PersonalizeOptionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Contracts;
+
+use Meilisearch\Contracts\PersonalizeOptions;
+use PHPUnit\Framework\TestCase;
+
+final class PersonalizeOptionsTest extends TestCase
+{
+    public function testEmptyOptions(): void
+    {
+        $data = new PersonalizeOptions();
+
+        self::assertSame([], $data->toArray());
+    }
+
+    public function testSetUserContext(): void
+    {
+        $data = (new PersonalizeOptions())->setUserContext('The user prefers science fiction movies');
+
+        self::assertSame(['userContext' => 'The user prefers science fiction movies'], $data->toArray());
+    }
+}

--- a/tests/Contracts/SearchQueryTest.php
+++ b/tests/Contracts/SearchQueryTest.php
@@ -6,6 +6,7 @@ namespace Tests\Contracts;
 
 use Meilisearch\Contracts\FederationOptions;
 use Meilisearch\Contracts\HybridSearchOptions;
+use Meilisearch\Contracts\PersonalizeOptions;
 use Meilisearch\Contracts\SearchQuery;
 use PHPUnit\Framework\TestCase;
 
@@ -185,6 +186,13 @@ final class SearchQueryTest extends TestCase
         $data = (new SearchQuery())->setHybrid((new HybridSearchOptions())->setSemanticRatio(0.5));
 
         self::assertSame(['hybrid' => ['semanticRatio' => 0.5]], $data->toArray());
+    }
+
+    public function testSetPersonalize(): void
+    {
+        $data = (new SearchQuery())->setPersonalize((new PersonalizeOptions())->setUserContext('loves science fiction'));
+
+        self::assertSame(['personalize' => ['userContext' => 'loves science fiction']], $data->toArray());
     }
 
     public function testSetAttributesToSearchOn(): void


### PR DESCRIPTION
## Summary

Meilisearch v1.47.0 adds experimental personalized search. This adds support for
the new `personalize` search parameter (`{ "userContext": "..." }`) to the typed
`SearchQuery` builder. Closes #917.

## Changes

- New `PersonalizeOptions` contract with `setUserContext()`, mirroring
  `HybridSearchOptions`.
- `SearchQuery::setPersonalize(PersonalizeOptions)`, serialized into the search
  payload through `toArray()` (used by `multiSearch` / federated search). The
  array-based `search()` path already forwards arbitrary parameters, so it needs
  no change.
- Contract tests for `PersonalizeOptions` and `SearchQuery::setPersonalize`.

## Example

```php
$client->multiSearch([
    (new SearchQuery())
        ->setIndexUid('movies')
        ->setQuery('shifu')
        ->setPersonalize((new PersonalizeOptions())->setUserContext('The user prefers science fiction')),
]);
```

## Testing

`composer lint` passes. Added contract tests for `PersonalizeOptions` and
`SearchQuery::setPersonalize`; they assert the serialized payload and don't
require a running Meilisearch instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds support for personalized search (experimental in Meilisearch v1.47.0) to the PHP SDK’s typed `SearchQuery` builder, allowing a `userContext` string to be attached to search requests.

## Changes

### New Contract: `PersonalizeOptions`

A new `Meilisearch\Contracts\PersonalizeOptions` contract was introduced (`src/Contracts/PersonalizeOptions.php`) to model personalization settings. It provides:
- `setUserContext(string $userContext): self` (fluent setter)
- `toArray(): array` to serialize the payload, omitting unset values

`PersonalizeOptions` is implemented as a `final` class.

### Enhanced `SearchQuery`

The `Meilisearch\Contracts\SearchQuery` contract now supports personalization by adding:
- a `private ?PersonalizeOptions $personalize` field
- `setPersonalize(PersonalizeOptions $personalize): self`

`SearchQuery::toArray()` was updated to include an optional `personalize` entry shaped like `{ userContext?: non-empty-string }`, serialized via `PersonalizeOptions->toArray()`. When `personalize` is not set, the field is omitted from the payload (with serialization simplified using PHP’s nullsafe operator).

This serialized payload is used by request flows that rely on typed query serialization (e.g., `multiSearch` and federated search).

## Test Coverage

- `tests/Contracts/PersonalizeOptionsTest.php` validates `PersonalizeOptions::toArray()` for both empty and populated `userContext`.
- `tests/Contracts/SearchQueryTest.php` adds coverage for `SearchQuery::setPersonalize()` ensuring the serialized `personalize.userContext` is present in `toArray()`.

## Resolution

Implements the requested SDK support for personalized search introduced in Meilisearch v1.47.0 (fixing issue `#917`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->