### PR TITLE
Add indexSize and usedIndexSize to IndexStats

### DIFF
--- a/src/Contracts/IndexStats.php
+++ b/src/Contracts/IndexStats.php
@@ -12,7 +12,9 @@ namespace Meilisearch\Contracts;
  *     isIndexing: bool,
  *     numberOfEmbeddings: non-negative-int,
  *     numberOfEmbeddedDocuments: non-negative-int,
- *     fieldDistribution: array<non-empty-string, non-negative-int>
+ *     fieldDistribution: array<non-empty-string, non-negative-int>,
+ *     indexSize: non-negative-int,
+ *     usedIndexSize: non-negative-int
  * }
  */
 final class IndexStats
@@ -24,6 +26,8 @@ final class IndexStats
      * @param non-negative-int                          $numberOfEmbeddings
      * @param non-negative-int                          $numberOfEmbeddedDocuments
      * @param array<non-empty-string, non-negative-int> $fieldDistribution
+     * @param non-negative-int                          $indexSize
+     * @param non-negative-int                          $usedIndexSize
      */
     public function __construct(
         private readonly int $numberOfDocuments,
@@ -33,6 +37,8 @@ final class IndexStats
         private readonly int $numberOfEmbeddings,
         private readonly int $numberOfEmbeddedDocuments,
         private readonly array $fieldDistribution,
+        private readonly int $indexSize,
+        private readonly int $usedIndexSize,
     ) {
     }
 
@@ -90,6 +96,22 @@ final class IndexStats
     }
 
     /**
+     * @return non-negative-int
+     */
+    public function getIndexSize(): int
+    {
+        return $this->indexSize;
+    }
+
+    /**
+     * @return non-negative-int
+     */
+    public function getUsedIndexSize(): int
+    {
+        return $this->usedIndexSize;
+    }
+
+    /**
      * @param RawIndexStats $data
      */
     public static function fromArray(array $data): self
@@ -102,6 +124,8 @@ final class IndexStats
             $data['numberOfEmbeddings'],
             $data['numberOfEmbeddedDocuments'],
             $data['fieldDistribution'],
+            $data['indexSize'],
+            $data['usedIndexSize'],
         );
     }
 }

--- a/tests/Contracts/StatsTest.php
+++ b/tests/Contracts/StatsTest.php
@@ -25,6 +25,8 @@ final class StatsTest extends TestCase
                     numberOfEmbeddings: 0,
                     numberOfEmbeddedDocuments: 0,
                     fieldDistribution: ['objectID' => 2, 'type' => 1],
+                    indexSize: 4096,
+                    usedIndexSize: 2048,
                 ),
             ],
         );
@@ -50,6 +52,8 @@ final class StatsTest extends TestCase
                     'numberOfEmbeddings' => 0,
                     'numberOfEmbeddedDocuments' => 0,
                     'fieldDistribution' => ['objectID' => 2, 'type' => 1],
+                    'indexSize' => 4096,
+                    'usedIndexSize' => 2048,
                 ],
             ],
         ]);
@@ -66,6 +70,8 @@ final class StatsTest extends TestCase
                 numberOfEmbeddings: 0,
                 numberOfEmbeddedDocuments: 0,
                 fieldDistribution: ['objectID' => 2, 'type' => 1],
+                indexSize: 4096,
+                usedIndexSize: 2048,
             ),
         ], $stats->getIndexes());
     }


### PR DESCRIPTION
## Summary

This adds `indexSize` and `usedIndexSize` to `IndexStats`. I just followed the same pattern already used by the other fields (constructor param, getter, `fromArray`, PHPStan type), so it should feel consistent with the rest of the class.

## Related issue

Fixes #943

## What does this PR do?

- Adds `indexSize` and `usedIndexSize` to the `RawIndexStats` PHPStan type in `src/Contracts/IndexStats.php`
- Adds both as constructor params, plus `getIndexSize()` / `getUsedIndexSize()` getters
- Reads both fields in `IndexStats::fromArray()`
- Updates `tests/Contracts/StatsTest.php` (`testConstruct` and `testFromArray`) to cover the new fields

## PR checklist

- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thanks for taking a look!