### PR TITLE
Make Dynamic Search Rules API compatible with Meilisearch v1.50

### DIFF
--- a/.agents/skills/write-meilisearch-php-phpdoc/SKILL.md
+++ b/.agents/skills/write-meilisearch-php-phpdoc/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: write-meilisearch-php-phpdoc
+description: Write PHPDoc for meilisearch-php public APIs. Use when documenting client, endpoint, or delegate methods, adding @since or @see tags, or updating PHPDoc on SDK public methods.
+disable-model-invocation: true
+---
+
+# Write meilisearch-php PHPDoc
+
+## Shape
+
+Match nearby methods in the same file. Prefer compact PHPDoc that adds information the native PHP signature cannot express.
+
+Typical stable method:
+
+```php
+/**
+ * Get a dynamic search rule.
+ *
+ * @param non-empty-string $uid Dynamic search rule UID
+ *
+ * @since Meilisearch v1.41.0
+ * @see https://www.meilisearch.com/docs/reference/api/search-rules/get-a-search-rule
+ */
+public function getDynamicSearchRule(string $uid): DynamicSearchRule
+```
+
+Typical experimental method:
+
+```php
+/**
+ * Get a dynamic search rule.
+ *
+ * This is an EXPERIMENTAL feature, which may break without a major version.
+ *
+ * @param non-empty-string $uid Dynamic search rule UID
+ *
+ * @since Meilisearch v1.41.0
+ * @see https://www.meilisearch.com/docs/reference/api/search-rules/get-a-search-rule
+ */
+public function getDynamicSearchRule(string $uid): DynamicSearchRule
+```
+
+If the signature already fully expresses the types, `@param` and `@return` are optional. Keep them when they add phpstan refinements such as `non-empty-string`, array shapes, or literal unions, or when a short description prevents ambiguity.
+
+## Rules
+
+- Link the matching API reference page with `@see https://www.meilisearch.com/docs/...`
+- Resolve URLs from `https://www.meilisearch.com/docs/llms.txt`; prefer current canonical paths over aliases
+- Use `@since Meilisearch vX.Y.Z` for version-gated APIs instead of putting version requirements in the prose summary
+- Mark experimental APIs with the prose notice `This is an EXPERIMENTAL feature, which may break without a major version.`
+- Prefer phpstan-friendly refinements in docblocks: `non-empty-string`, array shapes, literal unions, typed lists
+- Do not add redundant `@param` or `@return` tags when the native type already says enough
+- Match nearby summary punctuation and wording in the same file
+- Do not invent docs URLs; if no page exists, link the closest related API reference page
+
+## Check
+
+- `docker compose run --rm package bash -c "composer lint:fix && composer phpstan"`

--- a/.agents/skills/write-meilisearch-php-phpdoc/SKILL.md
+++ b/.agents/skills/write-meilisearch-php-phpdoc/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: write-meilisearch-php-phpdoc
 description: Write PHPDoc for meilisearch-php public APIs. Use when documenting client, endpoint, or delegate methods, adding @since or @see tags, or updating PHPDoc on SDK public methods.
-disable-model-invocation: true
 ---
 
 # Write meilisearch-php PHPDoc

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -598,19 +598,22 @@ list_dynamic_search_rules_1: |-
 get_dynamic_search_rule_1: |-
   $client->getDynamicSearchRule('RULE_UID');
 patch_dynamic_search_rule_1: |-
