### PR TITLE
Add PHPDoc return type for `HandlesDocuments::getDocument`.

### DIFF
--- a/src/Endpoints/Delegates/HandlesDocuments.php
+++ b/src/Endpoints/Delegates/HandlesDocuments.php
@@ -17,6 +17,8 @@ trait HandlesDocuments
 {
     /**
      * @param non-empty-string|int $documentId
+     *
+     * @return array<string, mixed>
      */
     public function getDocument(string|int $documentId, ?array $fields = null): array
     {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #742 

## What does this PR do?
- Typehint `HandlesDocuments::getDocument`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented return format for document retrieval results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->