### PR TITLE
feat: add SearchQuery::setRetrieveVectors

### DIFF
--- a/src/Contracts/SearchQuery.php
+++ b/src/Contracts/SearchQuery.php
@@ -91,6 +91,8 @@ class SearchQuery
      */
     private ?array $vector = null;
 
+    private ?bool $retrieveVectors = null;
+
     private ?HybridSearchOptions $hybrid = null;
 
     /**
@@ -413,6 +415,19 @@ class SearchQuery
     }
 
     /**
+     * Whether the vector data of the matching documents is returned in the
+     * search response (the `_vectors` field).
+     *
+     * @return $this
+     */
+    public function setRetrieveVectors(?bool $retrieveVectors): self
+    {
+        $this->retrieveVectors = $retrieveVectors;
+
+        return $this;
+    }
+
+    /**
      * This is an EXPERIMENTAL feature, which may break without a major version.
      *
      * Set hybrid search options
@@ -463,6 +478,7 @@ class SearchQuery
      *     hitsPerPage?: non-negative-int,
      *     page?: non-negative-int,
      *     vector?: non-empty-list<float|non-empty-list<float>>,
+     *     retrieveVectors?: bool,
      *     hybrid?: array<mixed>,
      *     attributesToSearchOn?: non-empty-list<non-empty-string>,
      *     showRankingScore?: bool,
@@ -496,6 +512,7 @@ class SearchQuery
             'hitsPerPage' => $this->hitsPerPage,
             'page' => $this->page,
             'vector' => $this->vector,
+            'retrieveVectors' => $this->retrieveVectors,
             'hybrid' => null !== $this->hybrid ? $this->hybrid->toArray() : null,
             'attributesToSearchOn' => $this->attributesToSearchOn,
             'showRankingScore' => $this->showRankingScore,

--- a/tests/Contracts/SearchQueryTest.php
+++ b/tests/Contracts/SearchQueryTest.php
@@ -198,6 +198,17 @@ final class SearchQueryTest extends TestCase
      * @testWith [true]
      *           [false]
      */
+    public function testSetRetrieveVectors(?bool $value): void
+    {
+        $data = (new SearchQuery())->setRetrieveVectors($value);
+
+        self::assertSame(['retrieveVectors' => $value], $data->toArray());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
     public function testSetShowRankingScore(?bool $value): void
     {
         $data = (new SearchQuery())->setShowRankingScore($value);


### PR DESCRIPTION
## Summary

Meilisearch's search endpoint accepts a `retrieveVectors` boolean to return each
document's vector data (the `_vectors` field) in the response, but the typed
`SearchQuery` builder had no setter for it. Closes #816.

## Changes

- Add `SearchQuery::setRetrieveVectors(?bool)`, serialized into the search payload
  through `toArray()`, mirroring the existing boolean options (e.g.
  `setShowRankingScore`).
- Contract test (`testSetRetrieveVectors`) asserting the serialized payload.

## Example

```php
$results = $client->multiSearch([
    (new SearchQuery())
        ->setIndexUid('products')
        ->setQuery('shoes')
        ->setRetrieveVectors(true),
]);
```

## Testing

Added a contract test following the existing boolean-option tests; it asserts the
`toArray()` payload and doesn't require a running Meilisearch instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add `setRetrieveVectors()` method to SearchQuery

Adds support for the `retrieveVectors` search option to the `SearchQuery` builder class, enabling developers to retrieve vector data (`_vectors` field) in search responses.

### Changes

**src/Contracts/SearchQuery.php:**
- Added `private ?bool $retrieveVectors` property
- Added public `setRetrieveVectors(?bool $retrieveVectors): self` fluent setter method with documentation explaining it controls whether `_vectors` is returned in the response
- Updated `toArray()` serialization to include the `retrieveVectors` option in the output array and array-shape phpdoc

**tests/Contracts/SearchQueryTest.php:**
- Added `testSetRetrieveVectors(?bool $value)` test method that verifies the setter correctly serializes boolean and null values through `toArray()`

### Implementation Details

The implementation follows the existing pattern used by other boolean option setters in the class (e.g., `setShowRankingScore`), ensuring consistency with the codebase conventions. The contract test validates the serialized payload without requiring a running Meilisearch instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->