-  $client->updateDynamicSearchRule('RULE_UID', [
-    'actions' => [
-      [
-        'selector' => [
-          'indexUid' => 'movies',
-          'id' => '299537'
-        ],
-        'action' => [
-          'type' => 'pin',
-          'position' => 0
+  $client->updateDynamicSearchRule(
+    (new \Meilisearch\Contracts\UpdateDynamicSearchRuleQuery('RULE_UID'))
+      ->setActions([
+        [
+          'selector' => [
+            'indexUid' => 'movies',
+            'id' => '299537'
+          ],
+          'action' => [
+            'type' => 'pin',
+            'position' => 0
+          ]
         ]
-      ]
-    ]
-  ]);
+      ])
+  );
 delete_dynamic_search_rule_1: |-
   $client->deleteDynamicSearchRule('RULE_UID');
+delete_all_dynamic_search_rules_1: |-
+  $client->deleteAllDynamicSearchRules();

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,1 +1,0 @@
-../.agents/skills

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
     name: integration-tests (PHP ${{ matrix.php-version }})
     services:
       meilisearch:
-        image: getmeili/meilisearch-enterprise:latest
+        image: getmeili/meilisearch-enterprise:v1.50.0
         ports:
           - "7700:7700"
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./:/home/package
 
   meilisearch:
-    image: getmeili/meilisearch-enterprise:v1.42.0
+    image: getmeili/meilisearch-enterprise:v1.50.0
     ports:
       - "7700"
     environment:

--- a/src/Contracts/DynamicSearchRule.php
+++ b/src/Contracts/DynamicSearchRule.php
@@ -7,7 +7,7 @@ namespace Meilisearch\Contracts;
 /**
  * @phpstan-type SearchRuleSelector array{
  *     indexUid?: non-empty-string|null,
- *     id?: non-empty-string|null
+ *     id: non-empty-string
  * }
  * @phpstan-type SearchRulePinAction array{
  *     type: 'pin',
@@ -17,23 +17,24 @@ namespace Meilisearch\Contracts;
  *     selector: SearchRuleSelector,
  *     action: SearchRulePinAction
  * }
- * @phpstan-type SearchRuleQueryCondition array{
- *     scope: 'query',
+ * @phpstan-type QueryCondition array{
  *     isEmpty?: bool|null,
- *     contains?: non-empty-string|null
+ *     words?: non-empty-string|null
  * }
- * @phpstan-type SearchRuleTimeCondition array{
- *     scope: 'time',
+ * @phpstan-type TimeCondition array{
  *     start?: non-empty-string|null,
  *     end?: non-empty-string|null
  * }
- * @phpstan-type SearchRuleCondition SearchRuleQueryCondition|SearchRuleTimeCondition
+ * @phpstan-type SearchRuleConditions array{
+ *     query?: QueryCondition|null,
+ *     time?: TimeCondition|null
+ * }
  * @phpstan-type RawDynamicSearchRule array{
  *     uid: non-empty-string,
  *     description?: string|null,
- *     priority?: non-negative-int|null,
+ *     precedence?: non-negative-int|null,
  *     active?: bool,
- *     conditions?: list<SearchRuleCondition>,
+ *     conditions?: SearchRuleConditions|null,
  *     actions: list<SearchRuleAction>
  * }
  */
@@ -54,12 +55,12 @@ final class DynamicSearchRule
     /**
      * @var non-negative-int|null
      */
-    private readonly ?int $priority;
+    private readonly ?int $precedence;
 
     private readonly ?bool $active;
 
     /**
-     * @var list<SearchRuleCondition>|null
+     * @var SearchRuleConditions|null
      */
     private readonly ?array $conditions;
 
@@ -72,7 +73,7 @@ final class DynamicSearchRule
         $this->uid = $raw['uid'];
         $this->actions = $raw['actions'];
         $this->description = $raw['description'] ?? null;
-        $this->priority = $raw['priority'] ?? null;
+        $this->precedence = $raw['precedence'] ?? null;
         $this->active = $raw['active'] ?? null;
         $this->conditions = $raw['conditions'] ?? null;
     }
@@ -95,9 +96,9 @@ final class DynamicSearchRule
         return $this->description;
     }
 
-    public function getPriority(): ?int
+    public function getPrecedence(): ?int
     {
-        return $this->priority;
+        return $this->precedence;
     }
 
     public function isActive(): ?bool
