### PR TITLE
feat: support retrieveVectors in getDocument

### DIFF
--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -17,10 +17,17 @@ trait HandlesDocuments
 {
     /**
      * @param non-empty-string|int $documentId
+     * @param list<non-empty-string>|null $fields
      */
-    public function getDocument(string|int $documentId, ?array $fields = null): array
+    public function getDocument(string|int $documentId, ?array $fields = null, bool $retrieveVectors = false): array
     {
-        $query = isset($fields) ? ['fields' => implode(',', $fields)] : [];
+        $query = [];
+        if (isset($fields)) {
+            $query['fields'] = implode(',', $fields);
+        }
+        if ($retrieveVectors) {
+            $query['retrieveVectors'] = true;
+        }
 
         return $this->http->get(self::PATH.'/'.$this->uid.'/documents/'.$documentId, $query);
     }

--- a/tests/Endpoints/DocumentsTest.php
+++ b/tests/Endpoints/DocumentsTest.php
@@ -681,6 +681,22 @@ final class DocumentsTest extends TestCase
         self::assertCount(5, $response);
     }
 
+    public function testGetDocumentWithVector(): void
+    {
+        $index = $this->createEmptyIndex($this->safeIndexName('movies'));
+
+        $index->updateEmbedders(['manual' => ['source' => 'userProvided', 'dimensions' => 3]])->wait();
+        $index->updateDocuments(self::VECTOR_MOVIES)->wait();
+
+        $documentId = self::VECTOR_MOVIES[0]['id'];
+
+        $response = $index->getDocument($documentId);
+        self::assertArrayNotHasKey('_vectors', $response);
+
+        $response = $index->getDocument($documentId, null, true);
+        self::assertArrayHasKey('_vectors', $response);
+    }
+
     public function testGetDocumentsMessageHintException(): void
     {
         $responseMock = $this->createMock(ResponseInterface::class);


### PR DESCRIPTION
## Summary

The get-one-document endpoint accepts a `retrieveVectors` query parameter (to
include each document's vector data in the `_vectors` field), but
`Index::getDocument()` had no way to set it — only `getDocuments()` did, through
`DocumentsQuery`. This closes that gap. Closes #809.

## Changes

- `getDocument(string|int $documentId, ?array $fields = null, bool $retrieveVectors = false)`:
  when `true`, the request now sends `retrieveVectors=true`. New optional
  parameter, so it's non-breaking for existing callers.
- Integration test (`testGetDocumentWithVector`) mirroring the existing
  `testGetDocumentsWithVector`, asserting `_vectors` is absent by default and
  present when `retrieveVectors` is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for the `retrieveVectors` query parameter to the `getDocument()` method in the Meilisearch PHP SDK, enabling retrieval of vector data for individual documents through the single-document endpoint. Previously, this functionality was only available through the `getDocuments()` method.

## Changes

**API Method Update**
- Modified `getDocument()` signature to accept an optional `$retrieveVectors` boolean parameter (defaults to `false` for backward compatibility)
- When `$retrieveVectors` is `true`, the method includes `retrieveVectors=true` in the query parameters sent to the `/documents/{id}` endpoint
- Refactored query parameter construction to conditionally build the request based on provided parameters

**Test Coverage**
- Added integration test `testGetDocumentWithVector()` that verifies:
  - The `_vectors` field is absent from the response by default
  - The `_vectors` field is included when `retrieveVectors` is enabled
  - Test uses a manual embedder with 3 dimensions and the `VECTOR_MOVIES` dataset

## Impact
This change brings feature parity between the single-document and multi-document retrieval methods, allowing developers to retrieve vector data via `getDocument()` just as they can with `getDocuments()`. Since the new parameter is optional with a default value of `false`, this is a non-breaking change for existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->