@@ -106,7 +107,7 @@ final class DynamicSearchRule
     }
 
     /**
-     * @return list<SearchRuleCondition>|null
+     * @return SearchRuleConditions|null
      */
     public function getConditions(): ?array
     {

--- a/src/Contracts/DynamicSearchRulesFilter.php
+++ b/src/Contracts/DynamicSearchRulesFilter.php
@@ -6,21 +6,16 @@ namespace Meilisearch\Contracts;
 
 final class DynamicSearchRulesFilter
 {
-    /**
-     * @var list<non-empty-string>|null
-     */
-    private ?array $attributePatterns = null;
+    private ?string $query = null;
 
     private ?bool $active = null;
 
     /**
-     * @param list<non-empty-string> $patterns
-     *
      * @return $this
      */
-    public function setAttributePatterns(array $patterns): self
+    public function setQuery(string $query): self
     {
-        $this->attributePatterns = $patterns;
+        $this->query = $query;
 
         return $this;
     }
@@ -37,14 +32,14 @@ final class DynamicSearchRulesFilter
 
     /**
      * @return array{
-     *     attributePatterns?: list<non-empty-string>,
+     *     query?: string,
      *     active?: bool
      * }
      */
     public function toArray(): array
     {
         return array_filter([
-            'attributePatterns' => $this->attributePatterns,
+            'query' => $this->query,
             'active' => $this->active,
         ], static function ($item) { return null !== $item; });
     }

--- a/src/Contracts/DynamicSearchRulesQuery.php
+++ b/src/Contracts/DynamicSearchRulesQuery.php
@@ -57,7 +57,7 @@ final class DynamicSearchRulesQuery
      *     offset?: non-negative-int,
      *     limit?: non-negative-int,
      *     filter?: array{
-     *         attributePatterns?: list<non-empty-string>,
+     *         query?: string,
      *         active?: bool
      *     }
      * }

--- a/src/Contracts/Task.php
+++ b/src/Contracts/Task.php
@@ -263,7 +263,7 @@ final class Task implements \ArrayAccess
             TaskType::TaskDeletion => self::detailFromArray($details, TaskDeletionDetails::fromArray(...)),
             // It’s intentional that SnapshotCreation tasks don’t have a details object
             // (no SnapshotCreationDetails exists and tests don’t exercise any details)
-            TaskType::SnapshotCreation, TaskType::NetworkTopologyChange => null,
+            TaskType::SnapshotCreation, TaskType::NetworkTopologyChange, TaskType::DsrUpdate, TaskType::DsrClear => null,
             TaskType::IndexCompaction => self::detailFromArray($details, IndexCompactionDetails::fromArray(...)),
         };
     }

--- a/src/Contracts/TaskType.php
+++ b/src/Contracts/TaskType.php
@@ -20,5 +20,7 @@ enum TaskType: string
     case SnapshotCreation = 'snapshotCreation';
     case NetworkTopologyChange = 'networkTopologyChange';
     case IndexCompaction = 'indexCompaction';
+    case DsrUpdate = 'dsrUpdate';
+    case DsrClear = 'dsrClear';
     case Unknown = 'unknown';
 }

--- a/src/Contracts/UpdateDynamicSearchRuleQuery.php
+++ b/src/Contracts/UpdateDynamicSearchRuleQuery.php
@@ -6,12 +6,12 @@ namespace Meilisearch\Contracts;
 
 /**
  * @phpstan-import-type SearchRuleAction from DynamicSearchRule
- * @phpstan-import-type SearchRuleCondition from DynamicSearchRule
+ * @phpstan-import-type SearchRuleConditions from DynamicSearchRule
  */
 final class UpdateDynamicSearchRuleQuery
 {
     private bool $hasDescription = false;
-    private bool $hasPriority = false;
+    private bool $hasPrecedence = false;
     private bool $hasActive = false;
     private bool $hasConditions = false;
     private bool $hasActions = false;
@@ -21,12 +21,12 @@ final class UpdateDynamicSearchRuleQuery
     /**
      * @var non-negative-int|null
      */
-    private ?int $priority = null;
+    private ?int $precedence = null;
 
     private ?bool $active = null;
 
     /**
-     * @var list<SearchRuleCondition>|null
+     * @var SearchRuleConditions|null
      */
     private ?array $conditions = null;
 
@@ -54,14 +54,14 @@ final class UpdateDynamicSearchRuleQuery
     }
 
     /**
-     * @param non-negative-int|null $priority
+     * @param non-negative-int|null $precedence
      *
      * @return $this
      */
-    public function setPriority(?int $priority): self
+    public function setPrecedence(?int $precedence): self
     {
-        $this->priority = $priority;
-        $this->hasPriority = true;
+        $this->precedence = $precedence;
+        $this->hasPrecedence = true;
 
         return $this;
     }
@@ -78,7 +78,7 @@ final class UpdateDynamicSearchRuleQuery
     }
 
     /**
-     * @param list<SearchRuleCondition>|null $conditions
+     * @param SearchRuleConditions|null $conditions
      *
      * @return $this
      */
@@ -106,9 +106,9 @@ final class UpdateDynamicSearchRuleQuery
     /**
      * @return array{
      *     description?: string|null,
-     *     priority?: non-negative-int|null,
+     *     precedence?: non-negative-int|null,
      *     active?: bool,
-     *     conditions?: list<SearchRuleCondition>|null,
+     *     conditions?: SearchRuleConditions|null,
      *     actions?: list<SearchRuleAction>|null
      * }
      */
@@ -120,8 +120,8 @@ final class UpdateDynamicSearchRuleQuery
             $payload['description'] = $this->description;
         }
 
-        if ($this->hasPriority) {
-            $payload['priority'] = $this->priority;
+        if ($this->hasPrecedence) {
+            $payload['precedence'] = $this->precedence;
         }
 
         if ($this->hasActive) {

--- a/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
+++ b/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
@@ -7,6 +7,7 @@ namespace Meilisearch\Endpoints\Delegates;
 use Meilisearch\Contracts\DynamicSearchRule;
 use Meilisearch\Contracts\DynamicSearchRulesQuery;
 use Meilisearch\Contracts\DynamicSearchRulesResults;
+use Meilisearch\Contracts\Task;
 use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 use Meilisearch\Endpoints\DynamicSearchRules;
 
@@ -27,7 +28,7 @@ trait HandlesDynamicSearchRules
         return $this->dynamicSearchRules->get($uid);
     }
 
-    public function updateDynamicSearchRule(UpdateDynamicSearchRuleQuery $request): DynamicSearchRule
+    public function updateDynamicSearchRule(UpdateDynamicSearchRuleQuery $request): Task
     {
         return $this->dynamicSearchRules->update($request);
     }
@@ -35,8 +36,13 @@ trait HandlesDynamicSearchRules
     /**
      * @param non-empty-string $uid
      */
-    public function deleteDynamicSearchRule(string $uid): ?array
+    public function deleteDynamicSearchRule(string $uid): Task
     {
         return $this->dynamicSearchRules->delete($uid);
+    }
+
+    public function deleteAllDynamicSearchRules(): Task
+    {
+        return $this->dynamicSearchRules->deleteAll();
     }
 }

--- a/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
+++ b/src/Endpoints/Delegates/HandlesDynamicSearchRules.php
@@ -15,32 +15,70 @@ trait HandlesDynamicSearchRules
 {
     protected DynamicSearchRules $dynamicSearchRules;
 
+    /**
+     * List dynamic search rules.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/list-search-rules
+     */
     public function getDynamicSearchRules(?DynamicSearchRulesQuery $options = null): DynamicSearchRulesResults
     {
         return $this->dynamicSearchRules->all($options);
     }
 
     /**
-     * @param non-empty-string $uid
+     * Get a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @param non-empty-string $uid Dynamic search rule UID
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/get-a-search-rule
      */
     public function getDynamicSearchRule(string $uid): DynamicSearchRule
     {
         return $this->dynamicSearchRules->get($uid);
     }
 
+    /**
+     * Create or update a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/create-or-update-a-search-rule
+     */
     public function updateDynamicSearchRule(UpdateDynamicSearchRuleQuery $request): Task
     {
         return $this->dynamicSearchRules->update($request);
     }
 
     /**
-     * @param non-empty-string $uid
+     * Delete a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @param non-empty-string $uid Dynamic search rule UID
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/delete-a-search-rule
      */
     public function deleteDynamicSearchRule(string $uid): Task
     {
         return $this->dynamicSearchRules->delete($uid);
     }
 
+    /**
+     * Delete all dynamic search rules.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.50.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/delete-a-search-rule
+     */
     public function deleteAllDynamicSearchRules(): Task
     {
         return $this->dynamicSearchRules->deleteAll();

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -8,7 +8,10 @@ use Meilisearch\Contracts\DynamicSearchRule;
 use Meilisearch\Contracts\DynamicSearchRulesQuery;
 use Meilisearch\Contracts\DynamicSearchRulesResults;
 use Meilisearch\Contracts\Endpoint;
+use Meilisearch\Contracts\Task;
 use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
+
+use function Meilisearch\partial;
 
 /**
  * @phpstan-import-type RawDynamicSearchRule from DynamicSearchRule
@@ -50,18 +53,30 @@ final class DynamicSearchRules extends Endpoint
         return DynamicSearchRule::fromArray($response);
     }
 
-    public function update(UpdateDynamicSearchRuleQuery $request): DynamicSearchRule
+    public function update(UpdateDynamicSearchRuleQuery $request): Task
     {
-        $response = $this->http->patch(self::PATH.'/'.$request->uid, $request->toArray());
-
-        return DynamicSearchRule::fromArray($response);
+        return Task::fromArray(
+            $this->http->patch(self::PATH.'/'.$request->uid, $request->toArray()),
+            partial(Tasks::waitTask(...), $this->http)
+        );
     }
 
     /**
      * @param non-empty-string $uid
      */
-    public function delete(string $uid): ?array
+    public function delete(string $uid): Task
     {
-        return $this->http->delete(self::PATH.'/'.$uid);
+        $response = $this->http->delete(self::PATH.'/'.$uid);
+        \assert(null !== $response);
+
+        return Task::fromArray($response, partial(Tasks::waitTask(...), $this->http));
+    }
+
+    public function deleteAll(): Task
+    {
+        $response = $this->http->delete(self::PATH);
+        \assert(null !== $response);
+
+        return Task::fromArray($response, partial(Tasks::waitTask(...), $this->http));
     }
 }

--- a/src/Endpoints/DynamicSearchRules.php
+++ b/src/Endpoints/DynamicSearchRules.php
@@ -27,6 +27,14 @@ final class DynamicSearchRules extends Endpoint
 {
     protected const PATH = '/dynamic-search-rules';
 
+    /**
+     * List dynamic search rules.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/list-search-rules
+     */
     public function all(?DynamicSearchRulesQuery $options = null): DynamicSearchRulesResults
     {
         $query = $options?->toArray() ?? [];
@@ -44,7 +52,14 @@ final class DynamicSearchRules extends Endpoint
     }
 
     /**
-     * @param non-empty-string $uid
+     * Get a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @param non-empty-string $uid Dynamic search rule UID
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/get-a-search-rule
      */
     public function get(string $uid): DynamicSearchRule
     {
@@ -53,6 +68,14 @@ final class DynamicSearchRules extends Endpoint
         return DynamicSearchRule::fromArray($response);
     }
 
+    /**
+     * Create or update a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/create-or-update-a-search-rule
+     */
     public function update(UpdateDynamicSearchRuleQuery $request): Task
     {
         return Task::fromArray(
@@ -62,7 +85,14 @@ final class DynamicSearchRules extends Endpoint
     }
 
     /**
-     * @param non-empty-string $uid
+     * Delete a dynamic search rule.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @param non-empty-string $uid Dynamic search rule UID
+     *
+     * @since Meilisearch v1.41.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/delete-a-search-rule
      */
     public function delete(string $uid): Task
     {
@@ -72,6 +102,14 @@ final class DynamicSearchRules extends Endpoint
         return Task::fromArray($response, partial(Tasks::waitTask(...), $this->http));
     }
 
+    /**
+     * Delete all dynamic search rules.
+     *
+     * This is an EXPERIMENTAL feature, which may break without a major version.
+     *
+     * @since Meilisearch v1.50.0
+     * @see https://www.meilisearch.com/docs/reference/api/search-rules/delete-a-search-rule
+     */
     public function deleteAll(): Task
     {
         $response = $this->http->delete(self::PATH);

--- a/tests/Contracts/DynamicSearchRuleTest.php
+++ b/tests/Contracts/DynamicSearchRuleTest.php
@@ -14,16 +14,14 @@ final class DynamicSearchRuleTest extends TestCase
         $raw = [
             'uid' => 'movie-rule',
             'description' => 'Movie promotion',
-            'priority' => 1,
+            'precedence' => 1,
             'active' => true,
             'conditions' => [
-                [
-                    'scope' => 'query',
+                'query' => [
                     'isEmpty' => false,
-                    'contains' => 'movie',
+                    'words' => 'movie',
                 ],
-                [
-                    'scope' => 'time',
+                'time' => [
                     'start' => '2026-01-01T00:00:00Z',
                     'end' => null,
                 ],
@@ -32,7 +30,7 @@ final class DynamicSearchRuleTest extends TestCase
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => null,
+                        'id' => '1',
                     ],
                     'action' => [
                         'type' => 'pin',
@@ -46,7 +44,7 @@ final class DynamicSearchRuleTest extends TestCase
 
         self::assertSame('movie-rule', $rule->getUid());
         self::assertSame('Movie promotion', $rule->getDescription());
-        self::assertSame(1, $rule->getPriority());
+        self::assertSame(1, $rule->getPrecedence());
         self::assertTrue($rule->isActive());
         self::assertSame($raw['conditions'], $rule->getConditions());
         self::assertSame($raw['actions'], $rule->getActions());

--- a/tests/Contracts/DynamicSearchRulesQueryTest.php
+++ b/tests/Contracts/DynamicSearchRulesQueryTest.php
@@ -34,13 +34,13 @@ final class DynamicSearchRulesQueryTest extends TestCase
         $data = (new DynamicSearchRulesQuery())
             ->setFilter(
                 (new DynamicSearchRulesFilter())
-                    ->setAttributePatterns(['movie-rule', 'promo*'])
+                    ->setQuery('movie')
                     ->setActive(true)
             );
 
         self::assertSame([
             'filter' => [
-                'attributePatterns' => ['movie-rule', 'promo*'],
+                'query' => 'movie',
                 'active' => true,
             ],
         ], $data->toArray());

--- a/tests/Contracts/TaskTest.php
+++ b/tests/Contracts/TaskTest.php
@@ -186,6 +186,8 @@ final class TaskTest extends TestCase
 
     #[TestWith([TaskType::SnapshotCreation, 'snapshotCreation'])]
     #[TestWith([TaskType::NetworkTopologyChange, 'networkTopologyChange'])]
+    #[TestWith([TaskType::DsrUpdate, 'dsrUpdate'])]
+    #[TestWith([TaskType::DsrClear, 'dsrClear'])]
     public function testFromArrayWithNoDetailsObjectForTaskType(TaskType $expectedType, string $type): void
     {
         $task = Task::fromArray([

--- a/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
+++ b/tests/Contracts/UpdateDynamicSearchRuleQueryTest.php
@@ -46,11 +46,11 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
     {
         $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
             ->setDescription(null)
-            ->setPriority(null);
+            ->setPrecedence(null);
 
         self::assertSame([
             'description' => null,
-            'priority' => null,
+            'precedence' => null,
         ], $data->toArray());
     }
 
@@ -70,16 +70,14 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
     {
         $data = (new UpdateDynamicSearchRuleQuery('movie-rule'))
             ->setDescription('Movie promotion')
-            ->setPriority(2)
+            ->setPrecedence(2)
             ->setActive(true)
             ->setConditions([
-                [
-                    'scope' => 'query',
+                'query' => [
                     'isEmpty' => false,
-                    'contains' => 'movie',
+                    'words' => 'movie',
                 ],
-                [
-                    'scope' => 'time',
+                'time' => [
                     'start' => '2026-01-01T00:00:00Z',
                     'end' => null,
                 ],
@@ -88,7 +86,7 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => null,
+                        'id' => '1',
                     ],
                     'action' => [
                         'type' => 'pin',
@@ -99,16 +97,14 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
 
         self::assertSame([
             'description' => 'Movie promotion',
-            'priority' => 2,
+            'precedence' => 2,
             'active' => true,
             'conditions' => [
-                [
-                    'scope' => 'query',
+                'query' => [
                     'isEmpty' => false,
-                    'contains' => 'movie',
+                    'words' => 'movie',
                 ],
-                [
-                    'scope' => 'time',
+                'time' => [
                     'start' => '2026-01-01T00:00:00Z',
                     'end' => null,
                 ],
@@ -117,7 +113,7 @@ final class UpdateDynamicSearchRuleQueryTest extends TestCase
                 [
                     'selector' => [
                         'indexUid' => 'movies',
-                        'id' => null,
+                        'id' => '1',
                     ],
                     'action' => [
                         'type' => 'pin',

--- a/tests/Endpoints/DynamicSearchRulesTest.php
+++ b/tests/Endpoints/DynamicSearchRulesTest.php
@@ -6,6 +6,8 @@ namespace Tests\Endpoints;
 
 use Meilisearch\Contracts\DynamicSearchRulesFilter;
 use Meilisearch\Contracts\DynamicSearchRulesQuery;
+use Meilisearch\Contracts\TaskStatus;
+use Meilisearch\Contracts\TaskType;
 use Meilisearch\Contracts\UpdateDynamicSearchRuleQuery;
 use Meilisearch\Http\Client;
 use Tests\TestCase;
@@ -13,6 +15,7 @@ use Tests\TestCase;
 final class DynamicSearchRulesTest extends TestCase
 {
     private const SEARCH_RULE_UID = 'movie-rule';
+    private const SEARCH_RULE_DESCRIPTION = 'Movie promotion rule';
     private const SEARCH_RULE_PATCH = [
         'actions' => [
             [
@@ -38,11 +41,7 @@ final class DynamicSearchRulesTest extends TestCase
 
     protected function tearDown(): void
     {
-        $response = $this->client->getDynamicSearchRules();
-
-        foreach ($response as $rule) {
-            $this->client->deleteDynamicSearchRule($rule->getUid());
-        }
+        $this->client->deleteAllDynamicSearchRules()->wait();
 
         parent::tearDown();
     }
@@ -50,14 +49,16 @@ final class DynamicSearchRulesTest extends TestCase
     public function testCanListDynamicSearchRules(): void
     {
         $this->client->updateDynamicSearchRule(
-            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
-        );
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))
+                ->setDescription(self::SEARCH_RULE_DESCRIPTION)
+                ->setActions(self::SEARCH_RULE_PATCH['actions'])
+        )->wait();
 
         $response = $this->client->getDynamicSearchRules(
             (new DynamicSearchRulesQuery())
                 ->setOffset(0)
                 ->setLimit(20)
-                ->setFilter((new DynamicSearchRulesFilter())->setAttributePatterns([self::SEARCH_RULE_UID]))
+                ->setFilter((new DynamicSearchRulesFilter())->setQuery('Movie promotion'))
         );
 
         self::assertCount(1, $response);
@@ -66,9 +67,15 @@ final class DynamicSearchRulesTest extends TestCase
 
     public function testCanCreateOrUpdateDynamicSearchRule(): void
     {
-        $response = $this->client->updateDynamicSearchRule(
+        $task = $this->client->updateDynamicSearchRule(
             (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
         );
+
+        self::assertSame(TaskStatus::Enqueued, $task->getStatus());
+
+        $task->wait();
+
+        $response = $this->client->getDynamicSearchRule(self::SEARCH_RULE_UID);
 
         self::assertSame(self::SEARCH_RULE_UID, $response->getUid());
         self::assertSame(self::SEARCH_RULE_PATCH['actions'], $response->getActions());
@@ -78,7 +85,7 @@ final class DynamicSearchRulesTest extends TestCase
     {
         $this->client->updateDynamicSearchRule(
             (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
-        );
+        )->wait();
 
         $response = $this->client->getDynamicSearchRule(self::SEARCH_RULE_UID);
 
@@ -89,11 +96,43 @@ final class DynamicSearchRulesTest extends TestCase
     public function testCanDeleteDynamicSearchRule(): void
     {
         $this->client->updateDynamicSearchRule(
-            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))->setActions(self::SEARCH_RULE_PATCH['actions'])
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))
+                ->setDescription(self::SEARCH_RULE_DESCRIPTION)
+                ->setActions(self::SEARCH_RULE_PATCH['actions'])
+        )->wait();
+
+        $task = $this->client->deleteDynamicSearchRule(self::SEARCH_RULE_UID);
+
+        $task->wait();
+
+        $response = $this->client->getDynamicSearchRules(
+            (new DynamicSearchRulesQuery())
+                ->setFilter((new DynamicSearchRulesFilter())->setQuery('promotion'))
         );
 
-        $response = $this->client->deleteDynamicSearchRule(self::SEARCH_RULE_UID);
+        self::assertCount(0, $response);
+    }
 
-        self::assertNull($response);
+    public function testCanDeleteAllDynamicSearchRules(): void
+    {
+        $this->client->updateDynamicSearchRule(
+            (new UpdateDynamicSearchRuleQuery(self::SEARCH_RULE_UID))
+                ->setDescription(self::SEARCH_RULE_DESCRIPTION)
+                ->setActions(self::SEARCH_RULE_PATCH['actions'])
+        )->wait();
+        $this->client->updateDynamicSearchRule(
+            (new UpdateDynamicSearchRuleQuery('promo-rule'))
+                ->setDescription('Promo rule')
+                ->setActions(self::SEARCH_RULE_PATCH['actions'])
+        )->wait();
+
+        $task = $this->client->deleteAllDynamicSearchRules();
+
+        self::assertSame(TaskStatus::Enqueued, $task->getStatus());
+        self::assertSame(TaskType::DsrClear, $task->getType());
+
+        $task->wait();
+
+        self::assertCount(0, $this->client->getDynamicSearchRules());
     }
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #932 

## What does this PR do?
- Update dynamic search rules API to v1.50

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, updating, and deleting dynamic search rules through asynchronous tasks.
  * Added the ability to delete all dynamic search rules at once.
  * Added query-based filtering for dynamic search rules.
  * Added support for new dynamic search rule task types.

* **Breaking Changes**
  * Dynamic search rule updates now use “precedence” instead of “priority.”
  * Update and delete operations now return tasks that can be monitored and awaited.
  * Existing attribute-pattern filters have been replaced by query filters.

* **Documentation**
  * Expanded API documentation and examples for dynamic search rule operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->